### PR TITLE
ci: add GitHub Actions workflow, pin toolchain, fill env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,35 @@
+# Mnemonic MCP server configuration.
+# Copy this file to `.env` and edit. `.env` is gitignored; `.env.example` is committed.
+
+# ── Identity & storage ────────────────────────────────────────────────────────
+# Ed25519 keypair. Auto-created on first run if missing.
+MNEMONIC_KEYPAIR_PATH=~/.mnemonic/id.json
+# SQLite database path. Schema is created on first run.
+DATABASE_PATH=~/.mnemonic/attestations.db
+# local  — SQLite-only, no on-chain writes, no funded keypair needed.
+# full   — Arweave + Solana + SQLite. Requires a funded keypair.
+STORAGE_MODE=local
+
+# ── Embedding provider ────────────────────────────────────────────────────────
+# fastembed (default, needs `--features local-embed`), openai, or hash (deprecated).
+EMBED_PROVIDER=fastembed
+# Required when EMBED_PROVIDER=openai.
+# OPENAI_API_KEY=
+
+# ── Compression ───────────────────────────────────────────────────────────────
+# TurboQuant bit width: 2, 3, or 4. Do not change for an existing database.
+TURBO_BITS=4
+
+# ── On-chain endpoints (full mode only) ───────────────────────────────────────
+ARWEAVE_URL=https://uploader.irys.xyz
+SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
+
+# ── MCP transport ─────────────────────────────────────────────────────────────
+# stdio — for Cursor/Claude Desktop local integration.
+# http  — for remote HTTP JSON-RPC.
+MCP_TRANSPORT=http
+MCP_HTTP_PORT=3000
+
+# ── Payment gating (full/http mode) ───────────────────────────────────────────
+# none — no gating. balance — API-key balance. x402 — x402 payment. both — either.
+PAYMENT_MODE=none

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: CI
+
+on:
+  push:
+    branches: [main, dev]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - run: cargo fmt --all -- --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: workspace
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: workspace
+      - run: cargo test --workspace --no-fail-fast
+
+  # NOTE: mcp local-mode round-trip (sign_memory → recall over stdio) is not
+  # run in PR gates because it requires either the `local-embed` feature (pulls
+  # a ~22MB fastembed ONNX model at runtime) or OPENAI_API_KEY. It belongs in a
+  # dedicated release workflow with a model cache — tracked as a follow-up.
+
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install gitleaks
+        run: |
+          curl -sSL -o /tmp/gitleaks.tar.gz \
+            https://github.com/gitleaks/gitleaks/releases/download/v8.21.2/gitleaks_8.21.2_linux_x64.tar.gz
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+      - name: Scan working tree
+        run: gitleaks detect --source . --redact --no-banner --verbose
+      - name: Scan full git history
+        run: gitleaks detect --source . --redact --no-banner --log-opts='--all'

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,10 @@ build/
 .next/
 out/
 
+# Rust
+target/
+**/*.rs.bk
+
 # IDE
 .vscode/
 .idea/

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]
+profile = "minimal"


### PR DESCRIPTION
Establish the PR-gate CI pipeline for the workspace:

- .github/workflows/ci.yml -- four parallel jobs on push to main/dev and
  every PR: rustfmt --check, clippy --all-targets -D warnings,
  cargo test --workspace, and gitleaks (working tree + full history).
  Uses Swatinem/rust-cache for the two cargo jobs; concurrency-cancels
  stale runs on the same ref.
- rust-toolchain.toml -- pin to stable + rustfmt + clippy so local and
  CI builds use the same toolchain.
- .gitignore -- add target/ and *.rs.bk; the Rust build directory was
  not ignored before.
- .env.example -- populate from deployment.md; previously empty.

The mcp local-mode round-trip (tools/list over stdio) is intentionally
omitted from this gate: without a HashEmbedder fallback the server
requires the local-embed feature (22MB ONNX model download) or an
OpenAI key. It belongs in a release workflow with a model cache --
tracked as follow-up.

https://claude.ai/code/session_01MY7wY9sQTxa1aoCuvNciGu