### PR TITLE
feat: wave 12 audit results (tasks 13, 14, 15) + cargo fmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ Thumbs.db
 
 # Logs
 *.log
-logs/
+/logs/
 
 # Test coverage
 coverage/

--- a/core/src/arweave/mod.rs
+++ b/core/src/arweave/mod.rs
@@ -235,16 +235,7 @@ fn build_data_item(keypair: &Keypair, data: &[u8], tags: &[(&str, &str)]) -> Vec
     let pubkey = keypair.pubkey().to_bytes();
     let avro_tags = avro_encode_tags(tags);
 
-    let msg = deep_hash_list(&[
-        b"dataitem",
-        b"1",
-        b"3",
-        &pubkey,
-        b"",
-        b"",
-        &avro_tags,
-        data,
-    ]);
+    let msg = deep_hash_list(&[b"dataitem", b"1", b"3", &pubkey, b"", b"", &avro_tags, data]);
 
     let sig = keypair.sign_message(&msg);
 

--- a/core/src/codec/canonical.rs
+++ b/core/src/codec/canonical.rs
@@ -17,7 +17,8 @@ use super::schema::ArtifactSchema;
 /// This function is **pure and deterministic** -- calling it N times on the same
 /// input always produces identical bytes.
 pub fn to_canonical_cbor(artifact: &JsonValue, schema: &ArtifactSchema) -> Result<Vec<u8>, String> {
-    let obj = artifact.as_object()
+    let obj = artifact
+        .as_object()
         .ok_or_else(|| "artifact must be a JSON object".to_string())?;
 
     // Build CBOR map with fields in schema-defined order.
@@ -45,8 +46,8 @@ pub fn to_canonical_cbor(artifact: &JsonValue, schema: &ArtifactSchema) -> Resul
 
 /// Deserialize canonical CBOR bytes back to a JSON value.
 pub fn from_canonical_cbor(bytes: &[u8]) -> Result<JsonValue, String> {
-    let cbor: CborValue = ciborium::from_reader(bytes)
-        .map_err(|e| format!("CBOR deserialization failed: {e}"))?;
+    let cbor: CborValue =
+        ciborium::from_reader(bytes).map_err(|e| format!("CBOR deserialization failed: {e}"))?;
 
     Ok(cbor_to_json(&cbor))
 }
@@ -74,18 +75,25 @@ fn json_to_cbor(json: &JsonValue) -> CborValue {
                 CborValue::Text(s.clone())
             }
         }
-        JsonValue::Array(arr) => {
-            CborValue::Array(arr.iter().map(json_to_cbor).collect())
-        }
+        JsonValue::Array(arr) => CborValue::Array(arr.iter().map(json_to_cbor).collect()),
         JsonValue::Object(obj) => {
             // For nested objects: use sorted keys (deterministic CBOR)
-            let mut entries: Vec<(CborValue, CborValue)> = obj.iter()
+            let mut entries: Vec<(CborValue, CborValue)> = obj
+                .iter()
                 .map(|(k, v)| (CborValue::Text(k.clone()), json_to_cbor(v)))
                 .collect();
             entries.sort_by(|a, b| {
                 // Sort by key text (canonical CBOR requires sorted map keys)
-                let ka = if let CborValue::Text(s) = &a.0 { s.as_str() } else { "" };
-                let kb = if let CborValue::Text(s) = &b.0 { s.as_str() } else { "" };
+                let ka = if let CborValue::Text(s) = &a.0 {
+                    s.as_str()
+                } else {
+                    ""
+                };
+                let kb = if let CborValue::Text(s) = &b.0 {
+                    s.as_str()
+                } else {
+                    ""
+                };
                 ka.cmp(kb)
             });
             CborValue::Map(entries)
@@ -106,20 +114,15 @@ fn cbor_to_json(cbor: &CborValue) -> JsonValue {
                 JsonValue::String(n.to_string())
             }
         }
-        CborValue::Float(f) => {
-            serde_json::Number::from_f64(*f)
-                .map(JsonValue::Number)
-                .unwrap_or(JsonValue::Null)
-        }
+        CborValue::Float(f) => serde_json::Number::from_f64(*f)
+            .map(JsonValue::Number)
+            .unwrap_or(JsonValue::Null),
         CborValue::Text(s) => JsonValue::String(s.clone()),
-        CborValue::Bytes(b) => {
-            JsonValue::String(base64::Engine::encode(
-                &base64::engine::general_purpose::STANDARD, b,
-            ))
-        }
-        CborValue::Array(arr) => {
-            JsonValue::Array(arr.iter().map(cbor_to_json).collect())
-        }
+        CborValue::Bytes(b) => JsonValue::String(base64::Engine::encode(
+            &base64::engine::general_purpose::STANDARD,
+            b,
+        )),
+        CborValue::Array(arr) => JsonValue::Array(arr.iter().map(cbor_to_json).collect()),
         CborValue::Map(entries) => {
             let mut obj = serde_json::Map::new();
             for (k, v) in entries {
@@ -191,7 +194,10 @@ mod tests {
         // Check key fields survived the round-trip
         assert_eq!(recovered["artifact_id"], "art:01JTEST");
         assert_eq!(recovered["type"], "rag.context");
-        assert_eq!(recovered["content"], "The quick brown fox jumps over the lazy dog");
+        assert_eq!(
+            recovered["content"],
+            "The quick brown fox jumps over the lazy dog"
+        );
         assert_eq!(recovered["schema_version"], 1);
     }
 
@@ -202,12 +208,21 @@ mod tests {
         let cbor: CborValue = ciborium::from_reader(&cbor_bytes[..]).unwrap();
 
         if let CborValue::Map(entries) = cbor {
-            let keys: Vec<&str> = entries.iter()
-                .filter_map(|(k, _)| if let CborValue::Text(s) = k { Some(s.as_str()) } else { None })
+            let keys: Vec<&str> = entries
+                .iter()
+                .filter_map(|(k, _)| {
+                    if let CborValue::Text(s) = k {
+                        Some(s.as_str())
+                    } else {
+                        None
+                    }
+                })
                 .collect();
 
             // Verify ordering matches schema (for present fields only)
-            let expected: Vec<&str> = RAG_CONTEXT_V1.cbor_field_order.iter()
+            let expected: Vec<&str> = RAG_CONTEXT_V1
+                .cbor_field_order
+                .iter()
                 .copied()
                 .filter(|f| keys.contains(f))
                 .collect();
@@ -260,7 +275,8 @@ mod tests {
         let cbor: CborValue = ciborium::from_reader(&cbor_bytes[..]).unwrap();
 
         if let CborValue::Map(entries) = cbor {
-            let created_at = entries.iter()
+            let created_at = entries
+                .iter()
                 .find(|(k, _)| matches!(k, CborValue::Text(s) if s == "created_at"))
                 .map(|(_, v)| v);
             assert!(

--- a/core/src/codec/hash.rs
+++ b/core/src/codec/hash.rs
@@ -14,7 +14,10 @@ use super::schema::ArtifactSchema;
 /// Compute blake3 hash of a JSON artifact's canonical CBOR representation.
 ///
 /// Returns lowercase hex string (64 chars).
-pub fn hash_artifact(artifact: &serde_json::Value, schema: &ArtifactSchema) -> Result<String, String> {
+pub fn hash_artifact(
+    artifact: &serde_json::Value,
+    schema: &ArtifactSchema,
+) -> Result<String, String> {
     let cbor_bytes = to_canonical_cbor(artifact, schema)?;
     Ok(hash_bytes(&cbor_bytes))
 }

--- a/core/src/codec/mod.rs
+++ b/core/src/codec/mod.rs
@@ -6,7 +6,7 @@
 //!
 //! This module is a prerequisite for the VAA (Verifiable Artifact Anchor) protocol.
 
-pub mod schema;
 pub mod canonical;
 pub mod hash;
+pub mod schema;
 pub mod sign;

--- a/core/src/codec/schema.rs
+++ b/core/src/codec/schema.rs
@@ -81,11 +81,26 @@ pub struct ArtifactSchema {
 pub const RAG_CONTEXT_V1: ArtifactSchema = ArtifactSchema {
     artifact_type: ArtifactType::RagContext,
     version: 1,
-    required_fields: &["artifact_id", "type", "schema_version", "content", "producer", "created_at"],
+    required_fields: &[
+        "artifact_id",
+        "type",
+        "schema_version",
+        "content",
+        "producer",
+        "created_at",
+    ],
     optional_fields: &["parents", "metadata", "tags", "sources"],
     cbor_field_order: &[
-        "artifact_id", "type", "schema_version", "content",
-        "metadata", "sources", "parents", "tags", "created_at", "producer",
+        "artifact_id",
+        "type",
+        "schema_version",
+        "content",
+        "metadata",
+        "sources",
+        "parents",
+        "tags",
+        "created_at",
+        "producer",
     ],
 };
 
@@ -93,12 +108,33 @@ pub const RAG_CONTEXT_V1: ArtifactSchema = ArtifactSchema {
 pub const RAG_RESULT_V1: ArtifactSchema = ArtifactSchema {
     artifact_type: ArtifactType::RagResult,
     version: 1,
-    required_fields: &["artifact_id", "type", "schema_version", "content", "producer", "created_at"],
-    optional_fields: &["context_artifacts", "citations", "parents", "metadata", "tags"],
+    required_fields: &[
+        "artifact_id",
+        "type",
+        "schema_version",
+        "content",
+        "producer",
+        "created_at",
+    ],
+    optional_fields: &[
+        "context_artifacts",
+        "citations",
+        "parents",
+        "metadata",
+        "tags",
+    ],
     cbor_field_order: &[
-        "artifact_id", "type", "schema_version", "content",
-        "context_artifacts", "citations", "metadata", "parents", "tags",
-        "created_at", "producer",
+        "artifact_id",
+        "type",
+        "schema_version",
+        "content",
+        "context_artifacts",
+        "citations",
+        "metadata",
+        "parents",
+        "tags",
+        "created_at",
+        "producer",
     ],
 };
 
@@ -106,11 +142,26 @@ pub const RAG_RESULT_V1: ArtifactSchema = ArtifactSchema {
 pub const AGENT_STATE_V1: ArtifactSchema = ArtifactSchema {
     artifact_type: ArtifactType::AgentState,
     version: 1,
-    required_fields: &["artifact_id", "type", "schema_version", "content", "producer", "created_at"],
+    required_fields: &[
+        "artifact_id",
+        "type",
+        "schema_version",
+        "content",
+        "producer",
+        "created_at",
+    ],
     optional_fields: &["parents", "metadata", "tags", "state_key"],
     cbor_field_order: &[
-        "artifact_id", "type", "schema_version", "content",
-        "state_key", "metadata", "parents", "tags", "created_at", "producer",
+        "artifact_id",
+        "type",
+        "schema_version",
+        "content",
+        "state_key",
+        "metadata",
+        "parents",
+        "tags",
+        "created_at",
+        "producer",
     ],
 };
 
@@ -118,12 +169,27 @@ pub const AGENT_STATE_V1: ArtifactSchema = ArtifactSchema {
 pub const RECEIPT_V1: ArtifactSchema = ArtifactSchema {
     artifact_type: ArtifactType::Receipt,
     version: 1,
-    required_fields: &["artifact_id", "type", "schema_version", "content", "producer", "created_at"],
+    required_fields: &[
+        "artifact_id",
+        "type",
+        "schema_version",
+        "content",
+        "producer",
+        "created_at",
+    ],
     optional_fields: &["parents", "metadata", "tags", "operation", "duration_ms"],
     cbor_field_order: &[
-        "artifact_id", "type", "schema_version", "content",
-        "operation", "duration_ms", "metadata", "parents", "tags",
-        "created_at", "producer",
+        "artifact_id",
+        "type",
+        "schema_version",
+        "content",
+        "operation",
+        "duration_ms",
+        "metadata",
+        "parents",
+        "tags",
+        "created_at",
+        "producer",
     ],
 };
 
@@ -131,11 +197,25 @@ pub const RECEIPT_V1: ArtifactSchema = ArtifactSchema {
 pub const MEMORY_V1: ArtifactSchema = ArtifactSchema {
     artifact_type: ArtifactType::Memory,
     version: 1,
-    required_fields: &["artifact_id", "type", "schema_version", "content", "producer", "created_at"],
+    required_fields: &[
+        "artifact_id",
+        "type",
+        "schema_version",
+        "content",
+        "producer",
+        "created_at",
+    ],
     optional_fields: &["parents", "metadata", "tags"],
     cbor_field_order: &[
-        "artifact_id", "type", "schema_version", "content",
-        "metadata", "parents", "tags", "created_at", "producer",
+        "artifact_id",
+        "type",
+        "schema_version",
+        "content",
+        "metadata",
+        "parents",
+        "tags",
+        "created_at",
+        "producer",
     ],
 };
 
@@ -152,8 +232,12 @@ pub fn get_schema(artifact_type: &str, version: u32) -> Option<&'static Artifact
 }
 
 /// Validate that an artifact JSON object has all required fields for its schema.
-pub fn validate_artifact(artifact: &serde_json::Value, schema: &ArtifactSchema) -> Result<(), String> {
-    let obj = artifact.as_object()
+pub fn validate_artifact(
+    artifact: &serde_json::Value,
+    schema: &ArtifactSchema,
+) -> Result<(), String> {
+    let obj = artifact
+        .as_object()
         .ok_or_else(|| "artifact must be a JSON object".to_string())?;
 
     for &field in schema.required_fields {
@@ -202,18 +286,29 @@ mod tests {
     #[test]
     fn test_artifact_type_strings() {
         assert_eq!(ArtifactType::RagContext.as_str(), "rag.context");
-        assert_eq!(ArtifactType::from_str("receipt"), Some(ArtifactType::Receipt));
+        assert_eq!(
+            ArtifactType::from_str("receipt"),
+            Some(ArtifactType::Receipt)
+        );
         assert_eq!(ArtifactType::from_str("invalid"), None);
     }
 
     #[test]
     fn test_cbor_field_order_covers_required() {
-        for schema in [&RAG_CONTEXT_V1, &RAG_RESULT_V1, &AGENT_STATE_V1, &RECEIPT_V1, &MEMORY_V1] {
+        for schema in [
+            &RAG_CONTEXT_V1,
+            &RAG_RESULT_V1,
+            &AGENT_STATE_V1,
+            &RECEIPT_V1,
+            &MEMORY_V1,
+        ] {
             for &field in schema.required_fields {
                 assert!(
                     schema.cbor_field_order.contains(&field),
                     "schema {:?} v{}: required field '{}' not in cbor_field_order",
-                    schema.artifact_type, schema.version, field,
+                    schema.artifact_type,
+                    schema.version,
+                    field,
                 );
             }
         }

--- a/core/src/codec/sign.rs
+++ b/core/src/codec/sign.rs
@@ -3,9 +3,7 @@
 //! Uses RFC 9052 COSE_Sign1 structure with Ed25519 (COSE alg: -8).
 //! The existing Solana Ed25519 keypair is reused -- no new key material needed.
 
-use coset::{
-    iana, CborSerializable, CoseSign1, CoseSign1Builder, HeaderBuilder,
-};
+use coset::{iana, CborSerializable, CoseSign1, CoseSign1Builder, HeaderBuilder};
 use solana_sdk::signature::{Keypair, Signer};
 
 use super::canonical::to_canonical_cbor;
@@ -61,9 +59,7 @@ pub fn sign_cose(canonical_cbor: &[u8], keypair: &Keypair) -> Result<Vec<u8>, St
 
     // Unprotected header: kid = Solana pubkey base58
     let kid = keypair.pubkey().to_string().into_bytes();
-    let unprotected = HeaderBuilder::new()
-        .key_id(kid)
-        .build();
+    let unprotected = HeaderBuilder::new().key_id(kid).build();
 
     // Build unsigned COSE_Sign1 to compute Sig_structure
     let unsigned = CoseSign1Builder::new()
@@ -86,7 +82,8 @@ pub fn sign_cose(canonical_cbor: &[u8], keypair: &Keypair) -> Result<Vec<u8>, St
         .signature(signature.as_ref().to_vec())
         .build();
 
-    signed.to_vec()
+    signed
+        .to_vec()
         .map_err(|e| format!("COSE serialization failed: {e}"))
 }
 
@@ -107,16 +104,18 @@ pub fn verify_artifact(
     cose_bytes: &[u8],
     expected_hash: Option<&str>,
 ) -> Result<VerificationResult, String> {
-    let cose_sign1 = CoseSign1::from_slice(cose_bytes)
-        .map_err(|e| format!("invalid COSE_Sign1: {e}"))?;
+    let cose_sign1 =
+        CoseSign1::from_slice(cose_bytes).map_err(|e| format!("invalid COSE_Sign1: {e}"))?;
 
-    let payload = cose_sign1.payload.as_ref()
+    let payload = cose_sign1
+        .payload
+        .as_ref()
         .ok_or_else(|| "COSE_Sign1 has no payload".to_string())?;
 
     // Extract signer from kid
     let kid_bytes = &cose_sign1.unprotected.key_id;
-    let signer = String::from_utf8(kid_bytes.clone())
-        .unwrap_or_else(|_| "<invalid kid>".to_string());
+    let signer =
+        String::from_utf8(kid_bytes.clone()).unwrap_or_else(|_| "<invalid kid>".to_string());
 
     // Parse pubkey for signature verification
     let pubkey = solana_sdk::pubkey::Pubkey::from_str(&signer)
@@ -128,7 +127,7 @@ pub fn verify_artifact(
     // Verify Ed25519 signature
     let sig_valid = if cose_sign1.signature.len() == 64 {
         let sig = solana_sdk::signature::Signature::from(
-            <[u8; 64]>::try_from(&cose_sign1.signature[..]).unwrap()
+            <[u8; 64]>::try_from(&cose_sign1.signature[..]).unwrap(),
         );
         sig.verify(pubkey.as_ref(), &sig_structure)
     } else {
@@ -143,7 +142,9 @@ pub fn verify_artifact(
 
     // Check algorithm
     let alg_valid = cose_sign1.protected.header.alg
-        == Some(coset::RegisteredLabelWithPrivate::Assigned(iana::Algorithm::EdDSA));
+        == Some(coset::RegisteredLabelWithPrivate::Assigned(
+            iana::Algorithm::EdDSA,
+        ));
 
     Ok(VerificationResult {
         valid: sig_valid && hash_valid && alg_valid,
@@ -236,8 +237,10 @@ mod tests {
     fn test_all_schemas_sign_verify() {
         let kp = Keypair::new();
         for (schema, name) in [
-            (&RAG_CONTEXT_V1, "rag.context"), (&RAG_RESULT_V1, "rag.result"),
-            (&AGENT_STATE_V1, "agent.state"), (&RECEIPT_V1, "receipt"),
+            (&RAG_CONTEXT_V1, "rag.context"),
+            (&RAG_RESULT_V1, "rag.result"),
+            (&AGENT_STATE_V1, "agent.state"),
+            (&RECEIPT_V1, "receipt"),
             (&MEMORY_V1, "memory"),
         ] {
             let artifact = serde_json::json!({
@@ -246,7 +249,8 @@ mod tests {
                 "producer": "p", "created_at": "2026-01-01T00:00:00Z",
             });
             let signed = sign_artifact(&artifact, schema, &kp).expect(name);
-            let result = verify_artifact(&signed.cose_bytes, Some(&signed.content_hash)).expect(name);
+            let result =
+                verify_artifact(&signed.cose_bytes, Some(&signed.content_hash)).expect(name);
             assert!(result.valid, "{name} failed");
         }
     }

--- a/core/src/compress/mod.rs
+++ b/core/src/compress/mod.rs
@@ -58,7 +58,14 @@ impl CompressedEmbedding {
         let signs_len = u32::from_le_bytes(data.get(off..off + 4)?.try_into().ok()?) as usize;
         off += 4;
         let qjl_signs_packed = data.get(off..off + signs_len)?.to_vec();
-        Some(Self { dim, bit_width, mse_indices_packed, qjl_signs_packed, vector_norm, residual_norm })
+        Some(Self {
+            dim,
+            bit_width,
+            mse_indices_packed,
+            qjl_signs_packed,
+            vector_norm,
+            residual_norm,
+        })
     }
 
     fn from_bytes_legacy_v1(data: &[u8]) -> Option<Self> {
@@ -88,7 +95,14 @@ impl CompressedEmbedding {
         let qjl_signs_unpacked = Array1::from_iter(qjl_signs.iter().map(|&b| b as i8));
         let mse_indices_packed = pack_indices(&mse_indices_unpacked, bit_width - 1);
         let qjl_signs_packed = pack_bits(&qjl_signs_unpacked);
-        Some(Self { dim, bit_width, mse_indices_packed, qjl_signs_packed, vector_norm, residual_norm })
+        Some(Self {
+            dim,
+            bit_width,
+            mse_indices_packed,
+            qjl_signs_packed,
+            vector_norm,
+            residual_norm,
+        })
     }
 }
 
@@ -158,8 +172,12 @@ mod tests {
         let compressed = c.compress(&original);
         let restored = c.decompress(&compressed);
         assert_eq!(restored.len(), 128);
-        let mse: f32 = original.iter().zip(restored.iter())
-            .map(|(a, b)| (a - b).powi(2)).sum::<f32>() / original.len() as f32;
+        let mse: f32 = original
+            .iter()
+            .zip(restored.iter())
+            .map(|(a, b)| (a - b).powi(2))
+            .sum::<f32>()
+            / original.len() as f32;
         assert!(mse < 0.1, "MSE too high: {mse}");
     }
 
@@ -172,8 +190,14 @@ mod tests {
         let restored = CompressedEmbedding::from_bytes(&bytes).unwrap();
         assert_eq!(restored.dim, 128);
         assert_eq!(restored.bit_width, 4);
-        assert_eq!(restored.mse_indices_packed.len(), compressed.mse_indices_packed.len());
-        assert_eq!(restored.qjl_signs_packed.len(), compressed.qjl_signs_packed.len());
+        assert_eq!(
+            restored.mse_indices_packed.len(),
+            compressed.mse_indices_packed.len()
+        );
+        assert_eq!(
+            restored.qjl_signs_packed.len(),
+            compressed.qjl_signs_packed.len()
+        );
         assert!((restored.vector_norm - compressed.vector_norm).abs() < 1e-6);
     }
 
@@ -191,8 +215,12 @@ mod tests {
         let compressed = c.compress(&v);
         let bytes = compressed.to_bytes();
         let original_bytes = 384 * 4;
-        assert!(bytes.len() < original_bytes,
-            "compressed {} >= original {}", bytes.len(), original_bytes);
+        assert!(
+            bytes.len() < original_bytes,
+            "compressed {} >= original {}",
+            bytes.len(),
+            original_bytes
+        );
     }
 
     #[test]
@@ -201,9 +229,16 @@ mod tests {
         let original: Vec<f32> = (0..384).map(|i| ((i as f32) * 0.007).sin()).collect();
         let compressed = c.compress(&original);
         let restored = c.decompress(&compressed);
-        let mse: f32 = original.iter().zip(restored.iter())
-            .map(|(a, b)| (a - b).powi(2)).sum::<f32>() / original.len() as f32;
-        assert!(mse < 0.05, "MSE {mse} exceeds 0.05 threshold for 384-dim 4-bit");
+        let mse: f32 = original
+            .iter()
+            .zip(restored.iter())
+            .map(|(a, b)| (a - b).powi(2))
+            .sum::<f32>()
+            / original.len() as f32;
+        assert!(
+            mse < 0.05,
+            "MSE {mse} exceeds 0.05 threshold for 384-dim 4-bit"
+        );
     }
 
     #[test]

--- a/core/src/embed/mod.rs
+++ b/core/src/embed/mod.rs
@@ -10,7 +10,9 @@ pub trait Embedder: Send + Sync {
     fn model_id(&self) -> &str;
     /// True if the model weights are publicly available (open source).
     /// Only open-weight models produce externally verifiable attestations.
-    fn is_open_weights(&self) -> bool { false }
+    fn is_open_weights(&self) -> bool {
+        false
+    }
 }
 
 // -- FastEmbed (local ONNX) --
@@ -27,14 +29,16 @@ pub struct FastEmbedder {
 #[cfg(feature = "local-embed")]
 impl FastEmbedder {
     pub fn try_new() -> Result<Self, String> {
-        use fastembed::{TextEmbedding, InitOptions, EmbeddingModel};
+        use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
         let model = TextEmbedding::try_new(InitOptions {
             model_name: EmbeddingModel::AllMiniLML6V2,
             ..Default::default()
-        }).map_err(|e| format!("fastembed init failed: {e}"))?;
+        })
+        .map_err(|e| format!("fastembed init failed: {e}"))?;
 
         // Probe dimension
-        let sample = model.embed(vec!["test"], None)
+        let sample = model
+            .embed(vec!["test"], None)
             .map_err(|e| format!("fastembed probe failed: {e}"))?;
         let dim = sample.first().map(|v| v.len()).unwrap_or(384);
 
@@ -46,9 +50,10 @@ impl FastEmbedder {
 impl Embedder for FastEmbedder {
     fn embed(&self, text: &str) -> Vec<f32> {
         match self.model.embed(vec![text.to_string()], None) {
-            Ok(embeddings) => {
-                embeddings.into_iter().next().unwrap_or_else(|| vec![0.0; self.dim])
-            }
+            Ok(embeddings) => embeddings
+                .into_iter()
+                .next()
+                .unwrap_or_else(|| vec![0.0; self.dim]),
             Err(e) => {
                 tracing::error!("fastembed inference failed: {e}");
                 vec![0.0; self.dim]
@@ -56,10 +61,18 @@ impl Embedder for FastEmbedder {
         }
     }
 
-    fn dim(&self) -> usize { self.dim }
-    fn provider_name(&self) -> &str { "fastembed" }
-    fn model_id(&self) -> &str { "all-MiniLM-L6-v2" }
-    fn is_open_weights(&self) -> bool { true } // Apache 2.0
+    fn dim(&self) -> usize {
+        self.dim
+    }
+    fn provider_name(&self) -> &str {
+        "fastembed"
+    }
+    fn model_id(&self) -> &str {
+        "all-MiniLM-L6-v2"
+    }
+    fn is_open_weights(&self) -> bool {
+        true
+    } // Apache 2.0
 }
 
 // -- OpenAI embedder --
@@ -86,7 +99,8 @@ impl Embedder for OpenAIEmbedder {
     fn embed(&self, text: &str) -> Vec<f32> {
         let client = reqwest::blocking::Client::new();
         let body = serde_json::json!({ "input": text, "model": self.model });
-        let resp = client.post("https://api.openai.com/v1/embeddings")
+        let resp = client
+            .post("https://api.openai.com/v1/embeddings")
             .header("Authorization", format!("Bearer {}", self.api_key))
             .header("Content-Type", "application/json")
             .json(&body)
@@ -96,7 +110,8 @@ impl Embedder for OpenAIEmbedder {
             Ok(r) => {
                 if let Ok(json) = r.json::<serde_json::Value>() {
                     if let Some(embedding) = json["data"][0]["embedding"].as_array() {
-                        return embedding.iter()
+                        return embedding
+                            .iter()
                             .filter_map(|v| v.as_f64().map(|f| f as f32))
                             .collect();
                     }
@@ -111,9 +126,15 @@ impl Embedder for OpenAIEmbedder {
         }
     }
 
-    fn dim(&self) -> usize { self.dim }
-    fn provider_name(&self) -> &str { "openai" }
-    fn model_id(&self) -> &str { &self.model }
+    fn dim(&self) -> usize {
+        self.dim
+    }
+    fn provider_name(&self) -> &str {
+        "openai"
+    }
+    fn model_id(&self) -> &str {
+        &self.model
+    }
 }
 
 // -- MockEmbedder (test only) --
@@ -126,7 +147,9 @@ pub struct MockEmbedder {
 
 #[cfg(test)]
 impl MockEmbedder {
-    pub fn new(dim: usize) -> Self { Self { dim } }
+    pub fn new(dim: usize) -> Self {
+        Self { dim }
+    }
 }
 
 #[cfg(test)]
@@ -140,9 +163,15 @@ impl Embedder for MockEmbedder {
         vec
     }
 
-    fn dim(&self) -> usize { self.dim }
-    fn provider_name(&self) -> &str { "mock" }
-    fn model_id(&self) -> &str { "mock-deterministic" }
+    fn dim(&self) -> usize {
+        self.dim
+    }
+    fn provider_name(&self) -> &str {
+        "mock"
+    }
+    fn model_id(&self) -> &str {
+        "mock-deterministic"
+    }
 }
 
 // -- Builder --
@@ -152,7 +181,11 @@ impl Embedder for MockEmbedder {
 /// Returns Ok(embedder) or Err with a message if no real embedder is available.
 ///
 /// Priority: fastembed (open, verifiable) > openai (proprietary but semantic)
-pub fn build_embedder(provider: &str, api_key: &str, model: &str) -> Result<Box<dyn Embedder>, String> {
+pub fn build_embedder(
+    provider: &str,
+    api_key: &str,
+    model: &str,
+) -> Result<Box<dyn Embedder>, String> {
     match provider {
         "fastembed" => {
             #[cfg(feature = "local-embed")]
@@ -161,7 +194,8 @@ pub fn build_embedder(provider: &str, api_key: &str, model: &str) -> Result<Box<
                     Ok(e) => {
                         tracing::info!(
                             "Embedder: fastembed ({}, {}-dim, open weights, verifiable)",
-                            e.model_id(), e.dim()
+                            e.model_id(),
+                            e.dim()
                         );
                         return Ok(Box::new(e));
                     }
@@ -172,11 +206,15 @@ pub fn build_embedder(provider: &str, api_key: &str, model: &str) -> Result<Box<
             }
             #[cfg(not(feature = "local-embed"))]
             {
-                tracing::warn!("fastembed not compiled in. Build with: cargo build --features local-embed");
+                tracing::warn!(
+                    "fastembed not compiled in. Build with: cargo build --features local-embed"
+                );
             }
             // Fallback to OpenAI if key available
             if !api_key.is_empty() {
-                tracing::info!("Falling back to OpenAI embeddings ({model}) -- NOT externally verifiable");
+                tracing::info!(
+                    "Falling back to OpenAI embeddings ({model}) -- NOT externally verifiable"
+                );
                 Ok(Box::new(OpenAIEmbedder::new(api_key, model)))
             } else {
                 Err(
@@ -188,15 +226,15 @@ pub fn build_embedder(provider: &str, api_key: &str, model: &str) -> Result<Box<
             }
         }
         "openai" if !api_key.is_empty() => {
-            tracing::info!("Embedder: OpenAI {model} -- NOT externally verifiable (proprietary model)");
+            tracing::info!(
+                "Embedder: OpenAI {model} -- NOT externally verifiable (proprietary model)"
+            );
             Ok(Box::new(OpenAIEmbedder::new(api_key, model)))
         }
-        "openai" => {
-            Err("EMBED_PROVIDER=openai but OPENAI_API_KEY not set.".to_string())
-        }
-        other => {
-            Err(format!("Unknown EMBED_PROVIDER={other}. Valid: fastembed, openai"))
-        }
+        "openai" => Err("EMBED_PROVIDER=openai but OPENAI_API_KEY not set.".to_string()),
+        other => Err(format!(
+            "Unknown EMBED_PROVIDER={other}. Valid: fastembed, openai"
+        )),
     }
 }
 
@@ -205,7 +243,9 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
     let dot: f32 = a.iter().zip(b.iter()).map(|(x, y)| x * y).sum();
     let na: f32 = a.iter().map(|x| x * x).sum::<f32>().sqrt();
     let nb: f32 = b.iter().map(|x| x * x).sum::<f32>().sqrt();
-    if na == 0.0 || nb == 0.0 { return 0.0; }
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
     dot / (na * nb)
 }
 
@@ -213,7 +253,9 @@ pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
 pub(crate) fn l2_normalize(vec: &mut [f32]) {
     let norm: f32 = vec.iter().map(|x| x * x).sum::<f32>().sqrt();
     if norm > 0.0 {
-        for v in vec.iter_mut() { *v /= norm; }
+        for v in vec.iter_mut() {
+            *v /= norm;
+        }
     }
 }
 

--- a/core/src/identity/mod.rs
+++ b/core/src/identity/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
-use solana_sdk::signature::{Keypair, Signer};
 use solana_sdk::pubkey::Pubkey;
+use solana_sdk::signature::{Keypair, Signer};
 use std::path::Path;
 
 /// Load keypair from JSON file, or generate and save a new one.

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,8 +1,8 @@
-pub mod codec;
-pub mod identity;
-pub mod embed;
-pub mod compress;
-pub mod storage;
 pub mod arweave;
-pub mod solana;
+pub mod codec;
+pub mod compress;
+pub mod embed;
+pub mod identity;
 pub mod lineage;
+pub mod solana;
+pub mod storage;

--- a/core/src/lineage/mod.rs
+++ b/core/src/lineage/mod.rs
@@ -53,9 +53,8 @@ pub fn record_parents(
 
 /// Get parents of an artifact.
 pub fn get_parents(conn: &Connection, artifact_id: &str) -> anyhow::Result<Vec<ParentRef>> {
-    let mut stmt = conn.prepare(
-        "SELECT parent_id, role FROM artifact_lineage WHERE child_id = ?"
-    )?;
+    let mut stmt =
+        conn.prepare("SELECT parent_id, role FROM artifact_lineage WHERE child_id = ?")?;
     let rows = stmt.query_map(params![artifact_id], |row| {
         Ok(ParentRef {
             artifact_id: row.get(0)?,
@@ -68,9 +67,7 @@ pub fn get_parents(conn: &Connection, artifact_id: &str) -> anyhow::Result<Vec<P
 
 /// Get children of an artifact.
 pub fn get_children(conn: &Connection, artifact_id: &str) -> anyhow::Result<Vec<String>> {
-    let mut stmt = conn.prepare(
-        "SELECT child_id FROM artifact_lineage WHERE parent_id = ?"
-    )?;
+    let mut stmt = conn.prepare("SELECT child_id FROM artifact_lineage WHERE parent_id = ?")?;
     let rows = stmt.query_map(params![artifact_id], |row| row.get(0))?;
     let collected: rusqlite::Result<Vec<_>> = rows.collect();
     Ok(collected?)
@@ -263,8 +260,14 @@ mod tests {
     fn test_record_and_get_parents() {
         let conn = setup_db();
         let parents = vec![
-            ParentRef { artifact_id: "art:parent1".into(), role: Some("context".into()) },
-            ParentRef { artifact_id: "art:parent2".into(), role: None },
+            ParentRef {
+                artifact_id: "art:parent1".into(),
+                role: Some("context".into()),
+            },
+            ParentRef {
+                artifact_id: "art:parent2".into(),
+                role: None,
+            },
         ];
         record_parents(&conn, "art:child", &parents, "2026-04-14").unwrap();
 
@@ -276,7 +279,10 @@ mod tests {
     #[test]
     fn test_get_children() {
         let conn = setup_db();
-        let parents = vec![ParentRef { artifact_id: "art:root".into(), role: None }];
+        let parents = vec![ParentRef {
+            artifact_id: "art:root".into(),
+            role: None,
+        }];
         record_parents(&conn, "art:child1", &parents, "2026-04-14").unwrap();
         record_parents(&conn, "art:child2", &parents, "2026-04-14").unwrap();
 
@@ -287,14 +293,20 @@ mod tests {
     #[test]
     fn test_validate_parents_ok() {
         let conn = setup_db();
-        let parents = vec![ParentRef { artifact_id: "art:p1".into(), role: None }];
+        let parents = vec![ParentRef {
+            artifact_id: "art:p1".into(),
+            role: None,
+        }];
         assert!(validate_parents(&conn, "art:new", &parents, &mock_exists).is_ok());
     }
 
     #[test]
     fn test_validate_parents_not_found() {
         let conn = setup_db();
-        let parents = vec![ParentRef { artifact_id: "missing:x".into(), role: None }];
+        let parents = vec![ParentRef {
+            artifact_id: "missing:x".into(),
+            role: None,
+        }];
         let err = validate_parents(&conn, "art:new", &parents, &mock_exists).unwrap_err();
         assert!(err.contains("PARENT_NOT_FOUND"));
     }
@@ -303,7 +315,10 @@ mod tests {
     fn test_validate_too_many_parents() {
         let conn = setup_db();
         let parents: Vec<ParentRef> = (0..MAX_PARENTS + 1)
-            .map(|i| ParentRef { artifact_id: format!("art:p{i}"), role: None })
+            .map(|i| ParentRef {
+                artifact_id: format!("art:p{i}"),
+                role: None,
+            })
             .collect();
         let err = validate_parents(&conn, "art:new", &parents, &mock_exists).unwrap_err();
         assert!(err.contains("TOO_MANY_PARENTS"));
@@ -313,11 +328,32 @@ mod tests {
     fn test_cycle_detection() {
         let conn = setup_db();
         // Build chain: A -> B -> C
-        record_parents(&conn, "art:B", &[ParentRef { artifact_id: "art:A".into(), role: None }], "t").unwrap();
-        record_parents(&conn, "art:C", &[ParentRef { artifact_id: "art:B".into(), role: None }], "t").unwrap();
+        record_parents(
+            &conn,
+            "art:B",
+            &[ParentRef {
+                artifact_id: "art:A".into(),
+                role: None,
+            }],
+            "t",
+        )
+        .unwrap();
+        record_parents(
+            &conn,
+            "art:C",
+            &[ParentRef {
+                artifact_id: "art:B".into(),
+                role: None,
+            }],
+            "t",
+        )
+        .unwrap();
 
         // Try to make A -> C (which would create a cycle)
-        let parents = vec![ParentRef { artifact_id: "art:C".into(), role: None }];
+        let parents = vec![ParentRef {
+            artifact_id: "art:C".into(),
+            role: None,
+        }];
         let err = validate_parents(&conn, "art:A", &parents, &mock_exists).unwrap_err();
         assert!(err.contains("CYCLE_DETECTED"), "got: {err}");
     }
@@ -326,10 +362,31 @@ mod tests {
     fn test_no_false_cycle() {
         let conn = setup_db();
         // Chain: A -> B -> C. Adding D -> C is fine (no cycle)
-        record_parents(&conn, "art:B", &[ParentRef { artifact_id: "art:A".into(), role: None }], "t").unwrap();
-        record_parents(&conn, "art:C", &[ParentRef { artifact_id: "art:B".into(), role: None }], "t").unwrap();
+        record_parents(
+            &conn,
+            "art:B",
+            &[ParentRef {
+                artifact_id: "art:A".into(),
+                role: None,
+            }],
+            "t",
+        )
+        .unwrap();
+        record_parents(
+            &conn,
+            "art:C",
+            &[ParentRef {
+                artifact_id: "art:B".into(),
+                role: None,
+            }],
+            "t",
+        )
+        .unwrap();
 
-        let parents = vec![ParentRef { artifact_id: "art:C".into(), role: None }];
+        let parents = vec![ParentRef {
+            artifact_id: "art:C".into(),
+            role: None,
+        }];
         assert!(validate_parents(&conn, "art:D", &parents, &mock_exists).is_ok());
     }
 
@@ -342,8 +399,26 @@ mod tests {
     #[test]
     fn test_traverse_ancestors() {
         let conn = setup_db();
-        record_parents(&conn, "art:B", &[ParentRef { artifact_id: "art:A".into(), role: Some("context".into()) }], "t").unwrap();
-        record_parents(&conn, "art:C", &[ParentRef { artifact_id: "art:B".into(), role: Some("trigger".into()) }], "t").unwrap();
+        record_parents(
+            &conn,
+            "art:B",
+            &[ParentRef {
+                artifact_id: "art:A".into(),
+                role: Some("context".into()),
+            }],
+            "t",
+        )
+        .unwrap();
+        record_parents(
+            &conn,
+            "art:C",
+            &[ParentRef {
+                artifact_id: "art:B".into(),
+                role: Some("trigger".into()),
+            }],
+            "t",
+        )
+        .unwrap();
 
         let node_fn = |id: &str| -> Option<LineageNode> {
             Some(LineageNode {

--- a/core/src/solana/mod.rs
+++ b/core/src/solana/mod.rs
@@ -2,12 +2,12 @@
 
 use anyhow::Context;
 use solana_sdk::{
+    hash::Hash,
     instruction::{AccountMeta, Instruction},
     message::Message,
     pubkey::Pubkey,
     signature::{Keypair, Signer},
     transaction::Transaction,
-    hash::Hash,
 };
 use std::str::FromStr;
 
@@ -26,7 +26,11 @@ impl SolanaClient {
         }
     }
 
-    pub async fn rpc(&self, method: &str, params: serde_json::Value) -> anyhow::Result<serde_json::Value> {
+    pub async fn rpc(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> anyhow::Result<serde_json::Value> {
         let body = serde_json::json!({
             "jsonrpc": "2.0", "id": 1, "method": method, "params": params
         });
@@ -46,9 +50,14 @@ impl SolanaClient {
             data: memo.as_bytes().to_vec(),
         };
 
-        let blockhash_result = self.rpc("getLatestBlockhash",
-            serde_json::json!([{"commitment": "confirmed"}])).await?;
-        let blockhash_str = blockhash_result["value"]["blockhash"].as_str()
+        let blockhash_result = self
+            .rpc(
+                "getLatestBlockhash",
+                serde_json::json!([{"commitment": "confirmed"}]),
+            )
+            .await?;
+        let blockhash_str = blockhash_result["value"]["blockhash"]
+            .as_str()
             .context("no blockhash")?;
         let blockhash = Hash::from_str(blockhash_str)?;
 
@@ -59,8 +68,12 @@ impl SolanaClient {
         let tx_bytes = bincode::serialize(&tx)?;
         let tx_b64 = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &tx_bytes);
 
-        let result = self.rpc("sendTransaction",
-            serde_json::json!([tx_b64, {"encoding": "base64"}])).await?;
+        let result = self
+            .rpc(
+                "sendTransaction",
+                serde_json::json!([tx_b64, {"encoding": "base64"}]),
+            )
+            .await?;
         let sig = result.as_str().context("no tx signature")?.to_string();
 
         self.confirm_tx(&sig).await?;
@@ -85,7 +98,9 @@ impl SolanaClient {
                         if let (Some(start), Some(end)) = (s.find('"'), s.rfind('"')) {
                             if end > start {
                                 let memo_str = &s[start + 1..end];
-                                if let Ok(parsed) = serde_json::from_str::<serde_json::Value>(memo_str) {
+                                if let Ok(parsed) =
+                                    serde_json::from_str::<serde_json::Value>(memo_str)
+                                {
                                     return Ok(Some(parsed));
                                 }
                                 return Ok(Some(serde_json::json!({"raw": memo_str})));
@@ -99,8 +114,12 @@ impl SolanaClient {
     }
 
     pub async fn airdrop(&self, pubkey: &Pubkey, lamports: u64) -> anyhow::Result<String> {
-        let result = self.rpc("requestAirdrop",
-            serde_json::json!([pubkey.to_string(), lamports])).await?;
+        let result = self
+            .rpc(
+                "requestAirdrop",
+                serde_json::json!([pubkey.to_string(), lamports]),
+            )
+            .await?;
         let sig = result.as_str().context("no airdrop sig")?.to_string();
         self.confirm_tx(&sig).await?;
         Ok(sig)
@@ -140,8 +159,9 @@ impl SolanaClient {
 
     async fn confirm_tx(&self, sig: &str) -> anyhow::Result<()> {
         for _ in 0..30 {
-            let result = self.rpc("getSignatureStatuses",
-                serde_json::json!([[sig]])).await?;
+            let result = self
+                .rpc("getSignatureStatuses", serde_json::json!([[sig]]))
+                .await?;
             if let Some(statuses) = result["value"].as_array() {
                 if let Some(status) = statuses.first().and_then(|s| s.as_object()) {
                     if let Some(conf) = status.get("confirmationStatus").and_then(|c| c.as_str()) {
@@ -168,7 +188,8 @@ mod tests {
 
     // 32 zero bytes base58-encoded — a valid Hash value for testing.
     const ZERO_BLOCKHASH_B58: &str = "11111111111111111111111111111111";
-    const FAKE_SIG: &str = "5j7s6NiJS3JAkvgkoc18WVAsiSaci2pxB2A6ueCJP4tprA2TFg9wSyTLeYouxPBJEMzJinENTkpA52YStRW5Dia7";
+    const FAKE_SIG: &str =
+        "5j7s6NiJS3JAkvgkoc18WVAsiSaci2pxB2A6ueCJP4tprA2TFg9wSyTLeYouxPBJEMzJinENTkpA52YStRW5Dia7";
 
     fn mock_blockhash(server: &MockServer) {
         server.mock(|when, then| {
@@ -182,7 +203,8 @@ mod tests {
     fn mock_send_transaction(server: &MockServer, sig: &str) {
         server.mock(|when, then| {
             when.method(POST).path("/").body_includes("sendTransaction");
-            then.status(200).body(format!(r#"{{"jsonrpc":"2.0","id":1,"result":"{sig}"}}"#));
+            then.status(200)
+                .body(format!(r#"{{"jsonrpc":"2.0","id":1,"result":"{sig}"}}"#));
         });
     }
 
@@ -233,7 +255,8 @@ mod tests {
         let server = MockServer::start();
         server.mock(|when, then| {
             when.method(POST).path("/").body_includes("getTransaction");
-            then.status(200).body(r#"{"jsonrpc":"2.0","id":1,"result":null}"#);
+            then.status(200)
+                .body(r#"{"jsonrpc":"2.0","id":1,"result":null}"#);
         });
 
         let client = SolanaClient::new(&server.base_url());
@@ -246,7 +269,9 @@ mod tests {
         let server = MockServer::start();
         server.mock(|when, then| {
             when.method(POST).path("/").body_includes("requestAirdrop");
-            then.status(200).body(format!(r#"{{"jsonrpc":"2.0","id":1,"result":"{FAKE_SIG}"}}"#));
+            then.status(200).body(format!(
+                r#"{{"jsonrpc":"2.0","id":1,"result":"{FAKE_SIG}"}}"#
+            ));
         });
         mock_signature_confirmed(&server);
 
@@ -280,14 +305,17 @@ mod tests {
         let server = MockServer::start();
         server.mock(|when, then| {
             when.method(POST).path("/").body_includes("requestAirdrop");
-            then.status(200).body(format!(r#"{{"jsonrpc":"2.0","id":1,"result":"{FAKE_SIG}"}}"#));
+            then.status(200).body(format!(
+                r#"{{"jsonrpc":"2.0","id":1,"result":"{FAKE_SIG}"}}"#
+            ));
         });
         // getSignatureStatuses always returns null status (pending) — never confirms
         server.mock(|when, then| {
-            when.method(POST).path("/").body_includes("getSignatureStatuses");
-            then.status(200).body(
-                r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":1},"value":[null]}}"#
-            );
+            when.method(POST)
+                .path("/")
+                .body_includes("getSignatureStatuses");
+            then.status(200)
+                .body(r#"{"jsonrpc":"2.0","id":1,"result":{"context":{"slot":1},"value":[null]}}"#);
         });
 
         let client = SolanaClient::new(&server.base_url());
@@ -304,7 +332,8 @@ mod tests {
         let server = MockServer::start();
         server.mock(|when, then| {
             when.method(POST).path("/").body_includes("getHealth");
-            then.status(200).body(r#"{"jsonrpc":"2.0","id":1,"result":"ok"}"#);
+            then.status(200)
+                .body(r#"{"jsonrpc":"2.0","id":1,"result":"ok"}"#);
         });
 
         let client = SolanaClient::new(&server.base_url());
@@ -317,7 +346,7 @@ mod tests {
         server.mock(|when, then| {
             when.method(POST).path("/");
             then.status(200).body(
-                r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}"#
+                r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}"#,
             );
         });
 

--- a/core/src/storage/mod.rs
+++ b/core/src/storage/mod.rs
@@ -1,8 +1,8 @@
 //! Storage layer -- trait abstractions and SQLite implementation for attestation persistence.
 
-pub mod traits;
 pub mod sqlite;
+pub mod traits;
 
-pub use traits::{AttestationStore, LineageStore};
 pub use sqlite::SqliteStore;
 pub use traits::{AttestationRow, SearchResult};
+pub use traits::{AttestationStore, LineageStore};

--- a/core/src/storage/sqlite.rs
+++ b/core/src/storage/sqlite.rs
@@ -4,7 +4,7 @@
 //! callers must wrap it in `std::sync::Mutex` and never hold the lock across an `.await` point.
 
 use anyhow::Context;
-use rusqlite::{Connection, params};
+use rusqlite::{params, Connection};
 use std::path::Path;
 
 use super::traits::{AttestationRow, AttestationStore, LineageStore, SearchResult};
@@ -162,8 +162,16 @@ impl AttestationStore for SqliteStore {
         let tags_json = serde_json::to_string(tags)?;
         self.conn.execute(
             "INSERT OR REPLACE INTO attestations VALUES (?,?,?,?,?,?,?,?)",
-            params![attestation_id, content, content_hash, tags_json,
-                    solana_tx, arweave_tx, signer_pubkey, created_at],
+            params![
+                attestation_id,
+                content,
+                content_hash,
+                tags_json,
+                solana_tx,
+                arweave_tx,
+                signer_pubkey,
+                created_at
+            ],
         )?;
         let emb_bytes = floats_to_bytes(embedding);
         self.conn.execute(
@@ -176,7 +184,7 @@ impl AttestationStore for SqliteStore {
     fn find_by_tx(&self, tx_id: &str) -> anyhow::Result<Option<AttestationRow>> {
         let mut stmt = self.conn.prepare(
             "SELECT attestation_id, content, content_hash, solana_tx, arweave_tx, signer_pubkey
-             FROM attestations WHERE solana_tx = ?1 OR arweave_tx = ?1 LIMIT 1"
+             FROM attestations WHERE solana_tx = ?1 OR arweave_tx = ?1 LIMIT 1",
         )?;
         let mut rows = stmt.query(params![tx_id])?;
         match rows.next()? {
@@ -195,7 +203,8 @@ impl AttestationStore for SqliteStore {
     fn count(&self, signer: &str) -> anyhow::Result<i64> {
         let count: i64 = self.conn.query_row(
             "SELECT COUNT(*) FROM attestations WHERE signer_pubkey = ?",
-            params![signer], |row| row.get(0),
+            params![signer],
+            |row| row.get(0),
         )?;
         Ok(count)
     }
@@ -211,7 +220,7 @@ impl AttestationStore for SqliteStore {
                     a.solana_tx, a.arweave_tx, a.created_at, ae.embedding
              FROM attestations a
              JOIN attestation_embeddings ae ON a.attestation_id = ae.attestation_id
-             WHERE a.signer_pubkey = ?"
+             WHERE a.signer_pubkey = ?",
         )?;
 
         let q_norm = l2_norm(query_embedding);
@@ -227,7 +236,11 @@ impl AttestationStore for SqliteStore {
                 let emb = bytes_to_floats(&emb_blob);
                 let e_norm = l2_norm(&emb);
                 let score = if e_norm > 0.0 {
-                    q_normalized.iter().zip(emb.iter()).map(|(a, b)| a * b / e_norm).sum::<f32>()
+                    q_normalized
+                        .iter()
+                        .zip(emb.iter())
+                        .map(|(a, b)| a * b / e_norm)
+                        .sum::<f32>()
                 } else {
                     0.0
                 };
@@ -262,9 +275,9 @@ impl LineageStore for SqliteStore {
     }
 
     fn get_edges(&self, child_id: &str) -> anyhow::Result<Vec<(String, i64)>> {
-        let mut stmt = self.conn.prepare(
-            "SELECT parent_id, depth FROM lineage_edges WHERE child_id = ?"
-        )?;
+        let mut stmt = self
+            .conn
+            .prepare("SELECT parent_id, depth FROM lineage_edges WHERE child_id = ?")?;
         let rows = stmt.query_map(params![child_id], |row| {
             Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?))
         })?;
@@ -301,11 +314,19 @@ mod tests {
     #[test]
     fn test_save_and_find_by_tx() {
         let store = SqliteStore::in_memory().unwrap();
-        store.save_attestation(
-            "att-1", "content", "hash1", &["tag".into()],
-            "sol_tx_1", "ar_tx_1", "signer1", "2026-04-13T00:00:00Z",
-            &[1.0, 0.0],
-        ).unwrap();
+        store
+            .save_attestation(
+                "att-1",
+                "content",
+                "hash1",
+                &["tag".into()],
+                "sol_tx_1",
+                "ar_tx_1",
+                "signer1",
+                "2026-04-13T00:00:00Z",
+                &[1.0, 0.0],
+            )
+            .unwrap();
 
         let found = store.find_by_tx("sol_tx_1").unwrap();
         assert!(found.is_some());
@@ -319,15 +340,33 @@ mod tests {
     fn test_count_by_signer() {
         let store = SqliteStore::in_memory().unwrap();
         for i in 0..2 {
-            store.save_attestation(
-                &format!("att-{i}"), "c", "h", &[], "sol", "ar",
-                "signer_a", "2026-01-01", &[1.0, 0.0],
-            ).unwrap();
+            store
+                .save_attestation(
+                    &format!("att-{i}"),
+                    "c",
+                    "h",
+                    &[],
+                    "sol",
+                    "ar",
+                    "signer_a",
+                    "2026-01-01",
+                    &[1.0, 0.0],
+                )
+                .unwrap();
         }
-        store.save_attestation(
-            "att-other", "c", "h", &[], "sol2", "ar2",
-            "signer_b", "2026-01-01", &[1.0, 0.0],
-        ).unwrap();
+        store
+            .save_attestation(
+                "att-other",
+                "c",
+                "h",
+                &[],
+                "sol2",
+                "ar2",
+                "signer_b",
+                "2026-01-01",
+                &[1.0, 0.0],
+            )
+            .unwrap();
 
         assert_eq!(store.count("signer_a").unwrap(), 2);
         assert_eq!(store.count("signer_b").unwrap(), 1);
@@ -337,14 +376,32 @@ mod tests {
     fn test_search_ranking() {
         let store = SqliteStore::in_memory().unwrap();
         // Two attestations with distinct embeddings
-        store.save_attestation(
-            "att-0", "topic zero", "h0", &[], "s0", "a0",
-            "agent", "2026-01-01", &[1.0, 0.0],
-        ).unwrap();
-        store.save_attestation(
-            "att-1", "topic one", "h1", &[], "s1", "a1",
-            "agent", "2026-01-01", &[0.0, 1.0],
-        ).unwrap();
+        store
+            .save_attestation(
+                "att-0",
+                "topic zero",
+                "h0",
+                &[],
+                "s0",
+                "a0",
+                "agent",
+                "2026-01-01",
+                &[1.0, 0.0],
+            )
+            .unwrap();
+        store
+            .save_attestation(
+                "att-1",
+                "topic one",
+                "h1",
+                &[],
+                "s1",
+                "a1",
+                "agent",
+                "2026-01-01",
+                &[0.0, 1.0],
+            )
+            .unwrap();
 
         // Query closer to att-0's embedding
         let results = store.search(&[1.0, 0.0], "agent", 2).unwrap();
@@ -362,14 +419,30 @@ mod tests {
     #[test]
     fn test_duplicate_attestation_id() {
         let store = SqliteStore::in_memory().unwrap();
-        store.save_attestation(
-            "att-dup", "c1", "h1", &[], "sol1", "ar1",
-            "s1", "2026-01-01", &[1.0],
-        ).unwrap();
+        store
+            .save_attestation(
+                "att-dup",
+                "c1",
+                "h1",
+                &[],
+                "sol1",
+                "ar1",
+                "s1",
+                "2026-01-01",
+                &[1.0],
+            )
+            .unwrap();
         // INSERT OR REPLACE so this succeeds (replaces)
         let result = store.save_attestation(
-            "att-dup", "c2", "h2", &[], "sol2", "ar2",
-            "s1", "2026-01-01", &[1.0],
+            "att-dup",
+            "c2",
+            "h2",
+            &[],
+            "sol2",
+            "ar2",
+            "s1",
+            "2026-01-01",
+            &[1.0],
         );
         assert!(result.is_ok());
         // Content should be updated

--- a/core/tests/integration_cbor.rs
+++ b/core/tests/integration_cbor.rs
@@ -81,8 +81,14 @@ fn test_determinism_across_multiple_keypairs() {
     let kp2 = Keypair::new();
     let s1 = sign_artifact(&artifact, &MEMORY_V1, &kp1).unwrap();
     let s2 = sign_artifact(&artifact, &MEMORY_V1, &kp2).unwrap();
-    assert_ne!(s1.cose_bytes, s2.cose_bytes, "different signers produce different COSE");
-    assert_eq!(s1.content_hash, s2.content_hash, "content hashes must match");
+    assert_ne!(
+        s1.cose_bytes, s2.cose_bytes,
+        "different signers produce different COSE"
+    );
+    assert_eq!(
+        s1.content_hash, s2.content_hash,
+        "content hashes must match"
+    );
 
     let r1 = verify_artifact(&s1.cose_bytes, Some(&s1.content_hash)).unwrap();
     let r2 = verify_artifact(&s2.cose_bytes, Some(&s2.content_hash)).unwrap();
@@ -122,11 +128,16 @@ fn test_all_artifact_schemas() {
         let hash = hash_bytes(&cbor);
 
         let signed = sign_artifact(&artifact, schema, &kp).expect(type_name);
-        let result = verify_artifact(&signed.cose_bytes, Some(&signed.content_hash)).expect(type_name);
+        let result =
+            verify_artifact(&signed.cose_bytes, Some(&signed.content_hash)).expect(type_name);
 
         assert!(result.valid, "{type_name}: COSE verification failed");
         assert_eq!(result.payload, cbor, "{type_name}: payload mismatch");
-        assert_eq!(hash_bytes(&result.payload), hash, "{type_name}: hash mismatch");
+        assert_eq!(
+            hash_bytes(&result.payload),
+            hash,
+            "{type_name}: hash mismatch"
+        );
     }
 }
 

--- a/mcp/src/config.rs
+++ b/mcp/src/config.rs
@@ -76,11 +76,16 @@ impl Config {
             treasury_pubkey: env_or("TREASURY_PUBKEY", ""),
             usdc_mint: env_or("USDC_MINT", "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"),
             sign_memory_cost_micro_usdc: env_or("SIGN_MEMORY_COST_MICRO_USDC", "1000")
-                .parse().unwrap_or(1000),
+                .parse()
+                .unwrap_or(1000),
             price_refresh_secs: env_or("PRICE_REFRESH_SECS", "1800").parse().unwrap_or(1800),
             pricing_margin_bps: env_or("PRICING_MARGIN_BPS", "2000").parse().unwrap_or(2000),
-            typical_payload_bytes: env_or("TYPICAL_PAYLOAD_BYTES", "2048").parse().unwrap_or(2048),
-            sol_tx_fee_lamports: env_or("SOL_TX_FEE_LAMPORTS", "5000").parse().unwrap_or(5000),
+            typical_payload_bytes: env_or("TYPICAL_PAYLOAD_BYTES", "2048")
+                .parse()
+                .unwrap_or(2048),
+            sol_tx_fee_lamports: env_or("SOL_TX_FEE_LAMPORTS", "5000")
+                .parse()
+                .unwrap_or(5000),
         }
     }
 }

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -4,7 +4,6 @@ mod payment;
 mod pricing;
 mod tools;
 
-use std::sync::Arc;
 use axum::{
     extract::{Query, State},
     http::{HeaderMap, StatusCode},
@@ -16,11 +15,15 @@ use clap::Parser;
 use mnemonic_core::{arweave, compress, embed, identity, solana, storage::SqliteStore};
 use serde::Deserialize;
 use solana_sdk::signer::Signer;
+use std::sync::Arc;
 
 // ── CLI ───────────────────────────────────────────────────────────────────────
 
 #[derive(Parser)]
-#[command(name = "mnemonic-mcp", about = "Mnemonic MCP server — verifiable memory attestation")]
+#[command(
+    name = "mnemonic-mcp",
+    about = "Mnemonic MCP server — verifiable memory attestation"
+)]
 struct Cli {
     /// Transport: "stdio" or "http"
     #[arg(long, default_value = "http")]
@@ -105,16 +108,13 @@ async fn mcp_handler(
                 // underlying failure class.
                 if resp.error.is_some() {
                     if let Some(ref key) = api_key {
-                        let reason = resp.error.as_ref()
+                        let reason = resp
+                            .error
+                            .as_ref()
                             .map(|e| e.message.as_str())
                             .unwrap_or("error");
                         let store = state.store.lock().unwrap();
-                        if let Err(e) = payment::refund_balance(
-                            &store,
-                            key,
-                            current_cost,
-                            reason,
-                        ) {
+                        if let Err(e) = payment::refund_balance(&store, key, current_cost, reason) {
                             tracing::warn!(api_key = %key, error = %e, "refund failed");
                         }
                     }
@@ -233,13 +233,15 @@ async fn deposit(
                     Json(serde_json::json!({
                         "error": "api key has no owner_pubkey — cannot verify deposit sender"
                     })),
-                ).into_response()
+                )
+                    .into_response()
             }
             Err(e) => {
                 return (
                     StatusCode::INTERNAL_SERVER_ERROR,
                     Json(serde_json::json!({"error": e.to_string()})),
-                ).into_response()
+                )
+                    .into_response()
             }
         }
     }; // lock released here
@@ -252,7 +254,8 @@ async fn deposit(
             return (
                 StatusCode::BAD_GATEWAY,
                 Json(serde_json::json!({"error": format!("failed to fetch tx signers: {e}")})),
-            ).into_response()
+            )
+                .into_response()
         }
     };
 
@@ -272,7 +275,8 @@ async fn deposit(
             Json(serde_json::json!({
                 "error": "deposit rejected: API key owner is not a signer of this transaction"
             })),
-        ).into_response();
+        )
+            .into_response();
     }
 
     let store = state.store.lock().unwrap();
@@ -355,14 +359,18 @@ async fn main() -> anyhow::Result<()> {
         &cfg.embed_provider,
         &cfg.openai_api_key,
         &cfg.openai_embed_model,
-    ).unwrap_or_else(|e| {
+    )
+    .unwrap_or_else(|e| {
         tracing::error!("FATAL: {e}");
         std::process::exit(1);
     });
     let dim = embedder.dim();
     tracing::info!(
         "Embedder: {} ({}-dim, model={}, verifiable={})",
-        embedder.provider_name(), dim, embedder.model_id(), embedder.is_open_weights(),
+        embedder.provider_name(),
+        dim,
+        embedder.model_id(),
+        embedder.is_open_weights(),
     );
 
     let compressor = compress::EmbeddingCompressor::new(dim, cfg.turbo_bits, 42);
@@ -372,8 +380,15 @@ async fn main() -> anyhow::Result<()> {
         compressor.compression_ratio()
     );
 
-    tracing::info!("Storage mode: {} ({})", cfg.storage_mode,
-        if cfg.storage_mode == "local" { "free, SQLite only" } else { "Arweave + Solana + SQLite" });
+    tracing::info!(
+        "Storage mode: {} ({})",
+        cfg.storage_mode,
+        if cfg.storage_mode == "local" {
+            "free, SQLite only"
+        } else {
+            "Arweave + Solana + SQLite"
+        }
+    );
     tracing::info!("Payment mode: {}", cfg.payment_mode);
 
     // ── Pricing engine ────────────────────────────────────────────────────────
@@ -487,7 +502,10 @@ async fn run_http(state: Arc<mcp::McpState>, host: &str, port: u16) -> anyhow::R
         .route("/balance", get(get_balance))
         .route("/deposit", post(deposit))
         .route("/admin/stats", get(admin_stats))
-        .route("/health", get(|| async { Json(serde_json::json!({"status": "ok"})) }))
+        .route(
+            "/health",
+            get(|| async { Json(serde_json::json!({"status": "ok"})) }),
+        )
         .with_state(state)
         .layer(
             CorsLayer::new()

--- a/mcp/src/mcp.rs
+++ b/mcp/src/mcp.rs
@@ -4,13 +4,13 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use solana_sdk::signature::Keypair;
 
-use std::sync::Arc;
+use crate::{pricing::PricingEngine, tools};
+use mnemonic_core::arweave::ArweaveClient;
 use mnemonic_core::compress::EmbeddingCompressor;
 use mnemonic_core::embed::Embedder;
-use mnemonic_core::storage::SqliteStore;
-use mnemonic_core::arweave::ArweaveClient;
 use mnemonic_core::solana::SolanaClient;
-use crate::{pricing::PricingEngine, tools};
+use mnemonic_core::storage::SqliteStore;
+use std::sync::Arc;
 
 /// JSON-RPC 2.0 request.
 #[derive(Debug, Deserialize)]
@@ -140,7 +140,11 @@ pub async fn handle_request(req: &JsonRpcRequest, state: &McpState) -> JsonRpcRe
         })),
         "tools/list" => Ok(serde_json::json!({"tools": tool_definitions()})),
         "tools/call" => {
-            let name = req.params.get("name").and_then(|n| n.as_str()).unwrap_or("");
+            let name = req
+                .params
+                .get("name")
+                .and_then(|n| n.as_str())
+                .unwrap_or("");
             let args = req.params.get("arguments").cloned().unwrap_or_default();
             handle_tool_call(name, &args, state).await
         }
@@ -150,11 +154,19 @@ pub async fn handle_request(req: &JsonRpcRequest, state: &McpState) -> JsonRpcRe
 
     match result {
         Ok(val) => JsonRpcResponse {
-            jsonrpc: "2.0".into(), id: req.id.clone(), result: Some(val), error: None,
+            jsonrpc: "2.0".into(),
+            id: req.id.clone(),
+            result: Some(val),
+            error: None,
         },
         Err(msg) => JsonRpcResponse {
-            jsonrpc: "2.0".into(), id: req.id.clone(), result: None,
-            error: Some(JsonRpcError { code: -32603, message: msg }),
+            jsonrpc: "2.0".into(),
+            id: req.id.clone(),
+            result: None,
+            error: Some(JsonRpcError {
+                code: -32603,
+                message: msg,
+            }),
         },
     }
 }
@@ -167,34 +179,68 @@ async fn handle_tool_call(name: &str, args: &Value, state: &McpState) -> Result<
             tools::whoami(&state.keypair, &store, &state.storage_mode)
         }
         "mnemonic_sign_memory" => {
-            let content = args["content"].as_str().ok_or("content required")?.to_string();
-            let tags: Vec<String> = args.get("tags")
+            let content = args["content"]
+                .as_str()
+                .ok_or("content required")?
+                .to_string();
+            let tags: Vec<String> = args
+                .get("tags")
                 .and_then(|t| t.as_array())
-                .map(|a| a.iter().filter_map(|v| v.as_str().map(|s| s.to_string())).collect())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                        .collect()
+                })
                 .unwrap_or_default();
             let cost_hint = state.pricing.cost_hint(state.sol_tx_fee_lamports);
             tools::sign_memory(
-                &state.keypair, &state.solana, &state.arweave, &state.store,
-                state.embedder.as_ref(), &state.compressor,
-                &content, &tags, &cost_hint, &state.storage_mode,
-            ).await.map_err(|e| e.to_string())?
+                &state.keypair,
+                &state.solana,
+                &state.arweave,
+                &state.store,
+                state.embedder.as_ref(),
+                &state.compressor,
+                &content,
+                &tags,
+                &cost_hint,
+                &state.storage_mode,
+            )
+            .await
+            .map_err(|e| e.to_string())?
         }
         "mnemonic_verify" => {
             let sol = args.get("solana_tx").and_then(|v| v.as_str());
             let ar = args.get("arweave_tx").and_then(|v| v.as_str());
-            tools::verify(&state.solana, &state.arweave, &state.store, sol, ar, &state.storage_mode)
-                .await.map_err(|e| e.to_string())?
+            tools::verify(
+                &state.solana,
+                &state.arweave,
+                &state.store,
+                sol,
+                ar,
+                &state.storage_mode,
+            )
+            .await
+            .map_err(|e| e.to_string())?
         }
         "mnemonic_prove_identity" => {
             // Pure crypto, no DB or network
-            tools::prove_identity(&state.keypair, args["challenge"].as_str().ok_or("challenge required")?)
+            tools::prove_identity(
+                &state.keypair,
+                args["challenge"].as_str().ok_or("challenge required")?,
+            )
         }
         "mnemonic_recall" => {
             let query = args["query"].as_str().ok_or("query required")?;
             let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(5) as usize;
             // DB-only: lock, query, release
             let store = state.store.lock().unwrap();
-            tools::recall(&state.keypair, &store, state.embedder.as_ref(), query, limit)
+            tools::recall(
+                &state.keypair,
+                &store,
+                state.embedder.as_ref(),
+                query,
+                limit,
+            )
         }
         _ => return Err(format!("unknown tool: {name}")),
     };

--- a/mcp/src/payment.rs
+++ b/mcp/src/payment.rs
@@ -160,9 +160,9 @@ fn check_balance(
     let store = store.lock().unwrap();
     match get_balance(&store, &key) {
         Ok(Some(bal)) if bal >= cost => PaymentGate::Proceed(Some(key)),
-        Ok(Some(bal)) => PaymentGate::Unauthorized(
-            format!("insufficient balance: have {bal} micro-USDC, need {cost}")
-        ),
+        Ok(Some(bal)) => PaymentGate::Unauthorized(format!(
+            "insufficient balance: have {bal} micro-USDC, need {cost}"
+        )),
         Ok(None) => PaymentGate::Unauthorized("api key not found".into()),
         Err(e) => PaymentGate::Unauthorized(format!("balance lookup failed: {e}")),
     }
@@ -182,17 +182,24 @@ async fn check_x402(
         Some(p) => p,
         None => {
             // No payment header — return 402 payment required
-            return PaymentGate::NeedPayment(x402_required(treasury, usdc_mint, cost,
-                "mnemonic_sign_memory attestation fee"));
+            return PaymentGate::NeedPayment(x402_required(
+                treasury,
+                usdc_mint,
+                cost,
+                "mnemonic_sign_memory attestation fee",
+            ));
         }
     };
 
     // Verify the Solana USDC transfer
     match verify_usdc_transfer(solana, &proof.tx_sig, treasury, usdc_mint, cost as u64).await {
         Ok(Some(_)) => {}
-        Ok(None) => return PaymentGate::Unauthorized(
-            format!("x402 payment not valid: tx {} does not transfer >= {cost} micro-USDC to treasury", proof.tx_sig)
-        ),
+        Ok(None) => {
+            return PaymentGate::Unauthorized(format!(
+                "x402 payment not valid: tx {} does not transfer >= {cost} micro-USDC to treasury",
+                proof.tx_sig
+            ))
+        }
         Err(e) => return PaymentGate::Unauthorized(format!("x402 verification error: {e}")),
     }
 
@@ -259,15 +266,19 @@ pub async fn verify_usdc_transfer(
     if let (Some(pre_balances), Some(post_balances)) = (pre, post) {
         for post_entry in post_balances {
             let owner = post_entry["owner"].as_str().unwrap_or("");
-            let mint  = post_entry["mint"].as_str().unwrap_or("");
+            let mint = post_entry["mint"].as_str().unwrap_or("");
             if owner != recipient || mint != usdc_mint {
                 continue;
             }
             let post_amount: u64 = post_entry["uiTokenAmount"]["amount"]
-                .as_str().unwrap_or("0").parse().unwrap_or(0);
+                .as_str()
+                .unwrap_or("0")
+                .parse()
+                .unwrap_or(0);
 
             let account_index = post_entry["accountIndex"].as_u64().unwrap_or(u64::MAX);
-            let pre_amount: u64 = pre_balances.iter()
+            let pre_amount: u64 = pre_balances
+                .iter()
                 .find(|e| e["accountIndex"].as_u64() == Some(account_index))
                 .and_then(|e| e["uiTokenAmount"]["amount"].as_str())
                 .and_then(|s| s.parse().ok())
@@ -315,18 +326,18 @@ pub fn create_api_key(store: &SqliteStore, owner_pubkey: &str) -> anyhow::Result
 
 /// Get the owner pubkey for an API key. Returns None if key not found.
 pub fn get_owner_pubkey(store: &SqliteStore, api_key: &str) -> anyhow::Result<Option<String>> {
-    let mut stmt = store.conn().prepare(
-        "SELECT owner_pubkey FROM api_keys WHERE api_key = ?"
-    )?;
+    let mut stmt = store
+        .conn()
+        .prepare("SELECT owner_pubkey FROM api_keys WHERE api_key = ?")?;
     let mut rows = stmt.query(params![api_key])?;
     Ok(rows.next()?.map(|r| r.get(0)).transpose()?)
 }
 
 /// Get balance in micro-USDC for an API key. Returns None if key not found.
 pub fn get_balance(store: &SqliteStore, api_key: &str) -> anyhow::Result<Option<i64>> {
-    let mut stmt = store.conn().prepare(
-        "SELECT balance_micro_usdc FROM api_keys WHERE api_key = ?"
-    )?;
+    let mut stmt = store
+        .conn()
+        .prepare("SELECT balance_micro_usdc FROM api_keys WHERE api_key = ?")?;
     let mut rows = stmt.query(params![api_key])?;
     Ok(rows.next()?.map(|r| r.get(0)).transpose()?)
 }
@@ -346,7 +357,12 @@ pub fn get_balance(store: &SqliteStore, api_key: &str) -> anyhow::Result<Option<
 /// read-only `get_balance` call to produce the precise user-visible error.
 /// Two concurrent deducts on the same key cannot both pass the guard because
 /// SQLite serializes writes to the same table under the IMMEDIATE write lock.
-pub fn deduct_balance(store: &SqliteStore, api_key: &str, amount: i64, description: &str) -> anyhow::Result<()> {
+pub fn deduct_balance(
+    store: &SqliteStore,
+    api_key: &str,
+    amount: i64,
+    description: &str,
+) -> anyhow::Result<()> {
     let conn = store.conn();
     let now = chrono::Utc::now().to_rfc3339();
 
@@ -379,9 +395,9 @@ pub fn deduct_balance(store: &SqliteStore, api_key: &str, amount: i64, descripti
         let _ = conn.execute("ROLLBACK", []);
         match get_balance(store, api_key)? {
             None => anyhow::bail!("api key not found"),
-            Some(balance) => anyhow::bail!(
-                "insufficient balance: have {balance} micro-USDC, need {amount}"
-            ),
+            Some(balance) => {
+                anyhow::bail!("insufficient balance: have {balance} micro-USDC, need {amount}")
+            }
         }
     }
 
@@ -410,7 +426,12 @@ pub fn deduct_balance(store: &SqliteStore, api_key: &str, amount: i64, descripti
 /// fails with `ConstraintViolation`, which we convert to a user-visible error.
 /// The INSERT + UPDATE are wrapped in an `IMMEDIATE` transaction so the
 /// balance is only credited when the idempotency row is actually inserted.
-pub fn credit_deposit(store: &SqliteStore, api_key: &str, amount: i64, tx_sig: &str) -> anyhow::Result<i64> {
+pub fn credit_deposit(
+    store: &SqliteStore,
+    api_key: &str,
+    amount: i64,
+    tx_sig: &str,
+) -> anyhow::Result<i64> {
     let conn = store.conn();
     let now = chrono::Utc::now().to_rfc3339();
 
@@ -456,7 +477,8 @@ pub fn credit_deposit(store: &SqliteStore, api_key: &str, amount: i64, tx_sig: &
 
     let new_balance: i64 = match conn.query_row(
         "SELECT balance_micro_usdc FROM api_keys WHERE api_key = ?",
-        params![api_key], |r| r.get(0),
+        params![api_key],
+        |r| r.get(0),
     ) {
         Ok(b) => b,
         Err(e) => {
@@ -516,7 +538,8 @@ pub fn refund_balance(
 
     let new_balance: i64 = match conn.query_row(
         "SELECT balance_micro_usdc FROM api_keys WHERE api_key = ?",
-        params![api_key], |r| r.get(0),
+        params![api_key],
+        |r| r.get(0),
     ) {
         Ok(b) => b,
         Err(e) => {
@@ -538,7 +561,9 @@ pub fn mark_x402_nonce(store: &SqliteStore, tx_sig: &str) -> anyhow::Result<()> 
     );
     match result {
         Ok(_) => Ok(()),
-        Err(rusqlite::Error::SqliteFailure(e, _)) if e.code == rusqlite::ErrorCode::ConstraintViolation => {
+        Err(rusqlite::Error::SqliteFailure(e, _))
+            if e.code == rusqlite::ErrorCode::ConstraintViolation =>
+        {
             anyhow::bail!("x402 payment already used: {tx_sig}")
         }
         Err(e) => Err(e.into()),
@@ -673,7 +698,10 @@ mod tests {
         let after_2 = refund_balance(&store, &key, 100, "arweave upload failed").unwrap();
 
         assert_eq!(after_1, 1_100, "first refund credits balance");
-        assert_eq!(after_2, 1_200, "second identical refund ALSO credits balance");
+        assert_eq!(
+            after_2, 1_200,
+            "second identical refund ALSO credits balance"
+        );
 
         // Both rows must exist in payment_events with event_type='refund'.
         let refund_count: i64 = store
@@ -730,10 +758,22 @@ mod tests {
 
         let successes = [&r1, &r2].iter().filter(|r| r.is_ok()).count();
         let failures = [&r1, &r2].iter().filter(|r| r.is_err()).count();
-        assert_eq!(successes, 1, "exactly one credit must succeed: {r1:?} {r2:?}");
-        assert_eq!(failures, 1, "the other must fail with duplicate: {r1:?} {r2:?}");
+        assert_eq!(
+            successes, 1,
+            "exactly one credit must succeed: {r1:?} {r2:?}"
+        );
+        assert_eq!(
+            failures, 1,
+            "the other must fail with duplicate: {r1:?} {r2:?}"
+        );
 
-        let err_msg = [&r1, &r2].iter().find(|r| r.is_err()).unwrap().as_ref().err().unwrap();
+        let err_msg = [&r1, &r2]
+            .iter()
+            .find(|r| r.is_err())
+            .unwrap()
+            .as_ref()
+            .err()
+            .unwrap();
         assert!(
             err_msg.contains("deposit tx already applied"),
             "duplicate error should surface: {err_msg}"
@@ -808,7 +848,10 @@ mod tests {
         credit_deposit(&store, &key, 50, "seed_tx_2").unwrap();
 
         let err = deduct_balance(&store, &key, 100, "too big").unwrap_err();
-        assert!(err.to_string().contains("insufficient balance"), "err = {err}");
+        assert!(
+            err.to_string().contains("insufficient balance"),
+            "err = {err}"
+        );
         assert_eq!(get_balance(&store, &key).unwrap(), Some(50));
     }
 
@@ -894,7 +937,10 @@ mod tests {
         let key = create_api_key(&store, "owner_c").unwrap();
         credit_deposit(&store, &key, 500, "unique_sig").unwrap();
         let err = credit_deposit(&store, &key, 500, "unique_sig").unwrap_err();
-        assert!(err.to_string().contains("deposit tx already applied"), "err = {err}");
+        assert!(
+            err.to_string().contains("deposit tx already applied"),
+            "err = {err}"
+        );
         assert_eq!(get_balance(&store, &key).unwrap(), Some(500));
     }
 }

--- a/mcp/src/pricing.rs
+++ b/mcp/src/pricing.rs
@@ -7,11 +7,11 @@
 //! Computes:  price = max(min_price, (irys + tx_fee) × sol_usd × (1 + margin))
 //! Stores result atomically so reads are always wait-free.
 
+use anyhow::Context;
 use std::sync::{
     atomic::{AtomicI64, AtomicU64, Ordering},
     Arc,
 };
-use anyhow::Context;
 
 // ── Config ────────────────────────────────────────────────────────────────────
 
@@ -107,8 +107,10 @@ impl PricingEngine {
             config.min_price_micro_usdc,
         );
 
-        self.irys_lamports.store(irys_lamports as i64, Ordering::Relaxed);
-        self.sol_price_bits.store(sol_price.to_bits(), Ordering::Relaxed);
+        self.irys_lamports
+            .store(irys_lamports as i64, Ordering::Relaxed);
+        self.sol_price_bits
+            .store(sol_price.to_bits(), Ordering::Relaxed);
         self.price_micro_usdc.store(new_price, Ordering::Relaxed);
 
         tracing::info!(

--- a/mcp/src/tools.rs
+++ b/mcp/src/tools.rs
@@ -120,8 +120,15 @@ pub async fn sign_memory(
     {
         let store = store.lock().unwrap();
         store.save_attestation(
-            &attestation_id, content, &content_hash, tags,
-            &solana_tx, &arweave_tx, &pubkey, &now, &embedding,
+            &attestation_id,
+            content,
+            &content_hash,
+            tags,
+            &solana_tx,
+            &arweave_tx,
+            &pubkey,
+            &now,
+            &embedding,
         )?;
         if storage_mode != "local" {
             let _ = payment::record_attestation_cost(
@@ -181,7 +188,9 @@ pub async fn verify(
 
     // Full mode
     if solana_tx.is_none() && arweave_tx.is_none() {
-        return Ok(serde_json::json!({"status": "error", "message": "Provide solana_tx or arweave_tx"}));
+        return Ok(
+            serde_json::json!({"status": "error", "message": "Provide solana_tx or arweave_tx"}),
+        );
     }
 
     let mut expected_hash: Option<String> = None;
@@ -197,14 +206,18 @@ pub async fn verify(
                 }
                 anchor_version = memo["v"].as_u64().unwrap_or(1);
             }
-            None => return Ok(serde_json::json!({"status": "anchor_not_found", "solana_tx": sol_tx})),
+            None => {
+                return Ok(serde_json::json!({"status": "anchor_not_found", "solana_tx": sol_tx}))
+            }
         }
     }
 
     let ar_tx_id = ar_tx.as_deref().unwrap_or("");
     let raw_bytes = match arweave.read(ar_tx_id).await {
         Ok(b) => b,
-        Err(_) => return Ok(serde_json::json!({"status": "arweave_not_found", "arweave_tx": ar_tx_id})),
+        Err(_) => {
+            return Ok(serde_json::json!({"status": "arweave_not_found", "arweave_tx": ar_tx_id}))
+        }
     };
 
     // Detect artifact format:
@@ -241,7 +254,11 @@ fn verify_cose(
     // Try to recover content preview from the CBOR payload
     let content_preview = from_canonical_cbor(&result.payload)
         .ok()
-        .and_then(|json| json["content"].as_str().map(|s| s[..s.len().min(200)].to_string()))
+        .and_then(|json| {
+            json["content"]
+                .as_str()
+                .map(|s| s[..s.len().min(200)].to_string())
+        })
         .unwrap_or_default();
 
     Ok(serde_json::json!({
@@ -268,7 +285,7 @@ fn verify_legacy_json(
     solana_tx: Option<&str>,
     arweave_tx: &str,
 ) -> anyhow::Result<serde_json::Value> {
-    use sha2::{Sha256, Digest};
+    use sha2::{Digest, Sha256};
 
     let payload: serde_json::Value = serde_json::from_slice(raw_bytes).unwrap_or_default();
     let content = payload["content"].as_str().unwrap_or("");
@@ -304,7 +321,8 @@ fn verify_local(
     solana_tx: Option<&str>,
     arweave_tx: Option<&str>,
 ) -> anyhow::Result<serde_json::Value> {
-    let lookup_id = solana_tx.or(arweave_tx)
+    let lookup_id = solana_tx
+        .or(arweave_tx)
         .ok_or_else(|| anyhow::anyhow!("provide solana_tx or arweave_tx"))?;
 
     let store = store.lock().unwrap();
@@ -320,12 +338,11 @@ fn verify_local(
             // hash won't match exactly — but if the content was tampered, both hashes
             // will differ from what was originally stored.
             let content_hash_check = blake3_hash(a.content.as_bytes());
-            let content_untampered = content_hash_check == a.content_hash
-                || {
-                    // Fallback: the stored hash might be SHA-256 from legacy v1
-                    use sha2::{Sha256, Digest};
-                    hex::encode(Sha256::digest(a.content.as_bytes())) == a.content_hash
-                };
+            let content_untampered = content_hash_check == a.content_hash || {
+                // Fallback: the stored hash might be SHA-256 from legacy v1
+                use sha2::{Digest, Sha256};
+                hex::encode(Sha256::digest(a.content.as_bytes())) == a.content_hash
+            };
 
             // If raw content hash doesn't match AND it's not a legacy hash,
             // the content has been tampered in SQLite

--- a/work/mnemonic-core/decisions.md
+++ b/work/mnemonic-core/decisions.md
@@ -286,3 +286,51 @@ Addressed findings from `code-reviewer-round1.json` (changes-required; 1 major +
 - `grep -n "wasm" .claude/skills/project-knowledge/references/architecture.md` -> only legitimate refs: `wasm-bindgen`, webapp `wasm/` subfolder, WASM export
 - `grep -rn "core/src/wasm" .claude/skills/project-knowledge/references/` -> empty (no matches)
 - Both files render as valid Markdown
+
+## Task 13: Code Audit
+
+**Status:** Done
+**Commit:** (pending — team lead commits audit wave together)
+**Agent:** code-auditor
+**Summary:** Issues-found verdict with 13 findings (1 critical, 4 major, 7 minor, 1 nit). Default `cargo build/test/clippy --workspace` all green (90 tests pass), but `cargo build --features local-embed` fails: fastembed 5.x is API-incompatible with the current `FastEmbedder` impl (`InitOptions` is non-exhaustive; `TextEmbedding::embed` takes `&mut self`). Other notable findings: payment schema + migration live in core despite Decision 2 saying payment stays in mcp; a vestigial `LineageStore` trait (Task 6) defines a second parallel lineage table never unified with Task 9's `core/src/lineage/`; `AttestationStore::search` still uses `filter_map(|r| r.ok())` — the same error-swallowing pattern Task 9 fixed in lineage.rs; `unsafe impl Send/Sync for McpState` is load-bearing without a SAFETY comment; `SolanaClient::rpc` is fully `pub` as a cross-crate escape hatch for `verify_usdc_transfer`.
+**Deviations:** None — audit only, no code changes.
+
+**Reviews:** N/A (audit task, no reviewers per tech-spec task 13).
+
+**Verification:**
+- Report: [logs/working/audit/code-auditor.json](logs/working/audit/code-auditor.json)
+- `cargo build --workspace` → pass
+- `cargo test --workspace` → 90 passed / 0 failed
+- `cargo clippy --workspace --all-targets -- -D warnings` → clean (default features)
+- `cargo clippy --workspace --all-targets --all-features -- -D warnings` → FAILS (fastembed API break, see critical finding)
+
+## Task 14: Security Audit (holistic final-state)
+
+**Status:** Done
+**Agent:** security-auditor-final
+**Summary:** Holistic OWASP Top 10 sweep of the final post-refactor state. Verdict: issues-found, but zero critical/major — 4 minor + 3 nit findings, all of which are either pre-existing deferred items (CORS, /admin/stats auth, keypair file permissions, OpenAI blocking client, WAL file permissions, SSRF-adjacent URL validation) already tracked as follow-ups in task-1 / task-11, or narrow nits with no immediate exploitation path (OpenAI embed zero-fill on failure, x402 tx_sig echo in error bodies, arlocal dev-only PRNG). Payment-layer atomicity is fully correct end-to-end: the three concurrent-execution tests on a shared file-backed DB methodologically prove that balance cannot be overdrawn, deposits cannot be applied twice, and every balance mutation has a matching audit row written atomically with it. No hardcoded secrets, all SQL parameterized, COSE_Sign1 + Ed25519 + blake3 + canonical CBOR cryptography implementation is correct and deterministic, httpmock tests contain no real mainnet URLs or funded keypairs.
+**Deviations:** None — audit-only, no code changes.
+
+**Report:** [logs/working/audit/security-auditor.json](logs/working/audit/security-auditor.json)
+
+## Task 15: Test Audit
+
+**Status:** Done
+**Agent:** test-auditor (test-master)
+**Summary:** Verdict: issues-found with 0 critical, 3 major, 4 minor, 1 nit findings. 83 tests registered (75 lib unit + 5 integration_cbor + 3 proptest_canonical), all pass. Test pyramid is healthy at 90.4% unit. 9 of 12 acceptance criteria PASS, 2 PARTIAL, 1 FAIL. The qualitative gaps the count-based gates masked: (a) MAJOR — storage tests use the concrete `SqliteStore` directly, never through `&dyn AttestationStore` / `&dyn LineageStore` references, so they are concrete-impl tests rather than the trait contract tests the spec requires; (b) MAJOR — `test_compress_roundtrip_mse` uses the magic number `0.05` rather than a named `const MAX_ROUNDTRIP_MSE_4BIT_384` (AC #7 explicitly requires a named threshold); (c) MAJOR — `test_compress_empty_embedding` and `test_compress_single_element` wrap the call in `catch_unwind` then discard the result with `let _ = result;`, passing regardless of whether the implementation panics or succeeds (Category 1 empty tests, litmus-test failures); (d) MINOR — no concurrent-SQLite-access test on the AttestationStore/LineageStore surface (payment side is fully covered in mcp/payment.rs, core side is not); (e) MINOR — MAX_DEPTH=64 boundary not tested; (f) MINOR — direct self-reference cycle (A→A) not tested; (g) MINOR — `embed::tests::empty_string_input` does not actually verify empty-string handling because MockEmbedder ignores its input text. Strengths: MockEmbedder is correctly `#[cfg(test)]`-gated with deterministic L2-normalized output; all 6 arweave + 8 solana httpmock scenarios are present; lineage tests use `Direction` enum and `Option<bool>` chain_valid; both bench files use criterion harness with no network deps; zero `#[ignore]` tests; zero real mainnet URLs or funded keypairs in test code.
+**Deviations:** None — audit-only, no code changes.
+
+**Reviews:** N/A (audit task, no reviewers per tech-spec task 15).
+
+**Verification:**
+- Report: [logs/working/audit/test-auditor.json](logs/working/audit/test-auditor.json)
+- `cargo test -p mnemonic-core --no-run` → pass (3 binaries compiled)
+- `cargo test -p mnemonic-core -- --list` → 83 tests registered (75 lib + 5 integration + 3 proptest)
+- `cargo test -p mnemonic-core` → 83 passed / 0 failed / 0 ignored
+- `cargo bench -p mnemonic-core --no-run` → both bench binaries (decompress, cbor_codec) compiled
+- `grep -n "MockEmbedder" core/src/embed/*.rs` → struct + impl gated with `#[cfg(test)]` at lines 122-146
+- `grep -rn "#\[ignore\]" core/src/ core/tests/` → 0 matches
+- `grep -rn "uploader.irys.xyz\|mainnet.*solana\|api.mainnet-beta" core/` → 2 matches, both in non-test code (production default URL constant + module doc comment)
+
+**Follow-up note for pre-deploy QA (task 16):** No findings are blocking pre-deploy QA. The two non-trivial items to address in a follow-up cycle are TEST-STORAGE-CONTRACT-1 (cast to `&dyn AttestationStore` / `&dyn LineageStore` in storage tests so the trait abstraction provides actual contract guarantees) and TEST-COMPRESS-EDGE-1 (replace the `let _ = result;` discard with a real assertion on the empty/single-element edge cases). Both can be addressed by editing existing test functions; no new test infrastructure required.
+

--- a/work/mnemonic-core/logs/checkpoint.yml
+++ b/work/mnemonic-core/logs/checkpoint.yml
@@ -1,0 +1,36 @@
+# Feature Execution Checkpoint
+# Written by feature-execution skill after each wave.
+# Read by SessionStart(compact) hook for context recovery.
+# Read by feature-execution Phase 1 to detect resume scenario.
+
+skill: feature-execution
+feature: mnemonic-core
+feature_dir: work/mnemonic-core
+execution_plan: work/mnemonic-core/logs/execution-plan.md
+team_name: mnemonic-core
+
+last_completed_wave: 11
+total_waves: 13
+
+# Waves (from task frontmatter):
+#   wave 10: task 10
+#   wave 11: tasks 11, 12 (parallel)
+#   wave 12: tasks 13, 14, 15 (audits, parallel)
+#   wave 13: task 16 (pre-deploy QA)
+
+# Format: task_number: status (planned | in_progress | done)
+tasks:
+  1: done
+  2: done
+  3: done
+  4: done
+  5: done
+  6: done
+  7: done
+  8: done
+  9: done
+  10: done
+  11: done
+  12: done
+
+next_wave: 12

--- a/work/mnemonic-core/logs/tasks/cross-task-reality-review-iter2.json
+++ b/work/mnemonic-core/logs/tasks/cross-task-reality-review-iter2.json
@@ -1,0 +1,66 @@
+{
+  "check": "cross-task-iter2",
+  "status": "approved",
+  "findings": [
+    {
+      "severity": "minor",
+      "category": "cross-task-integration",
+      "task": "tech-spec",
+      "issue": "tech-spec.md Agent Verification Plan (line 174) and Acceptance Criteria (line 213) still use the 7-method payment grep pattern without get_balance. Tasks 11, 13, 14, 16 were all correctly patched to include get_balance. Task 15 (Test Audit) has no payment grep pattern at all (it is a test-coverage audit, not a grep checker — confirmed as acceptable). The tech-spec itself, which is a reference document rather than an executable task, still reads: 'grep -r \"create_api_key|...|verify_usdc_transfer\" core/src/' without get_balance. This is an inconsistency between the reference document and the task execution instructions but does not affect implementation — all executing tasks (11, 13, 14, 16) are correct.",
+      "fix": "Update tech-spec.md Agent Verification Plan step 6 and Acceptance Criteria line 213 to include get_balance in the grep pattern for completeness. This is a doc-only fix and does not block execution."
+    }
+  ],
+  "fix_verifications": [
+    {
+      "fix_id": "fix-1-get_balance",
+      "description": "Tasks 11, 13, 14, 16 grep pattern now includes get_balance",
+      "status": "VERIFIED",
+      "evidence": "Task 11 line 70 and 125: pattern includes get_balance. Task 13 lines 41, 59, 103: pattern includes get_balance. Task 14 lines 61, 95: pattern includes get_balance. Task 16 lines 48, 112, 137: pattern includes get_balance. Task 15 has no payment grep at all — confirmed acceptable (task 15 is test-audit only, not a grep-checker). Tech-spec itself still missing get_balance — flagged as minor doc inconsistency above."
+    },
+    {
+      "fix_id": "fix-2-write_bytes-bypass",
+      "description": "Task 7 write() AND write_bytes() both patched with bypass_local_routing guard; TDD anchor explains independent routing in both methods",
+      "status": "VERIFIED",
+      "evidence": "Task 7 step 4 explicitly states 'Update the routing logic in BOTH write() AND write_bytes(). Each method has its own independent is_local() check and must be patched separately — write_bytes() does NOT delegate to write()'. Code blocks show both methods with the guard. TDD Anchor for test_write_bytes_success (line 101-103) explicitly explains 'new_for_test sets bypass_local_routing: true so write_bytes() skips its own independent is_local() check'. Acceptance criteria bullet (line 115) lists write_bytes as one of the 6 required tests. Details section (line 162) has CRITICAL label: 'write_bytes() has its own independent is_local() check — it does NOT delegate to write().' Fix is fully applied."
+    },
+    {
+      "fix_id": "fix-3-db-rs-TestEmbedder",
+      "description": "Task 4 db.rs tests use inline struct TestEmbedder (NOT mnemonic_core::embed::MockEmbedder); note about #[cfg(test)] cross-crate visibility present",
+      "status": "VERIFIED",
+      "evidence": "Task 4 Description (lines 30, 59-70) explicitly states 'The 2 db.rs tests that used HashEmbedder cannot use MockEmbedder — #[cfg(test)] items from mnemonic_core are invisible to external crates.' Step 7 has the inline struct TestEmbedder with full implementation. Acceptance criteria (line 103) requires 'db.rs tests that used HashEmbedder now use an inline TestEmbedder struct (not MockEmbedder — #[cfg(test)] items from mnemonic_core are not visible to external crates)'. Details section (line 172) repeats the constraint. Fix is fully applied."
+    },
+    {
+      "fix_id": "fix-4-lineage-store-minimal",
+      "description": "Task 6 LineageStore is minimal (only save_edge, get_edges, clear_edges); no lineage result types; TODO(task-9) comment; Option A/B ambiguity removed",
+      "status": "VERIFIED",
+      "evidence": "Task 6 Description (line 25-26) explicitly states 'Important: LineageStore scope in Task 6 is intentionally minimal.' Step 2 defines LineageStore with only three methods: save_edge, get_edges, clear_edges using primitive types. Acceptance criteria (lines 79-80) require exactly these three methods and the TODO(task-9) comment. Details section (lines 172-177) explicitly states this is a 'firm decision — use minimal trait' with no Option A/B ambiguity. The TODO comment is specified as 'TODO(task-9): add get_lineage, get_ancestry, validate_chain methods after lineage types are in core'. Fix is fully applied."
+    },
+    {
+      "fix_id": "fix-5-compress-embed-dependency",
+      "description": "Task 5 false compress-depends-on-embed claim removed; dependency is wave-ordering only",
+      "status": "VERIFIED",
+      "evidence": "Task 5 Dependencies section (line 130) now explicitly reads: 'Depends on Task 4 (embed extraction) — wave ordering places compress after embed extraction for architectural consistency (compress is a higher-level concern than the embedding types). In practice compress.rs does not import the Embedder trait or any embed types — it only uses ndarray::Array1 and turboquant_plus_rs. Task 4 simply must complete before Task 5 starts.' The sentence about EmbeddingCompressor referencing embed types is absent. Note: Task 5 Description (line 19) still says 'compress depends on the Embedder trait and embedding types introduced in Task 4' which is technically still the old false claim in the Description prose, though the Dependencies section correctly contradicts it. This is a residual inconsistency between the Description and Dependencies sections within Task 5."
+    },
+    {
+      "fix_id": "fix-6-decompress-bench-path-hack",
+      "description": "Task 10 has explicit instruction to replace #[path = '../src/compress.rs'] with use mnemonic_core::compress::EmbeddingCompressor",
+      "status": "VERIFIED",
+      "evidence": "Task 10 step 4 (line 34) explicitly states: 'For decompress.rs specifically: it currently uses a #[path = \"../src/compress.rs\"] mod compress; path-include trick to reach the compressor without going through the public API. Replace this with use mnemonic_core::compress::EmbeddingCompressor;'. Details section (line 113) repeats with stronger language: 'Remove that line entirely and replace it with use mnemonic_core::compress::EmbeddingCompressor; — after the move the public API is available directly and the path hack no longer works'. Fix is fully applied."
+    }
+  ],
+  "new_issue_scan": {
+    "result": "One residual issue found in Task 5 Description text (not introduced by fixes — pre-existing inconsistency that the fix only partially resolved). No new cross-task issues introduced by the six fixes.",
+    "details": "Task 5 Description line 19 still says 'compress depends on the Embedder trait and embedding types introduced in Task 4' which contradicts the correctly-fixed Dependencies section. The fix was applied to the Dependencies section but the Description was not updated. This is minor — an implementer reading the full task will see the correct explanation in Dependencies before starting. Classified as minor/feasibility."
+  },
+  "summary": "All 6 claimed fixes are correctly applied. Fix 1 (get_balance): tasks 11/13/14/16 all have get_balance in their grep patterns — verified at multiple locations per file. Task 15 correctly has no payment grep (it is a test audit, not a grep checker). Fix 2 (write_bytes bypass_local_routing): both write() and write_bytes() are explicitly patched with the bypass guard, the critical note is present, and the TDD anchor explains independent routing. Fix 3 (TestEmbedder): Task 4 fully documents the inline TestEmbedder approach with code block, explains the #[cfg(test)] cross-crate visibility constraint, and has the requirement in acceptance criteria. Fix 4 (LineageStore minimal): Task 6 has a firm decision for minimal trait with only 3 primitive-type methods, Option A/B ambiguity eliminated, TODO(task-9) comment required. Fix 5 (compress false claim): Dependencies section correctly states wave-ordering only dependency, though Task 5 Description prose still carries the old false claim — minor residual inconsistency. Fix 6 (path-include replacement): Task 10 has explicit step and detailed instruction to replace the path hack with the public API import. One new finding: tech-spec.md Agent Verification Plan and Acceptance Criteria still use the 7-method grep without get_balance — minor doc inconsistency that does not affect task execution. Overall status: approved.",
+  "stats": {
+    "tasks_checked": 16,
+    "fixes_verified": 6,
+    "fixes_fully_applied": 5,
+    "fixes_partially_applied": 1,
+    "new_issues_found": 2,
+    "new_issues_critical": 0,
+    "new_issues_major": 0,
+    "new_issues_minor": 2
+  }
+}

--- a/work/mnemonic-core/logs/tasks/cross-task-reality-review.json
+++ b/work/mnemonic-core/logs/tasks/cross-task-reality-review.json
@@ -1,0 +1,84 @@
+{
+  "check": "cross-task",
+  "status": "needs_fix",
+  "findings": [
+    {
+      "severity": "critical",
+      "category": "cross-task-integration",
+      "tasks": [6, 11, 13, 14, 15, 16],
+      "issue": "grep pattern for payment method isolation is inconsistent across tasks. Tech-spec Decision 2 lists 7 payment methods (create_api_key, deduct_balance, credit_deposit, mark_x402_nonce, record_attestation_cost, get_pnl_stats, get_owner_pubkey) plus verify_usdc_transfer as 8th. The tech-spec Agent Verification Plan and acceptance criteria DO NOT include get_balance in the grep pattern — they use the 7-method pattern plus verify_usdc_transfer. However, Task 6 correctly identifies get_balance as an 8th DB payment method and its grep patterns include get_balance. Tasks 11, 13, 14, 15, 16 all use the 7+1 (verify_usdc_transfer) pattern WITHOUT get_balance. This means the final verification steps will not catch get_balance leaking into core/. Verified: get_balance exists in mcp/src/db.rs (line 135) and is a genuine payment method that must stay in mcp/.",
+      "fix": "Add get_balance to the grep pattern in Tasks 11, 13, 14, 15, and 16 acceptance criteria and verification steps. The pattern should be: grep -r 'create_api_key|deduct_balance|credit_deposit|mark_x402_nonce|record_attestation_cost|get_pnl_stats|get_owner_pubkey|get_balance|verify_usdc_transfer' core/src/"
+    },
+    {
+      "severity": "critical",
+      "category": "cross-task-integration",
+      "tasks": [7],
+      "issue": "Task 7 arweave write_bytes routing guard is incomplete. The actual arweave.rs code shows write() delegates to write_bytes() (line 27), and write_bytes() has its own is_local() check (lines 32-38). Task 7 instructs adding bypass_local_routing guard only in write() routing logic, but the same is_local() check exists independently in write_bytes(). The test test_write_bytes_success calls write_bytes() directly via new_for_test(). With only write() patched, write_bytes() still takes the arlocal path for mock server addresses and test_write_bytes_success will produce a PRNG id instead of the mock-returned id. The task body does say 'Apply the same guard in write_bytes() if it has the same pattern' but this is a conditional hint, not a firm instruction — the acceptance criteria does not explicitly require it.",
+      "fix": "In Task 7's What to do step 4, change the write_bytes() routing guard from a conditional hint to a mandatory instruction: 'Apply the same bypass_local_routing guard to write_bytes() — it has the same is_local() routing pattern as write() and will fail test_write_bytes_success without this fix.' Update acceptance criteria to include a bullet: write_bytes() routing in write_bytes() is also guarded by bypass_local_routing."
+    },
+    {
+      "severity": "major",
+      "category": "cross-task-integration",
+      "tasks": [6, 9],
+      "issue": "Task 6 introduces LineageStore trait but lineage types (LineageResult, LineageNode, LineageEdge, ParentRef) are not moved to core/src/ until Task 9. Task 6's Details section acknowledges this with Option A / Option B workaround, but neither option is declared as the chosen approach in the task specification — it is left to the implementer to decide. This creates ambiguity: if the implementer picks Option B (placeholder structs) they will define LineageResult etc. in core/src/storage/ which is the wrong final location. Task 9 then must know to delete those placeholders and replace them. There is no explicit depends_on note in Task 9 about cleaning up Option B artifacts.",
+      "fix": "In Task 6 Details section, replace 'Option A (recommended): ... Option B: ...' with a firm decision: 'Use Option A. Do NOT define lineage types in storage/. Define LineageStore trait methods as taking conn: &rusqlite::Connection directly (same as the free functions in lineage.rs) rather than typed structs, OR defer the LineageStore trait implementation to Task 9 by adding only AttestationStore to Task 6 scope.' If Option A is chosen, update Task 6 acceptance criteria to remove the LineageStore trait requirement and move it to Task 9."
+    },
+    {
+      "severity": "major",
+      "category": "cross-task-integration",
+      "tasks": [4, 6],
+      "issue": "Task 4 instructs updating mcp/src/db.rs test code to use MockEmbedder from mnemonic_core::embed::MockEmbedder (Step 7). But MockEmbedder is behind #[cfg(test)] in core/src/embed/. In Rust, #[cfg(test)] items in a library crate are NOT visible to external crates — they are only available when that specific crate is under test. So mcp/src/db.rs cannot import mnemonic_core::embed::MockEmbedder even in its own #[cfg(test)] block. This is a fundamental Rust visibility constraint. Task 6 then moves db.rs tests to core/src/storage/sqlite.rs (where MockEmbedder would be visible within the same crate). But between Task 4 completion and Task 6 completion, the db.rs tests that need MockEmbedder will fail to compile.",
+      "fix": "Two options: (1) In Task 4, instruct the implementer that the db.rs #[cfg(test)] import of MockEmbedder will only work if MockEmbedder is re-exported with #[cfg(test)] pub use at the crate root of mnemonic_core — which still requires a special mechanism. More practically: (2) Update Task 4 Step 7 to read 'Do not update db.rs tests in this task — they will be moved to core/src/storage/sqlite.rs in Task 6 where MockEmbedder is directly accessible within the same crate.' Add a note to Task 6 that the db.rs HashEmbedder tests must be rewritten as MockEmbedder tests during the storage extraction."
+    },
+    {
+      "severity": "major",
+      "category": "cross-task-integration",
+      "tasks": [8],
+      "issue": "Task 8 TDD Anchor and What to do step 7 describe test test_confirm_tx_retry_exhaustion using tokio::time::pause() to skip the 30 x 500ms sleep (15 seconds total). Task 8 details say: 'annotate with #[tokio::test(flavor = \"current_thread\", start_paused = true)]'. However, Task 7 introduced httpmock dev-dependency which spawns a background HTTP server thread. httpmock's MockServer::start() uses a multi-threaded runtime internally. tokio::test with flavor = \"current_thread\" may conflict with httpmock's thread spawning depending on the httpmock version. The test is for confirm_tx retry — it does not need httpmock (it mocks getSignatureStatuses directly via MockServer). This is a test setup inconsistency that could cause flaky failures or require careful sequencing of the time::pause() call relative to the mock server startup.",
+      "fix": "In Task 8 Details, add a note: 'The retry exhaustion test should use MockServer::start_async() or MockServer::start() outside the async test, and call tokio::time::pause() inside the test body after mock server creation but before the client call. Alternatively, run the test in a separate thread using #[tokio::test(start_paused = true)] — this works with httpmock because MockServer runs its own OS thread, not a tokio task.' Verify the chosen httpmock version (0.8) supports concurrent use with paused tokio time."
+    },
+    {
+      "severity": "major",
+      "category": "cross-task-integration",
+      "tasks": [5],
+      "issue": "Task 5 states compress.rs depends on the Embedder trait from Task 4. The actual mcp/src/compress.rs (verified) does NOT import or use the Embedder trait at all — it only uses turboquant, ndarray, and its own CompressedEmbedding/EmbeddingCompressor types. The dependency claim in Task 5 Details section ('EmbeddingCompressor may reference embedding types from mnemonic_core::embed::') is factually incorrect based on the actual source code. This could cause the implementer to unnecessarily wait for Task 4 or add incorrect imports.",
+      "fix": "Correct Task 5 Dependencies section: 'compress.rs does NOT import the Embedder trait or any embed types. It only uses turboquant_plus_rs, ndarray, and its own types. The stated dependency on Task 4 is for sequencing only (core/src/lib.rs already has embed mod from Task 4), not for actual code imports.' Remove the misleading sentence 'EmbeddingCompressor may reference embedding types from mnemonic_core::embed::' from Task 5 Details."
+    },
+    {
+      "severity": "major",
+      "category": "cross-task-integration",
+      "tasks": [10],
+      "issue": "Task 10 moves mcp/benches/decompress.rs to core/benches/. The actual decompress.rs (verified) uses a path trick: '#[path = \"../src/compress.rs\"] mod compress;' — it directly includes the compress source file. After the move to core/benches/, this relative path '#[path = \"../src/compress.rs\"]' would resolve to core/src/compress.rs which now exists. However, the correct approach per Task 10 is to replace the inline mod include with 'use mnemonic_core::compress::EmbeddingCompressor'. If the implementer fails to replace the path trick and just moves the file, the bench will compile (because the path now happens to point to the right place) but will be using a private copy of compress.rs rather than the public mnemonic_core API — defeating the purpose of the migration. Task 10 hints say 'replace inline helpers with imports' but does not specifically call out this path trick.",
+      "fix": "Add an explicit instruction to Task 10 What to do step 4: 'In core/benches/decompress.rs, remove the #[path = \"../src/compress.rs\"] mod compress; declaration entirely and replace it with use mnemonic_core::compress::EmbeddingCompressor; — this is the path-include trick the original benchmark used to access the compress module directly.'"
+    },
+    {
+      "severity": "minor",
+      "category": "cross-task-integration",
+      "tasks": [1, 6, 8, 11, 13, 14, 15, 16],
+      "issue": "solana-client and solana-transaction-status are listed in mcp/Cargo.toml as dependencies. Verified: neither crate is imported anywhere in mcp/src/ (grep returns no matches for solana_client or solana_transaction_status). Task 1 says to remove them, Task 8 says to remove solana-client if present after extraction, Task 11 says to evaluate solana-transaction-status. However, since both are already unused in mcp/src/ (they appear to have been leftover or never actually used), their removal in Task 1 should be unconditional, not conditional on 'verify they are only used in solana.rs'. This minor inconsistency in wording could cause the implementer to do unnecessary verification work.",
+      "fix": "In Task 1 step 5, change 'confirm they are only used in solana.rs before removing' to 'grep confirms neither crate is imported in any mcp/src/ file — both can be removed unconditionally.'"
+    },
+    {
+      "severity": "minor",
+      "category": "cross-task-integration",
+      "tasks": [6, 9],
+      "issue": "Task 6 SqliteStore attempts to implement LineageStore (using free functions from lineage.rs as trait methods). But lineage functions in the actual mcp/src/lineage.rs take a raw rusqlite::Connection parameter — they are not methods on any struct. Task 6 creates SqliteStore wrapping rusqlite::Connection, and the LineageStore trait methods would need to pass self.conn to these free functions. This means SqliteStore's LineageStore impl in Task 6 is effectively calling lineage functions with a Connection reference before lineage is extracted to core. The types (LineageResult etc.) are also not yet in core. This creates a circular situation: SqliteStore implements LineageStore but needs lineage module types that live in mcp/src/lineage.rs — creating a cross-crate dependency that does not yet exist.",
+      "fix": "This reinforces the major finding above. Firm decision must be made in Task 6: either defer LineageStore to Task 9, or scope Task 6 SqliteStore to only implement AttestationStore, with LineageStore deferred. The acceptance criteria for Task 6 should be updated to reflect the chosen approach."
+    },
+    {
+      "severity": "minor",
+      "category": "hints",
+      "tasks": [7],
+      "issue": "Task 7 Details section contains complete pseudocode blocks for the new_for_test constructor, upload_url routing, and all 3 httpmock test patterns (write, health_check, read). These are not hints pointing to patterns — they are complete implementation blueprints with exact struct field names, exact Rust syntax, and exact test assertion code. This crosses from 'hint' into 'prescription', which is a hints-category finding per the validation rules.",
+      "fix": "Reduce the code blocks in Task 7 Details to pattern pointers: 'Add bypass_local_routing: bool field to ArweaveClient. In new(), set it false. In new_for_test(), set it true. Use this flag to guard the is_local() check. For test patterns, see how existing httpmock tests are structured in the project.' Remove the verbatim Rust snippets that implement the full logic."
+    },
+    {
+      "severity": "minor",
+      "category": "hints",
+      "tasks": [8],
+      "issue": "Task 8 Details section contains verbatim Rust implementation guidance for the verify_usdc_transfer extraction ('The function body is identical to the removed method — it calls client.rpc(...)'), the check_x402 call site change ('changes from solana.verify_usdc_transfer(...) to verify_usdc_transfer(solana, ...)'), and the full description of how the httpmock test for write_memo needs three sequential RPC mocks. While not full code blocks, the level of prescriptive detail for write_memo test structure goes beyond a pattern hint.",
+      "fix": "Acceptable as-is for complexity level, but the write_memo test setup description could be shortened to: 'write_memo requires mocking three sequential JSON-RPC calls — getLatestBlockhash, sendTransaction, getSignatureStatuses — refer to the Solana JSON-RPC spec for response shapes.'"
+    }
+  ],
+  "summary": "16 tasks checked across all waves. Two critical findings: (1) get_balance is a genuine payment method in db.rs but is missing from the grep isolation patterns in Tasks 11/13/14/15/16 — it will not be caught if it leaks into core/; (2) write_bytes() in arweave.rs has the same is_local() routing as write() but Task 7's bypass_local_routing fix instructions are ambiguous about whether write_bytes() is also patched. Two other major findings: MockEmbedder cannot be imported by external crates from #[cfg(test)] in Rust — Task 4's db.rs test update step is structurally broken and will fail to compile; and Task 6's LineageStore implementation creates a circular dependency on types not yet in core until Task 9. All 8 core modules (codec, identity, embed, compress, storage, arweave, solana, lineage) are correctly assigned across Tasks 2-9 with proper sequential wave ordering and no duplicate initialization of heavy resources. httpmock pattern is consistent between Tasks 7 and 8. MockEmbedder usage pattern is consistent across Tasks 4, 6, and 15."
+}

--- a/work/mnemonic-core/logs/tasks/cross-task-validator-review.json
+++ b/work/mnemonic-core/logs/tasks/cross-task-validator-review.json
@@ -1,0 +1,73 @@
+{
+  "check": "cross-task",
+  "status": "approved",
+  "findings": [
+    {
+      "severity": "minor",
+      "category": "decomposition",
+      "tasks": [2, 3, 4, 5, 6, 7, 8, 9, 11],
+      "section": "What to do",
+      "issue": "Multiple extraction tasks (2–9) each state they will delete the source file from mcp/src/ AND update mcp/src/tools.rs and mcp/src/main.rs. Task 11 then performs a final pass to delete 'any remaining' source files and re-audit the same import files. This creates intentional redundancy (each task cleans up after itself, Task 11 is defensive), which is fine architecturally, but means Task 11's scope description is ambiguous about whether it is doing new work or verifying prior work. If a prior extraction task skips its cleanup step, Task 11 silently picks it up with no traceability.",
+      "fix": "In Task 11's Description and What to do, explicitly state which deletions are expected to already be done (by prior tasks) vs. which are Task 11's responsibility. Consider adding a pre-condition check: list the files that SHOULD already be absent and assert they are gone before proceeding."
+    },
+    {
+      "severity": "minor",
+      "category": "decomposition",
+      "tasks": [11, 12],
+      "section": "Frontmatter",
+      "issue": "Tasks 11 and 12 are both in wave 11 with depends_on: [10]. This is correct — they can run in parallel. However, Task 13 (code audit, wave 12) depends on both Task 11 AND Task 12 being complete. Task 13's description says 'Depends on Task 11 (MCP server rewiring) and Task 12 (architecture.md updated).' The frontmatter correctly encodes this as depends_on: [11, 12]. No structural defect, but if Task 11 and Task 12 are executed sequentially (not in parallel), the critical path is longer than necessary. This is a scheduling note, not a correctness issue.",
+      "fix": "No fix required. Confirm the feature-execution orchestrator is configured to run wave 11 tasks in parallel."
+    },
+    {
+      "severity": "minor",
+      "category": "consistency",
+      "tasks": [6],
+      "section": "What to do",
+      "issue": "Task 6 modifies mcp/src/payment.rs (receives 8 payment methods from db.rs). Task 8 also modifies mcp/src/payment.rs (adds standalone verify_usdc_transfer). These are in waves 6 and 8 respectively — sequential, no file conflict. However, Task 6 step 8 says payment methods 'can be free functions or methods on a new PaymentStore wrapper — whatever approach keeps payment.rs callers compiling.' Task 8 step 4 says verify_usdc_transfer becomes a 'module-level pub async fn'. If Task 6 chose a PaymentStore struct approach, Task 8's addition of a free function may be stylistically inconsistent. The spec does not mandate a uniform approach across both tasks.",
+      "fix": "Add a note in Task 8's Details section that the style of verify_usdc_transfer (free function) must be consistent with how Task 6 structured the payment methods in payment.rs. If Task 6 used a PaymentStore impl, consider whether verify_usdc_transfer should also be a method or remain a free function — and document the decision."
+    }
+  ],
+  "checks_performed": {
+    "dependency_cycles": {
+      "status": "pass",
+      "detail": "Directed graph of all 16 tasks has no cycles. Full chain: 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 9 → 10 → {11, 12} → {13, 14, 15} → 16."
+    },
+    "wave_sequencing": {
+      "status": "pass",
+      "detail": "All 16 tasks satisfy the invariant wave(task) > max(wave(dependency)) for every entry in depends_on. Sequential wave numbers 1–13 are correctly assigned."
+    },
+    "competing_instances_same_wave": {
+      "status": "pass",
+      "detail": "Wave 11: Tasks 11 and 12 modify completely disjoint files (mcp/src/* vs .claude/skills/project-knowledge/references/*). Wave 12: Tasks 13, 14, 15 are read-only audits — no file modifications. Wave 13: Task 16 is read-only QA. No two tasks in the same wave write to the same file."
+    },
+    "shared_resource_ownership": {
+      "status": "pass",
+      "detail": "Tech-spec declares 'Shared Resources: None.' Three files are modified by multiple tasks but always in strict sequential waves: core/src/lib.rs (owner: Task 1, consumers: Tasks 2–9), mcp/src/tools.rs (consumers: Tasks 2–9, 11), mcp/src/main.rs (consumers: Tasks 3–9, 11). Each consumer depends on all prior consumers through the linear chain — correct ownership by sequential ordering."
+    },
+    "skill_assignment_audit_wave": {
+      "status": "pass",
+      "detail": "Task 13 (wave 12): skills: [code-reviewing] — correct. Task 14 (wave 12): skills: [security-auditor] — correct. Task 15 (wave 12): skills: [test-master] — correct. Task 16 (wave 13): skills: [pre-deploy-qa] — correct. All audit-wave tasks use the appropriate specialized skill."
+    },
+    "reviewer_consistency_audit_tasks": {
+      "status": "pass",
+      "detail": "Tasks 13, 14, 15 correctly have reviewers: [] (they are the reviewer tasks). Task 16 correctly has reviewers: [] (pre-deploy-qa is self-contained). No audit task incorrectly assigns itself a reviewer."
+    },
+    "shared_file_mcp_tools_rs": {
+      "status": "pass",
+      "detail": "mcp/src/tools.rs is modified by Tasks 2, 3, 4, 5, 6, 7, 8, 9, 11. Each is in a distinct wave (2–9, 11) with strict sequential dependencies. Task N depends on Task N-1 for all N in this chain. No concurrent writes."
+    },
+    "shared_file_mcp_main_rs": {
+      "status": "pass",
+      "detail": "mcp/src/main.rs is modified by Tasks 3, 4, 5, 6, 7, 8, 9, 11. All in sequential waves with no parallel execution. Safe."
+    },
+    "shared_file_core_lib_rs": {
+      "status": "pass",
+      "detail": "core/src/lib.rs is created by Task 1 and extended by Tasks 2–9. All sequential. Task 10 reads it but does not modify it. Task 11 reads it. Safe."
+    },
+    "shared_file_mcp_payment_rs": {
+      "status": "pass",
+      "detail": "mcp/src/payment.rs is modified by Tasks 6 (wave 6) and 8 (wave 8). Task 8 depends on Task 7 which depends on Task 6 — sequential. No conflict."
+    }
+  },
+  "summary": "All 16 tasks pass cross-task integration checks. Dependency graph is acyclic. Wave sequencing is valid across all 13 waves. No two tasks in the same wave modify the same file. Audit-wave tasks (13, 14, 15) correctly use specialized audit skills. Final wave (16) correctly uses pre-deploy-qa. Three minor findings: (1) Task 11's cleanup scope is ambiguous about which file deletions are expected vs. new — defensive wording should be clarified; (2) Wave 11 parallel execution opportunity (Tasks 11 and 12) should be confirmed with the orchestrator; (3) payment.rs structure consistency between Task 6's chosen pattern and Task 8's free-function addition should be documented. No critical or major findings. Feature is cleared for execution."
+}

--- a/work/mnemonic-core/logs/tasks/reality-batch1-review-iter2.json
+++ b/work/mnemonic-core/logs/tasks/reality-batch1-review-iter2.json
@@ -1,0 +1,49 @@
+{
+  "validator": "reality-checker",
+  "batch": "1-iter2",
+  "iteration": 2,
+  "tasks": {
+    "1": {
+      "status": "approved",
+      "findings": []
+    },
+    "4": {
+      "status": "approved",
+      "findings": []
+    },
+    "5": {
+      "status": "approved",
+      "findings": []
+    },
+    "6": {
+      "status": "approved",
+      "findings": []
+    },
+    "7": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "critical",
+          "category": "hallucination",
+          "task": 7,
+          "issue": "The new_for_test + force_irys bypass is fundamentally broken. When force_irys=true, write() routes to write_irys() (not write_arlocal()). But write_irys() posts to the hardcoded URL 'https://uploader.irys.xyz/upload' — it completely ignores self.base_url. The mock server URL from MockServer::start() is never used. Tests test_write_success, test_write_bytes_success, and test_malformed_json_response will actually attempt real HTTP connections to uploader.irys.xyz/upload — not to the mock server. The task claims mocking 'POST /tx' will intercept write() calls via new_for_test, but write_irys() never posts to {base_url}/tx.",
+          "fix": "The write_irys() method must be refactored to accept a configurable upload URL (defaulting to 'https://uploader.irys.xyz/upload' in production, but overridable in tests). Add an upload_url field to ArweaveClient or pass it to write_irys(). The new_for_test constructor should set both force_irys=true AND point write_irys() to the mock server URL (e.g., '{base_url}/upload' or a separate upload_url field). The mock must serve POST /upload (not POST /tx) for write tests, and POST /tx is only the arlocal path. Alternatively, re-architect write_irys to use self.base_url for the upload endpoint in test mode."
+        }
+      ]
+    },
+    "8": {
+      "status": "approved",
+      "findings": []
+    },
+    "9": {
+      "status": "approved",
+      "findings": []
+    }
+  },
+  "stats": {
+    "tasks_checked": 7,
+    "claims_verified": 52,
+    "issues_found": 1
+  },
+  "summary": "6 approved, 1 needs fix"
+}

--- a/work/mnemonic-core/logs/tasks/reality-batch1-review-iter3.json
+++ b/work/mnemonic-core/logs/tasks/reality-batch1-review-iter3.json
@@ -1,0 +1,50 @@
+{
+  "batch": "1-iter3",
+  "iteration": 3,
+  "tasks": {
+    "7": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "critical",
+          "category": "feasibility",
+          "task": 7,
+          "issue": "The upload_url fix solves only half the routing problem and will not make write/write_bytes tests pass. The task correctly identifies (line 38) that is_local() returns true for 127.0.0.1 URLs, routing write() to write_arlocal() instead of write_irys(). The proposed fix adds an upload_url field and new_for_test(base_url) constructor where base_url = server.base_url() (a 127.0.0.1 URL). But write() still calls self.is_local() on self.base_url before deciding whether to call write_irys() or write_arlocal(). Since new_for_test sets base_url to the mock server's 127.0.0.1 address, is_local() returns true and write_arlocal() is still called — write_irys() (which uses self.upload_url) is never reached. The upload_url field and new_for_test are unreachable code for write() and write_bytes() when called from tests. test_write_success will still get a PRNG ID, not 'test-tx-id-123'. test_malformed_json_response will still silently pass via write_arlocal() skipping JSON parsing.",
+          "fix": "The fix must also bypass the is_local() routing in write() and write_bytes(). Options: (a) Add a boolean field force_irys: bool to ArweaveClient, set it to true in new_for_test; write() and write_bytes() check force_irys and route to write_irys() regardless of is_local(). (b) Change write() routing to check self.upload_url.starts_with('https://uploader.irys.xyz') instead of is_local(base_url) — non-production URL means use write_irys with self.upload_url. (c) Remove is_local() routing from write() entirely and have write_irys() always use self.upload_url (production URL in new(), mock URL in new_for_test()). Any of these must be explicitly described and included in the task so the implementing agent adds the routing bypass alongside the upload_url field."
+        }
+      ]
+    },
+    "14": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "feasibility",
+          "task": 14,
+          "issue": "Task 14 audits core/src/solana/ test module (step 4) for httpmock hygiene, but solana module extraction is Task 8 — wave 8. Task 14 depends_on: [11, 12] which does not include Task 8 explicitly. Task 8 is upstream of 11 (wave 8 < wave 11), so the dependency is transitively satisfied. No missing direct depends_on issue, but worth confirming the solana module will exist at audit time.",
+          "fix": "No action required — transitive dependency through Task 11 ensures solana module exists before Task 14 runs. Finding is informational only."
+        }
+      ]
+    }
+  },
+  "verified": {
+    "7": {
+      "security_auditor_skill_path": "~/.claude/skills/security-auditor/SKILL.md — EXISTS at /home/claude/.claude/skills/security-auditor/SKILL.md",
+      "task_14_wave": "wave=12 — confirmed in task frontmatter",
+      "upload_url_field": "Field description is internally consistent — new() sets 'https://uploader.irys.xyz/upload', new_for_test sets format!('{}/upload', base_url)",
+      "write_irys_uses_self_upload_url": "Described correctly — write_irys() must use self.upload_url instead of hardcoded string",
+      "new_for_test_constructor": "Format matches spec: Self { base_url, upload_url, client: reqwest::Client::new() }",
+      "mock_post_upload_not_tx": "Correctly specified — write tests mock POST /upload; POST /tx is arlocal path",
+      "mock_get_tx_id_no_prefix": "Correctly specified — read tests mock GET /{tx_id} with no /tx/ prefix and no /data suffix",
+      "mock_get_info": "Correctly specified — health_check tests mock GET /info",
+      "routing_bypass_missing": "MISSING — upload_url alone does not bypass is_local() check in write(); write_arlocal() is still called for 127.0.0.1 base_url"
+    },
+    "14": {
+      "skill_path_exists": "/home/claude/.claude/skills/security-auditor/SKILL.md — EXISTS",
+      "wave": "12 — matches tech-spec Audit Wave",
+      "depends_on": "[11, 12] — correct, both implementation and documentation waves must complete first",
+      "task_nature_analysis_only": "Confirmed — no files modified, produces findings report only"
+    }
+  },
+  "summary": "1 approved, 1 needs fix"
+}

--- a/work/mnemonic-core/logs/tasks/reality-batch1-review.json
+++ b/work/mnemonic-core/logs/tasks/reality-batch1-review.json
@@ -1,0 +1,56 @@
+{
+  "validator": "reality-checker",
+  "batch": 1,
+  "iteration": 1,
+  "tasks": {
+    "1": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "major",
+          "category": "missing_function",
+          "task": 1,
+          "issue": "Task Step 6 says to update only one `turboquant::` import line in mcp/src/compress.rs: 'use turboquant::{pack_bits, pack_indices, TurboQuant};'. However, grep confirms there are TWO occurrences of 'turboquant::' in compress.rs — line 8 (the use statement) and line 158 ('let cv = turboquant::CompressedVectors {'). The task description in Step 6 only mentions the use-import line and says 'Scan the rest of the file for any other turboquant:: occurrences and update them all' — so the intent is correct. The Details section's one-liner about 'Before/After' only shows the import, which could mislead the agent into missing line 158. The instruction in Step 6 to scan is present but the Detail section's concrete example is incomplete.",
+          "fix": "Update the Details section to explicitly show BOTH replacements: (1) the use statement on line 8 and (2) the 'turboquant::CompressedVectors' struct literal on line 158. Both must become 'turboquant_plus_rs::'. The Step 6 scan instruction is correct but the worked example in Details should reflect both sites to avoid the agent stopping after the first substitution."
+        },
+        {
+          "severity": "minor",
+          "category": "feasibility",
+          "task": 1,
+          "issue": "Task Step 5 says to remove 'solana-client = \"2.2\"' and 'solana-transaction-status = \"2.2\"' from mcp/Cargo.toml, and instructs the agent to confirm they are only used in solana.rs before removing. Grep of mcp/src/ confirms neither 'solana_client::' nor 'solana_transaction_status::' appear anywhere in any .rs file — the crate was likely declared but not actually imported via 'use' in the source. This is a safe removal. The task's 'confirm before removing' guard is appropriate but creates minor ambiguity because the agent must also verify that removing these deps does not break a transitive re-export. The instruction is feasible and conservative enough, but a minor note helps.",
+          "fix": "No change required to task logic. Minor clarification: solana-client and solana-transaction-status have zero 'use' appearances in mcp/src/, so removal is safe. Agent should still run 'cargo build -p mnemonic-mcp' to confirm after removal."
+        }
+      ]
+    },
+    "2": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "feasibility",
+          "task": 2,
+          "issue": "Task Details section (mcp/src/mcp.rs) states: 'No crate::codec present in the first 50 lines read; verify there are no codec references in the rest of the file.' Actual inspection of mcp/src/mcp.rs confirms no 'crate::codec' references exist anywhere in the file — only 'crate::{arweave, compress, db, embed, pricing, solana, tools}'. The task's instruction to verify is correct. However, the task Step 7 says 'Update mcp/src/mcp.rs: any crate::codec:: references become mnemonic_core::codec::' — there are none to update. This is a no-op step. Not a blocking issue since the step will correctly complete with zero edits, but it adds noise.",
+          "fix": "Minor: annotate Step 7 with 'If no codec references found in mcp.rs, this step is a no-op — confirmed by code-research.md.' Prevents the agent from second-guessing itself."
+        }
+      ]
+    },
+    "3": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "feasibility",
+          "task": 3,
+          "issue": "Task Details section says 'mcp/src/main.rs (modify) — line 7 is mod identity;'. Actual main.rs confirms 'mod identity;' is on line 7 and identity call sites are on lines 344 and 346. These are accurate. However, the task says 'There are two call sites: identity::load_or_create_keypair and identity::did_sol' — confirmed correct. The task also says to add 'use mnemonic_core::identity;' near other imports and remove 'mod identity;'. This is fully feasible given the actual source structure.",
+          "fix": "No fix needed. All file references, line numbers, and function names verified against actual source."
+        }
+      ]
+    }
+  },
+  "summary": "1 needs fix (Task 1: incomplete turboquant replacement example in Details section), 2 approved (Tasks 2 and 3 are accurate and feasible)",
+  "stats": {
+    "tasks_checked": 3,
+    "claims_verified": 31,
+    "issues_found": 3
+  }
+}

--- a/work/mnemonic-core/logs/tasks/reality-batch2-review.json
+++ b/work/mnemonic-core/logs/tasks/reality-batch2-review.json
@@ -1,0 +1,79 @@
+{
+  "validator": "reality-checker",
+  "batch": 2,
+  "iteration": 1,
+  "tasks": {
+    "4": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "major",
+          "category": "missing_file",
+          "task": 4,
+          "issue": "Task 4 lists 'Files to modify' as only mcp/src/main.rs, mcp/src/tools.rs, mcp/src/embed.rs, and mcp/src/db.rs. However, mcp/src/mcp.rs also imports embed::Embedder directly: `use crate::{arweave::ArweaveClient, compress::EmbeddingCompressor, db::AttestationStore, embed::Embedder, ...}` (mcp.rs line 8). After mcp/src/embed.rs is deleted, mcp/src/mcp.rs will fail to compile unless updated to `mnemonic_core::embed::Embedder`.",
+          "fix": "Add mcp/src/mcp.rs to the 'Files to modify' list and step 4/5 instructions. After moving embed to core, update the mcp.rs import from `embed::Embedder` to `mnemonic_core::embed::Embedder`."
+        },
+        {
+          "severity": "minor",
+          "category": "hints",
+          "task": 4,
+          "issue": "Task 4 says 'All 8 existing embed tests updated to use MockEmbedder'. However, 6 of the 8 existing tests (test_hash_deterministic, test_hash_dimension, test_hash_normalized, test_hash_model_id, test_cosine_self, test_build_test_embedder) specifically test HashEmbedder behavior and properties. These tests cannot simply be 'updated' — they test the thing being deleted. The TDD anchor provides 9 replacement tests, but the task description understates the scope by calling it an 'update'.",
+          "fix": "Clarify that the 6 HashEmbedder-specific tests are replaced (not updated) by the 9 TDD anchor tests. Only test_build_hash_rejected and test_build_openai_without_key_rejected survive as-is."
+        }
+      ]
+    },
+    "5": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "major",
+          "category": "missing_file",
+          "task": 5,
+          "issue": "Task 5 lists 'Files to modify' as mcp/src/main.rs, mcp/src/tools.rs, and mcp/src/compress.rs. However, mcp/src/mcp.rs also imports compress::EmbeddingCompressor directly: `use crate::{arweave::ArweaveClient, compress::EmbeddingCompressor, ...}` (mcp.rs line 8). After mcp/src/compress.rs is deleted, mcp/src/mcp.rs will fail to compile unless updated.",
+          "fix": "Add mcp/src/mcp.rs to the 'Files to modify' list. Update the mcp.rs import from `compress::EmbeddingCompressor` to `mnemonic_core::compress::EmbeddingCompressor`."
+        },
+        {
+          "severity": "minor",
+          "category": "feasibility",
+          "task": 5,
+          "issue": "Task 5 Dependencies section states: 'Depends on Task 4 (embed extraction) — EmbeddingCompressor may reference embedding types from mnemonic_core::embed::'. In reality, compress.rs has zero dependency on the embed module — it only imports `ndarray::Array1` and `turboquant::{pack_bits, pack_indices, TurboQuant}`. The compress task could technically run independently of Task 4 (aside from the workspace structure). The stated dependency rationale is incorrect.",
+          "fix": "Update the dependency rationale: 'Depends on Task 4 for wave ordering only; compress.rs has no runtime dependency on embed types — it accepts &[f32] slices directly.' This is a documentation accuracy issue, not a blocking problem since the wave order is still correct."
+        }
+      ]
+    },
+    "6": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "critical",
+          "category": "hallucination",
+          "task": 6,
+          "issue": "Task 6 repeatedly states that payment methods (create_api_key, deduct_balance, credit_deposit, mark_x402_nonce, record_attestation_cost, get_pnl_stats, get_owner_pubkey) 'stay in mcp/src/payment.rs' (Description line 21, AC line 80, Details line 134). These methods do NOT currently exist in payment.rs — they live on the AttestationStore struct in mcp/src/db.rs. payment.rs only contains check_payment, extract_api_key, extract_x402_proof, and the payment gate types. The task must MOVE these methods from db.rs into payment.rs, but the AC says 'retain all 7 payment methods untouched' which contradicts the required migration.",
+          "fix": "Correct the description and AC to reflect the actual source: 'Move payment methods from mcp/src/db.rs (currently on AttestationStore) into mcp/src/payment.rs as standalone functions or a new PaymentDb wrapper'. The Detail section (line 134) partially acknowledges this correctly but contradicts the Description and AC. Align all three sections."
+        },
+        {
+          "severity": "major",
+          "category": "missing_file",
+          "task": 6,
+          "issue": "Task 6 lists 'Files to modify' as mcp/src/payment.rs, mcp/src/tools.rs, mcp/src/main.rs — but omits mcp/src/mcp.rs. After db.rs is deleted, mcp.rs will fail to compile because it imports: `use crate::{..., db::AttestationStore, ...}` (mcp.rs line 8). This is the same pattern as the missing mcp.rs issue in Tasks 4 and 5.",
+          "fix": "Add mcp/src/mcp.rs to the 'Files to modify' list. Update its import from `db::AttestationStore` to `mnemonic_core::storage::{AttestationStore, SqliteStore}`."
+        },
+        {
+          "severity": "major",
+          "category": "hallucination",
+          "task": 6,
+          "issue": "Task 6 AC and verification grep check for 7 payment methods: `create_api_key|deduct_balance|credit_deposit|mark_x402_nonce|record_attestation_cost|get_pnl_stats|get_owner_pubkey`. The actual db.rs also has an 8th payment-related method: `get_balance` (used by payment.rs check_balance function to verify API key balance). get_balance is excluded from the verification grep list, meaning it could silently leak into core/src/ without being caught.",
+          "fix": "Add `get_balance` to the grep exclusion list in the AC and smoke verification: `grep -r 'create_api_key|deduct_balance|credit_deposit|mark_x402_nonce|record_attestation_cost|get_pnl_stats|get_owner_pubkey|get_balance' core/src/`"
+        },
+        {
+          "severity": "minor",
+          "category": "feasibility",
+          "task": 6,
+          "issue": "Task 6 says 'Move ONLY the non-payment methods from db.rs: save_attestation, find_by_tx, count, search; lineage methods from lineage.rs'. Pulling lineage methods into SqliteStore at Wave 6 while lineage.rs itself is not moved until Task 9 creates a structural awkwardness: lineage methods in storage/sqlite.rs will reference types (LineageResult, LineageNode, LineageEdge, ParentRef) that are still defined in mcp/src/lineage.rs (or codec/schema.rs). The implementation must re-export or import those types cross-boundary. This is feasible but the task doesn't acknowledge this complexity.",
+          "fix": "Add a note clarifying that lineage types (LineageResult, LineageNode, LineageEdge) will temporarily be imported from mcp/src/lineage.rs via `crate::lineage::*` in the sqlite.rs implementation until Task 9 moves them to core/src/lineage/. Alternatively, defer LineageStore trait to Task 9."
+        }
+      ]
+    }
+  },
+  "summary": "0 approved, 3 need fixes. Tasks 4 and 5 each have one major issue (mcp.rs missing from files-to-modify lists causing compile failures) and one minor issue. Task 6 has two major issues (payment methods misattributed to payment.rs, mcp.rs missing from files-to-modify) and one critical issue (task incorrectly states payment methods 'stay in' payment.rs when they must be MOVED there from db.rs — contradicting the AC which says 'retain untouched')."
+}

--- a/work/mnemonic-core/logs/tasks/reality-batch3-review.json
+++ b/work/mnemonic-core/logs/tasks/reality-batch3-review.json
@@ -1,0 +1,99 @@
+{
+  "validator": "reality-checker",
+  "batch": 3,
+  "iteration": 1,
+  "tasks_checked": [7, 8, 9],
+  "tasks": {
+    "7": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "critical",
+          "category": "hallucination",
+          "task": 7,
+          "section": "What to do / TDD Anchor / Details",
+          "issue": "Task says `health_check()` mocks `GET /`. Actual code in `arweave.rs` line 62 uses `GET {base_url}/info`. The mock path `/` will never be hit — the test will fail with a connection error or timeout.",
+          "fix": "Change the health_check mock path from `/` to `/info` in the test definition and TDD Anchor."
+        },
+        {
+          "severity": "critical",
+          "category": "hallucination",
+          "task": 7,
+          "section": "TDD Anchor / Details",
+          "issue": "Task says `read()` mocks `GET /tx/{id}/data`. Actual code in `arweave.rs` line 41 uses `GET {base_url}/{tx_id}` (no `/tx/` prefix, no `/data` suffix). The mock will not match any request.",
+          "fix": "Change the read mock path to `/{tx_id}` (or a wildcard like `/{id}`)."
+        },
+        {
+          "severity": "critical",
+          "category": "feasibility",
+          "task": 7,
+          "section": "What to do / TDD Anchor / Details",
+          "issue": "All httpmock tests use `ArweaveClient::new(&server.base_url())` where `server.base_url()` returns `http://127.0.0.1:{port}`. The `is_local()` check in `arweave.rs` line 70 returns `true` for any URL containing `127.0.0.1` or `localhost`, causing `write_bytes()` to call the `write_arlocal()` code path — which generates its own fake tx ID from a local PRNG and does NOT parse the mock server response body for the `id` field. The tests for `test_write_success`, `test_write_bytes_success`, and especially `test_malformed_json_response` are all based on the wrong code path. `test_write_success` will return a locally-generated ID (not `test-tx-id-123`), making `assert_eq!(result.unwrap(), \"test-tx-id-123\")` fail. `test_malformed_json_response` will succeed (return `Ok`) instead of `Err` because `write_arlocal()` ignores the response body entirely on HTTP 200.",
+          "fix": "Either (a) override `is_local()` to be testable (e.g., add a `#[cfg(test)]` constructor that bypasses the localhost check), or (b) add an `irys_mode` flag to `ArweaveClient` so tests can force the Irys code path, or (c) use a non-localhost address in tests (not possible with httpmock's default behavior since it binds to 127.0.0.1). The cleanest fix is option (a): add `pub fn new_irys(base_url: &str) -> Self` that always uses `write_irys` regardless of URL, and use that constructor in tests for write/write_bytes scenarios. The arlocal test path should have its own test using the `write_arlocal` behavior (no JSON response parsing)."
+        }
+      ]
+    },
+    "8": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "major",
+          "category": "tdd",
+          "task": 8,
+          "section": "TDD Anchor / Description / Acceptance Criteria",
+          "issue": "The Description says '~7 httpmock-based unit tests'. The TDD Anchor section lists 8 named tests (test_write_memo_success, test_read_memo_success, test_read_memo_not_found, test_airdrop_success, test_get_tx_signers, test_confirm_tx_retry_exhaustion, test_health_check_ok, test_rpc_error_handling). Acceptance Criteria say 'All 7+ httpmock tests pass'. The count mismatch between description (~7) and TDD Anchor (8 entries) will cause confusion about the expected deliverable.",
+          "fix": "Update the Description to say '~8 httpmock-based unit tests' and update the Acceptance Criteria to 'All 8 httpmock tests pass: cargo test -p mnemonic-core -- solana'."
+        },
+        {
+          "severity": "major",
+          "category": "feasibility",
+          "task": 8,
+          "section": "Details — Writing httpmock tests",
+          "issue": "`test_confirm_tx_retry_exhaustion` mocks `getSignatureStatuses` to always return null, causing `confirm_tx()` to exhaust 30 retries at 500ms each. The task acknowledges '~15 seconds' duration but leaves resolution vague: 'consider using `#[tokio::test]` and accepting the delay, or testing the error path differently'. A 15-second unit test is a CI concern. The implementation hints are contradictory: `#[tokio::test]` is already required for all solana tests (async); it doesn't help reduce the 15s. The suggested alternative 'return an error status directly instead of null' would need different mock setup. The task does not prescribe a concrete solution.",
+          "fix": "Make the hint concrete: use `#[tokio::test(flavor = \"current_thread\", start_paused = true)]` with `tokio::time::pause()` so that `tokio::time::sleep` advances instantly. This is the standard approach for testing timeout/retry loops. Add this pattern explicitly to the test detail for `test_confirm_tx_retry_exhaustion`. Alternatively, reduce the retry mock to 2-3 iterations with a reduced sleep (passing a `max_retries` parameter), but that requires changing the source code."
+        }
+      ]
+    },
+    "9": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "critical",
+          "category": "missing_function",
+          "task": 9,
+          "section": "What to do step 6 / Acceptance Criteria / Details",
+          "issue": "Task step 6 says 'Update `mcp/src/tools.rs` to change all `use crate::lineage::` imports to `use mnemonic_core::lineage::`'. Actual codebase inspection shows `mcp/src/tools.rs` has ZERO lineage imports or calls — lineage is only declared via `mod lineage;` in `mcp/src/main.rs` and never called from tools.rs. The tools.rs file does not contain `use crate::lineage::` anywhere. The acceptance criterion '`mcp/src/tools.rs` uses `mnemonic_core::lineage::Direction` enum, not string literals' is therefore impossible to satisfy as written.",
+          "fix": "Replace 'Update `mcp/src/tools.rs`...' with 'Update `mcp/src/main.rs`: remove `mod lineage;` declaration and add `use mnemonic_core::lineage;` if lineage is initialized there. Also update the acceptance criterion to reference `main.rs` instead of `tools.rs`."
+        },
+        {
+          "severity": "critical",
+          "category": "hallucination",
+          "task": 9,
+          "section": "What to do step 3 / TDD Anchor",
+          "issue": "Task specifies Direction enum variants as `Direction::Forward` and `Direction::Backward`. The actual direction strings in `lineage.rs` are `\"ancestors\"`, `\"descendants\"`, and `\"both\"` (verified at lines 206, 220, 354). Two variants `Forward`/`Backward` do not map to the three operational values. The TDD Anchor `test_traverse_direction_enum` calls `traverse_lineage` with `Direction::Forward` and asserts `result.direction == Direction::Forward` — but \"ancestors\" is the actual concept, not \"forward\". Using only two variants loses the `\"both\"` traversal case.",
+          "fix": "Define the Direction enum with three variants matching the actual semantics: `pub enum Direction { Ancestors, Descendants, Both }`. Update all references in the task from `Direction::Forward`/`Direction::Backward` to `Direction::Ancestors`/`Direction::Descendants`, and include `Direction::Both`. The TDD Anchor test should use `Direction::Ancestors`. The Details section 'Replace any `direction: \"forward\".to_string()`' should be 'Replace any `direction: \"ancestors\".to_string()`'."
+        },
+        {
+          "severity": "major",
+          "category": "hints",
+          "task": 9,
+          "section": "Details — core/Cargo.toml",
+          "issue": "`rusqlite = { version = \"0.31\", features = [\"bundled\"] }` is specified in Task 9. The actual project `mcp/Cargo.toml` uses `rusqlite = { version = \"0.34\", features = [\"bundled\"] }` and the local cargo registry contains only rusqlite 0.34.0. Version 0.31 is outdated relative to the existing codebase. Using a mismatched version could cause resolution conflicts or introduce unintended API differences.",
+          "fix": "Change to `rusqlite = { version = \"0.34\", features = [\"bundled\"] }` to match the existing project dependency."
+        }
+      ]
+    }
+  },
+  "cross_task_findings": [],
+  "status": "changes_required",
+  "stats": {
+    "tasks_checked": 3,
+    "approved": 0,
+    "needs_fix": 3,
+    "issues_found": 7,
+    "critical": 5,
+    "major": 2,
+    "minor": 0
+  },
+  "summary": "0 approved, 3 need fixes. Task 7: 3 critical issues — health_check mocks wrong endpoint (/info not /), read mocks wrong path (no /tx/ prefix or /data suffix), and the is_local() branching makes all write/write_bytes httpmock tests exercise the wrong code path (arlocal instead of irys), breaking the write_success and malformed_json_response tests. Task 8: 1 major issue — test count inconsistency (8 TDD anchor entries vs '~7' description); 1 major feasibility issue — retry exhaustion test will take ~15 seconds without explicit tokio time-pause guidance. Task 9: 2 critical issues — tools.rs is the wrong target file (lineage lives only in main.rs); Direction enum needs 3 variants (Ancestors/Descendants/Both) not 2 (Forward/Backward). 1 major issue — rusqlite version 0.31 specified but project uses 0.34."
+}

--- a/work/mnemonic-core/logs/tasks/reality-batch4-review.json
+++ b/work/mnemonic-core/logs/tasks/reality-batch4-review.json
@@ -1,0 +1,66 @@
+{
+  "validator": "reality-checker",
+  "batch": 4,
+  "iteration": 1,
+  "tasks": {
+    "10": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "feasibility",
+          "task": 10,
+          "issue": "Task notes that proptest 'may already be present from Task 7 or 8 (httpmock tests)'. proptest is not a dependency of httpmock tests — it was in the original mcp codebase for proptest_canonical.rs and may be added in Task 5 (compress) or Task 9 (lineage). The comment is directionally correct but the cited source tasks (7/8) are wrong.",
+          "fix": "Update the note to say 'proptest may already be present from Task 5 (compress) or an earlier extraction task — check core/Cargo.toml before adding a duplicate entry.'"
+        }
+      ]
+    },
+    "11": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "hallucination",
+          "task": 11,
+          "issue": "Task details section describes AttestationStore as a trait: 'AttestationStore → mnemonic_core::storage::AttestationStore (the trait impl)'. After Task 6, AttestationStore becomes a trait defined in core/src/storage/traits.rs and the SQLite implementation is a separate struct. mcp/src/mcp.rs McpState field should hold the concrete SQLite impl type, not the trait itself (traits are not directly stored in structs without Box<dyn ...> or a concrete type). The phrasing is ambiguous and may mislead the agent.",
+          "fix": "Clarify that McpState holds the concrete SQLite implementation of AttestationStore (e.g. SqliteAttestationStore or similar concrete type name), not the trait object. The agent should read core/src/lib.rs to determine the exact exported concrete type name."
+        },
+        {
+          "severity": "minor",
+          "category": "feasibility",
+          "task": 11,
+          "issue": "The round-trip smoke check uses 'cargo run -p mnemonic-mcp -- --transport stdio' but transport flag availability depends on how the binary's CLI is configured in config.rs. If --transport is not a registered clap argument, the command will fail. Task acknowledges this risk in edge cases but does not provide a fallback invocation.",
+          "fix": "Add a note to check config.rs/main.rs for the exact CLI flag syntax before running the round-trip check. Acceptable fallback: run without --transport stdio if the binary defaults to stdio mode."
+        }
+      ]
+    },
+    "12": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "hints",
+          "task": 12,
+          "issue": "The Required Skills section references the wrong SKILL.md path. It says: '/skill:documentation-writing — [SKILL.md](/home/claude/.openclaw/workspace/mnemonic-refactored/.claude/skills/project-knowledge/SKILL.md)'. The path resolves to the project-knowledge skill, not the documentation-writing skill. The actual documentation-writing SKILL.md lives at /home/claude/.claude/skills/documentation-writing/SKILL.md.",
+          "fix": "Update the SKILL.md link to /home/claude/.claude/skills/documentation-writing/SKILL.md. The skill name '/skill:documentation-writing' is correct — only the path hint is wrong."
+        },
+        {
+          "severity": "minor",
+          "category": "feasibility",
+          "task": 12,
+          "issue": "The architecture.md currently contains 'openai → fastembed → hash' as the fallback chain (confirmed by reading the file). Task 12 correctly identifies this as needing to change to 'openai → fastembed → Err'. However, the task only specifies updating the External Integrations section and does not mention the Project Structure section of architecture.md where core/src/ embed/ is described as having 'three provider implementations (fastembed, openai, hash)'. That description also needs HashEmbedder removed. The acceptance criteria do cover 'grep HashEmbedder returns no matches' so it will be caught, but the What to do steps only mention removing HashEmbedder from 'the embed provider list in the embed/ description' — this is consistent with the Project Structure section fix. No real gap, just noting the two locations are both covered.",
+          "fix": "No fix required — the acceptance criteria (grep for HashEmbedder returns empty) will catch any missed location. Issue is informational only."
+        }
+      ]
+    }
+  },
+  "summary": "3 approved, 0 need fixes",
+  "stats": {
+    "tasks_checked": 3,
+    "claims_verified": 31,
+    "issues_found": 4,
+    "critical": 0,
+    "major": 0,
+    "minor": 4
+  }
+}

--- a/work/mnemonic-core/logs/tasks/reality-batch5-review.json
+++ b/work/mnemonic-core/logs/tasks/reality-batch5-review.json
@@ -1,0 +1,60 @@
+{
+  "validator": "reality-checker",
+  "batch": 5,
+  "iteration": 1,
+  "tasks": {
+    "13": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "feasibility",
+          "task": 13,
+          "issue": "wave field is the string 'Audit Wave' instead of a numeric value. This was flagged in batch4 review for task 16 as a critical issue; the same non-numeric wave value appears here. String wave values cannot be used for numeric dependency ordering.",
+          "fix": "Replace 'wave: Audit Wave' with a numeric value. Per batch4 suggestion, assign wave: 12 (tasks 13-15 as Audit Wave; task 16 as wave 13)."
+        }
+      ]
+    },
+    "14": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "feasibility",
+          "task": 14,
+          "issue": "wave field is the string 'Audit Wave' instead of a numeric value. Same issue as tasks 13 and 15.",
+          "fix": "Replace 'wave: Audit Wave' with 'wave: 12' (consistent with tasks 13 and 15)."
+        },
+        {
+          "severity": "minor",
+          "category": "feasibility",
+          "task": 14,
+          "issue": "The unwrap() grep in the Verification section uses a line-based filter to exclude test code: `grep -rn \".unwrap()\" core/src/ | grep -v \"#[cfg(test)]\" | grep -v \"mod tests\"`. This will produce false negatives: a test module opened with `#[cfg(test)]` on one line contains unwrap() calls on subsequent lines — the grep-v filter only suppresses lines that literally contain the cfg(test) annotation, not all lines inside the block. The check may miss unwrap() calls inside test blocks while also producing false positives on non-test code that happens to appear near test annotations.",
+          "fix": "Accept this as an approximation check (common practice in audit scripts). If strict enforcement is needed, use `cargo clippy -p mnemonic-core -- -D clippy::unwrap_used` in combination with `#[allow(clippy::unwrap_used)]` annotations on test functions. Document the limitation in the audit step rather than relying on grep for full accuracy."
+        }
+      ]
+    },
+    "15": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "feasibility",
+          "task": 15,
+          "issue": "wave field is the string 'Audit Wave' instead of a numeric value. Same issue as tasks 13 and 14.",
+          "fix": "Replace 'wave: Audit Wave' with 'wave: 12' (consistent with tasks 13 and 14)."
+        }
+      ]
+    }
+  },
+  "stats": {
+    "tasks_checked": 3,
+    "claims_verified": 31,
+    "issues_found": 4,
+    "critical": 0,
+    "major": 0,
+    "minor": 4
+  },
+  "status": "approved",
+  "summary": "3 approved, 0 need fixes. All three audit tasks are structurally sound: skill paths verified (code-reviewing/SKILL.md, security-auditor/SKILL.md, test-master/SKILL.md all exist), dependency declarations correct (depends_on: [11, 12]), project knowledge reference files verified (architecture.md, patterns.md, project.md all exist at referenced paths), audit scopes correctly defined against post-implementation file paths, post-completion output target (decisions.md) consistent across all three tasks, no code modifications planned (analysis-only). 4 minor issues: all three tasks use string 'Audit Wave' for the wave field instead of a numeric value (repeat of batch4 finding for task 16); task 14 unwrap() grep filter is a line-based approximation that may miss unwrap() calls inside multi-line test blocks."
+}

--- a/work/mnemonic-core/logs/tasks/reality-batch6-review.json
+++ b/work/mnemonic-core/logs/tasks/reality-batch6-review.json
@@ -1,0 +1,50 @@
+{
+  "validator": "reality-checker",
+  "batch": 6,
+  "iteration": 1,
+  "tasks": {
+    "16": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "feasibility",
+          "task": 16,
+          "issue": "grep checks against core/src/ and mcp/src/ (steps 5, 6 in Verification Steps) will produce an error or empty output if the directories do not exist at QA time rather than returning the expected \"empty\" result. If tasks 1-15 failed to create these directories, the grep will silently pass (no output = 0 exit code) rather than flagging missing content. Task does not guard against this scenario.",
+          "fix": "Add a pre-condition check that core/src/ and mcp/src/ exist and are non-empty before running grep checks. A simple `test -d core/src/` with a clear failure message would prevent false-green grep results on empty directories."
+        },
+        {
+          "severity": "minor",
+          "category": "missing_function",
+          "task": 16,
+          "issue": "Task AC checklist (lines 41-53) omits two tech-spec acceptance criteria that are present in the 'Tech-spec acceptance criteria to verify' block in Details (lines 155-174): (a) `pricing.rs` unchanged in mcp/src/ — no grep/check planned; (b) All SQL in core/src/storage/ uses rusqlite parameterized queries — no verification step defined. Both are in tech-spec Acceptance Criteria section but absent from the formal AC checklist and Verification Steps blocks.",
+          "fix": "Add to AC checklist and Verification Steps: `grep -r 'pricing' mcp/src/ | grep -v 'mnemonic_core'` to confirm pricing.rs stays in mcp/, and a manual read of core/src/storage/sqlite.rs to confirm all SQL uses `?` placeholder syntax (parameterized queries)."
+        },
+        {
+          "severity": "minor",
+          "category": "feasibility",
+          "task": 16,
+          "issue": "AC item 'cargo test -p mnemonic-core succeeds independently without building mnemonic-mcp (standalone usability)' and the corresponding verification step (step 8 in Details) are identical to AC item 2 ('cargo test -p mnemonic-core — all tests green including httpmock tests'). Running `cargo test -p mnemonic-core` does not build mnemonic-mcp as a side effect in a Cargo workspace — the -p flag scopes the build. The verification note 'confirm it does NOT trigger a build of mnemonic-mcp' is correct in intent but there is no concrete mechanism to verify this (e.g., checking build output for mnemonic-mcp compilation). The task could be clearer on what 'independently usable' means in a practical verification sense.",
+          "fix": "Clarify the standalone check: run `cargo test -p mnemonic-core` and verify the output does NOT contain 'Compiling mnemonic-mcp'. This makes the check concrete and distinguishable from the regular test run."
+        },
+        {
+          "severity": "minor",
+          "category": "feasibility",
+          "task": 16,
+          "issue": "The `grep -E \"codec/|lineage/\" .claude/skills/project-knowledge/references/architecture.md` check (step 7 in Verification Steps) is a path-dependent command. It uses a relative path that only works if the QA agent runs from the workspace root `/home/claude/.openclaw/workspace/mnemonic-refactored`. The task does not specify the working directory for bash commands. The current architecture.md also references 'attest/' (not 'codec/') and does not list lineage/ as a module — so this check will fail against the current pre-implementation state, which is expected. However, task 12 (documentation update) must complete before this check can pass.",
+          "fix": "No structural fix needed — dependency on task 12 is implicitly covered by depends_on: [13, 14, 15] → task 12 must be done before audits. Minor: add absolute path or a note that commands run from workspace root."
+        }
+      ]
+    }
+  },
+  "stats": {
+    "tasks_checked": 1,
+    "claims_verified": 31,
+    "issues_found": 4,
+    "critical": 0,
+    "major": 0,
+    "minor": 4
+  },
+  "status": "approved",
+  "summary": "1 approved, 0 need fixes. Task 16 is well-structured and comprehensive. All verification commands are real, all referenced paths exist or are expected to exist post-implementation, all acceptance criteria from both specs are covered in the Details section. Four minor findings: (1) grep on potentially missing directories may produce false-green results; (2) two tech-spec AC items (pricing.rs unchanged, parameterized SQL) are missing from the formal AC checklist; (3) standalone usability check is indistinguishable from the regular test run without a build-output check; (4) grep command uses relative path requiring workspace root CWD. No critical or major issues."
+}

--- a/work/mnemonic-core/logs/tasks/template-batch1-review-iter2.json
+++ b/work/mnemonic-core/logs/tasks/template-batch1-review-iter2.json
@@ -1,0 +1,72 @@
+{
+  "validator": "task-validator",
+  "batch": "1-iter2",
+  "iteration": 2,
+  "tasks": {
+    "1": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "content",
+          "section": "TDD Anchor",
+          "issue": "Fix verified as applied. TDD Anchor now contains 3 compile-level anchor entries in the format `path::identifier — description` (e.g., `mnemonic-refactored/Cargo.toml::workspace_members`). These are not standard Rust test function paths but are adapted for a scaffold task where the test gate is compilation. The format is a reasonable application of the anchor convention and the prior finding is resolved. Residual note: the entries reference file::pseudo-identifier paths rather than real test function names, which is inherent to a compilation-only task.",
+          "fix": "No further action required."
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "section": "Context Files",
+          "issue": "Fix verified as applied. All 13 'Files to create/modify' entries are now markdown links in the form `[name](absolute/path) — description`. Prior finding fully resolved.",
+          "fix": "No further action required."
+        }
+      ]
+    },
+    "4": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "content",
+          "section": "Context Files",
+          "issue": "Fix verified as applied. All 8 'Code files (to create/modify)' entries are now markdown links, including `mcp/src/mcp.rs` which was missing in iteration 1. Prior findings fully resolved.",
+          "fix": "No further action required."
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "section": "Context Files",
+          "issue": "code-research.md link verified — `work/mnemonic-core/code-research.md` exists. Prior finding resolved.",
+          "fix": "No further action required."
+        }
+      ]
+    },
+    "5": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "major",
+          "category": "carry-forward",
+          "section": "TDD Anchor",
+          "issue": "Fix verified as applied. TDD Anchor now enumerates 4 migrated tests by name (`test_compress_roundtrip`, `test_decompress_roundtrip`, `test_bit_width_4`, `test_bit_width_2`) plus 3 new tests, totaling 7. Each entry has path, test name, and a description of what it verifies. Consistent with Verification Steps claim of '4 migrated + 3 new = 7 total'. Prior major finding fully resolved.",
+          "fix": "No further action required."
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "section": "Context Files",
+          "issue": "Fix verified as applied. All context files are now markdown links including `mcp/src/mcp.rs`. Prior finding fully resolved.",
+          "fix": "No further action required."
+        },
+        {
+          "severity": "minor",
+          "category": "consistency",
+          "section": "Verification Steps",
+          "issue": "Fix verified as applied. Verification Steps Automated section now states '4 migrated + 3 new = 7 total' matching TDD Anchor enumeration of 7 entries. Prior inconsistency resolved.",
+          "fix": "No further action required."
+        }
+      ]
+    }
+  },
+  "summary": "3 approved, 0 need fixes. All iteration 1 findings confirmed resolved: Task 1 TDD Anchor reformatted with compile-level anchors and Context Files converted to markdown links; Task 4 mcp/src/mcp.rs added to Context Files and all code files converted to markdown links, code-research.md confirmed to exist; Task 5 4 migrated tests added to TDD Anchor with names and descriptions, Context Files converted to markdown links, test count made consistent at 7. No new issues found. All three tasks are clear for execution."
+}

--- a/work/mnemonic-core/logs/tasks/template-batch1-review-iter3.json
+++ b/work/mnemonic-core/logs/tasks/template-batch1-review-iter3.json
@@ -1,0 +1,60 @@
+{
+  "validator": "task-validator",
+  "batch": "1-iter3",
+  "iteration": 3,
+  "tasks": {
+    "7": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 7,
+          "section": "Verification Steps",
+          "issue": "NOT FIXED from iter-1/iter-2: `cargo build -p mnemonic-mcp` is absent from the Automated section. Acceptance Criteria explicitly checks this compilation step (step 13) and What to do step 9 requires it. Only `cargo test` and `cargo clippy` appear in Automated.",
+          "fix": "Add to Automated section: `cargo build -p mnemonic-mcp` — compiles successfully after import updates from local mod to mnemonic_core::arweave"
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 7,
+          "section": "Reviewers",
+          "issue": "NOT FIXED from iter-1/iter-2: Reviewer report paths use absolute filesystem paths (/home/claude/.openclaw/workspace/mnemonic-refactored/work/mnemonic-core/logs/working/task-7/...) instead of project-root-anchored paths. Absolute paths are machine-specific.",
+          "fix": "Replace with: work/mnemonic-core/logs/working/task-7/code-reviewer-1.json (and similarly for security-auditor-1.json and test-reviewer-1.json)"
+        }
+      ],
+      "focused_checks_verified": [
+        "upload_url field approach: ArweaveClient gains `upload_url: String` field set to 'https://uploader.irys.xyz/upload' in new(), used by write_irys(). new_for_test sets upload_url to '{base_url}/upload'. Correct — no force_irys field.",
+        "Write tests mock POST /upload: TDD Anchor (test_write_success, test_write_bytes_success, test_malformed_json_response) and What to do step 5 all specify POST /upload. 'POST /tx is only arlocal path' explicitly noted. Correct.",
+        "GET /info for health_check: TDD Anchor line documents 'mock serves GET /info -> 200', Details health_check section shows when.method(GET).path(\"/info\"). Correct.",
+        "GET /{tx_id} for read: TDD Anchor documents 'GET /{tx_id} from mock (actual path: no /tx/ prefix, no /data suffix)', Details read() section shows path(format!(\"/{}\", tx_id)). Correct.",
+        "POST /upload for write: all three write-path tests (write, write_bytes, malformed) use POST /upload via new_for_test. Correct.",
+        "No hardcoded mainnet URLs in test code: AC and Security constraints section both require Keypair::new() and ban irys.xyz in cfg(test) blocks. Correct."
+      ]
+    },
+    "14": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 14,
+          "section": "Reviewers",
+          "issue": "Reviewers section prose still says 'No reviewers for Audit Wave tasks (wave 12).' The label 'Audit Wave' was the old non-numeric wave name — the partial fix adds '(wave 12)' but leaves the stale label. Minor inconsistency; wave number is now correct.",
+          "fix": "Change to: 'No downstream reviewers — this is the security audit task itself.' This removes the stale 'Audit Wave' reference entirely."
+        }
+      ],
+      "focused_checks_verified": [
+        "Required Skills path: Line 15 is `[SKILL.md](~/.claude/skills/security-auditor/SKILL.md)` — tilde-anchored home directory path, NOT the workspace-local path. Critical finding from iter-2 is FIXED.",
+        "wave=12: frontmatter line 4 shows `wave: 12` — numeric integer, correct.",
+        "reviewers: [] in frontmatter: correct for audit task. Consistent with Reviewers section body.",
+        "skills: [security-auditor]: correct array format.",
+        "No TDD Anchor section: correct for analysis-only non-code task.",
+        "All mandatory context files present with markdown links: user-spec.md, tech-spec.md, decisions.md, project.md, architecture.md, patterns.md all present.",
+        "Verification Steps present with concrete grep commands and expected outputs.",
+        "Post-completion checklist present."
+      ]
+    }
+  },
+  "summary": "2 approved, 0 need fixes. Task 7: focused checks all pass — upload_url field approach (not force_irys) is correctly specified throughout the task; all three mock paths correct (GET /info, GET /{tx_id}, POST /upload); write tests mock POST /upload not POST /tx. Two minor carry-forward findings remain (reviewer absolute paths, missing cargo build in Automated) but no critical or major issues. Task 14: critical finding from iter-2 is confirmed fixed — Required Skills now points to ~/.claude/skills/security-auditor/SKILL.md (tilde path); wave=12 is correct. One residual minor finding: Reviewers section prose still references 'Audit Wave' label. Both tasks are clear for execution."
+}

--- a/work/mnemonic-core/logs/tasks/template-batch1-review.json
+++ b/work/mnemonic-core/logs/tasks/template-batch1-review.json
@@ -1,0 +1,162 @@
+{
+  "validator": "task-validator",
+  "batch": [1, 2, 3, 4, 5],
+  "batch_number": 1,
+  "iteration": 1,
+  "status": "changes_required",
+  "findings": [
+    {
+      "severity": "minor",
+      "category": "content",
+      "task": 1,
+      "section": "TDD Anchor",
+      "issue": "TDD Anchor entries are not in the required format `tests/path::test_name — description`. Instead, the section contains build/smoke commands (cargo build, cargo test) and prose explaining why unit tests don't apply. The section must either be deleted (non-code task) or contain properly formatted test anchor entries. Task 1 does produce code (Cargo.toml files, lib.rs stubs), so deletion is not appropriate, but the current content does not match the required format.",
+      "fix": "Replace the current prose with properly formatted entries. For a scaffold task where the primary test gate is compilation, use entries like: `cargo build -p mnemonic-core` — empty-stub library crate compiles without errors. Alternatively, if no Rust test functions are written, note explicitly in the section that compile verification replaces unit tests and provide one entry per build command in the standard anchor format."
+    },
+    {
+      "severity": "minor",
+      "category": "content",
+      "task": 1,
+      "section": "Context Files",
+      "issue": "The 'Files to create/modify (workspace target)' subsection lists 13 file paths as plain text (not markdown links). The checklist rule requires all context files to be markdown links with both name and path: `[name](path)`. Plain text paths like `mnemonic-refactored/Cargo.toml — new workspace root` do not satisfy this requirement.",
+      "fix": "Convert all plain text file paths in 'Files to create/modify' to markdown links. Example: `[Cargo.toml](../../../Cargo.toml) — new workspace root`. Use relative paths anchored to the task file location or absolute paths."
+    },
+    {
+      "severity": "minor",
+      "category": "content",
+      "task": 2,
+      "section": "Context Files",
+      "issue": "Lines 96-104 list source code files (mcp/src/codec/mod.rs, mcp/src/codec/schema.rs, mcp/src/codec/canonical.rs, mcp/src/codec/hash.rs, mcp/src/codec/sign.rs, mcp/src/tools.rs, mcp/src/mcp.rs, core/src/lib.rs, core/Cargo.toml) as backtick-quoted inline code with descriptions but without markdown link format. These are context files relevant to the task and should be formatted as `[name](path)` links.",
+      "fix": "Convert inline code file references to markdown links. Example: `[mcp/src/codec/mod.rs](/home/claude/.openclaw/workspace/mnemonic-protocol/mcp/src/codec/mod.rs) — current source: declares pub mod schema; pub mod canonical; pub mod hash; pub mod sign;`"
+    },
+    {
+      "severity": "minor",
+      "category": "content",
+      "task": 4,
+      "section": "Context Files",
+      "issue": "The 'Code files (to create/modify)' subsection on lines 108-114 lists 7 files as plain text paths without markdown link format: core/src/embed/mod.rs, core/src/lib.rs, core/Cargo.toml, mcp/src/main.rs, mcp/src/tools.rs, mcp/src/embed.rs, mcp/src/db.rs. Required format is markdown links.",
+      "fix": "Convert to markdown links. Example: `[mcp/src/embed.rs](/home/claude/.openclaw/workspace/mnemonic-protocol/mcp/src/embed.rs) — source to migrate (will be deleted after move)`"
+    },
+    {
+      "severity": "minor",
+      "category": "content",
+      "task": 4,
+      "section": "Context Files",
+      "issue": "code-research.md is referenced as `[code-research.md](../code-research.md)` but this file may not exist in the feature directory. Context file links should only reference files that exist. If code-research.md was produced during discovery, its presence should be verified.",
+      "fix": "Verify that `work/mnemonic-core/code-research.md` exists. If it does not exist, remove the link or replace it with the actual research notes location."
+    },
+    {
+      "severity": "major",
+      "category": "carry-forward",
+      "task": 5,
+      "section": "TDD Anchor",
+      "issue": "The tech-spec Testing Strategy states: 'compress module (existing 4 tests): move, update turboquant imports, add numerical fidelity test comparing compress→decompress roundtrip MSE stays below threshold after namespace change.' The task's TDD Anchor lists only 3 new tests (fidelity roundtrip, empty embedding, single-element) but does NOT list the 4 existing tests that must be moved from mcp/src/compress.rs. The body text says 'The 4 tests already in mcp/src/compress.rs must move and continue to pass — do not rewrite them' but they are absent from the TDD Anchor. Tests that must pass are missing from the anchor.",
+      "fix": "Add the 4 existing compress tests from mcp/src/compress.rs as TDD Anchor entries. Read the actual test function names from the source file and add them in the format: `core/src/compress/mod.rs::tests::{test_name}` — description of what the test verifies. The TDD Anchor must enumerate all tests expected to pass, not just new ones."
+    },
+    {
+      "severity": "minor",
+      "category": "content",
+      "task": 5,
+      "section": "Context Files",
+      "issue": "Lines 80-85 list 5 context files (mcp/src/compress.rs, core/src/lib.rs, core/Cargo.toml, mcp/src/main.rs, mcp/src/tools.rs) as plain text with backtick-quoted paths instead of markdown links. Required format is `[name](path)`.",
+      "fix": "Convert to markdown links. Example: `[mcp/src/compress.rs](/home/claude/.openclaw/workspace/mnemonic-protocol/mcp/src/compress.rs) — current EmbeddingCompressor implementation (source to migrate)`"
+    },
+    {
+      "severity": "minor",
+      "category": "consistency",
+      "task": 5,
+      "section": "Verification Steps",
+      "issue": "The Automated section claims '4 migrated + 3 new = 7 total' tests. However, the TDD Anchor only lists 3 tests (the new ones). The count of 4 migrated tests is asserted but those tests are not enumerated anywhere in the task document — they are only referenced by implication. This creates inconsistency between the verification claim and the actual anchor.",
+      "fix": "Either add the 4 migrated test names to the TDD Anchor (preferred), or correct the verification step to say '3 new tests (existing tests verified by running cargo test -p mnemonic-mcp first)'. The test count must be verifiable from the task document."
+    }
+  ],
+  "decomposition_findings": [
+    {
+      "severity": "none",
+      "category": "decomposition",
+      "note": "Dependency chain 1→2→3→4→5 is correct: no cycles, wave numbers strictly increase with dependencies. Task count (5 of 16 total for this feature) is proportional to feature scale (L). File scope per task is 4-8 files with related changes. No merge or split candidates identified in tasks 1-5."
+    }
+  ],
+  "stats": {
+    "tasks_checked": 5,
+    "critical_findings": 0,
+    "major_findings": 1,
+    "minor_findings": 7,
+    "issues_found": 8
+  },
+  "tasks": {
+    "1": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "section": "TDD Anchor",
+          "issue": "TDD Anchor entries use smoke/build command format rather than `tests/path::test_name — description` format. The section contains prose and build commands instead of formatted test anchors.",
+          "fix": "Reformat entries to use the standard anchor format, or add a clear note that compilation is the test gate and provide one entry per build command in the required format."
+        },
+        {
+          "severity": "minor",
+          "section": "Context Files",
+          "issue": "13 'Files to create/modify' listed as plain text without markdown link format.",
+          "fix": "Convert all file paths in the 'Files to create/modify' subsection to markdown links [name](path)."
+        }
+      ]
+    },
+    "2": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "section": "Context Files",
+          "issue": "9 source code files in the context section (lines 96-104) listed as backtick inline code without markdown link format.",
+          "fix": "Convert to markdown links [name](path)."
+        }
+      ]
+    },
+    "3": {
+      "status": "approved",
+      "findings": []
+    },
+    "4": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "section": "Context Files",
+          "issue": "7 'Code files (to create/modify)' listed as plain text without markdown link format.",
+          "fix": "Convert to markdown links [name](path)."
+        },
+        {
+          "severity": "minor",
+          "section": "Context Files",
+          "issue": "Link to code-research.md may reference a non-existent file.",
+          "fix": "Verify work/mnemonic-core/code-research.md exists; remove or correct the link if not."
+        }
+      ]
+    },
+    "5": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "major",
+          "section": "TDD Anchor",
+          "issue": "4 existing compress tests from mcp/src/compress.rs are not listed in TDD Anchor. Tech-spec requires them to be moved and pass. They are mentioned in body text but absent from the anchor, making them unverifiable from the task document.",
+          "fix": "Read test function names from mcp/src/compress.rs and add them as TDD anchor entries in format: `core/src/compress/mod.rs::tests::{name}` — what the test verifies."
+        },
+        {
+          "severity": "minor",
+          "section": "Context Files",
+          "issue": "5 context files listed as plain text without markdown link format.",
+          "fix": "Convert to markdown links [name](path)."
+        },
+        {
+          "severity": "minor",
+          "section": "Verification Steps",
+          "issue": "Claims '4 migrated + 3 new = 7 total' but TDD Anchor only enumerates 3 tests. Count is inconsistent with anchor.",
+          "fix": "Either add the 4 migrated test names to TDD Anchor, or correct the count to match what is actually enumerated."
+        }
+      ]
+    }
+  },
+  "summary": "4 approved (tasks 1-4 with minor findings only), 1 needs fix (task 5 has a major carry-forward issue: 4 existing compress tests missing from TDD Anchor). All 5 tasks have correct frontmatter, section structure, section order, dependency chain, and wave assignments. No critical findings. The recurring minor issue across tasks 1, 2, 4, 5 is that source code files in the Context Files section are listed as plain text rather than markdown links."
+}

--- a/work/mnemonic-core/logs/tasks/template-batch2-review-iter2.json
+++ b/work/mnemonic-core/logs/tasks/template-batch2-review-iter2.json
@@ -1,0 +1,110 @@
+{
+  "validator": "task-validator",
+  "batch": "2-iter2",
+  "iteration": 2,
+  "tasks": {
+    "6": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 6,
+          "section": "Required Skills",
+          "issue": "Skill path still uses absolute path /home/claude/.claude/skills/code-writing/SKILL.md — NOT FIXED from iter-1. Template requires tilde-relative path.",
+          "fix": "Change to: `/skill:code-writing` — [SKILL.md](~/.claude/skills/code-writing/SKILL.md)"
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 6,
+          "section": "Reviewers",
+          "issue": "Reviewer report paths still use absolute filesystem paths (/home/claude/.openclaw/...) — NOT FIXED from iter-1. Template specifies project-root-anchored paths.",
+          "fix": "Replace with: work/mnemonic-core/logs/working/task-6/code-reviewer-1.json (and similarly for security-auditor and test-reviewer)"
+        }
+      ],
+      "fixes_verified": [
+        "get_balance added to payment-methods grep in Description and Acceptance Criteria",
+        "mcp/src/mcp.rs added to Code files to modify in Context Files",
+        "Lineage types timing note (Options A/B + TODO comment) added to Details"
+      ]
+    },
+    "7": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 7,
+          "section": "Verification Steps",
+          "issue": "cargo build -p mnemonic-mcp still absent from Automated section — NOT FIXED from iter-1. AC explicitly checks this compilation and What to do step 9 mentions it.",
+          "fix": "Add to Automated: `cargo build -p mnemonic-mcp` — compiles successfully after import updates"
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 7,
+          "section": "Reviewers",
+          "issue": "Reviewer report paths still use absolute filesystem paths — NOT FIXED from iter-1.",
+          "fix": "Replace with: work/mnemonic-core/logs/working/task-7/code-reviewer-1.json (and similarly for security-auditor and test-reviewer)"
+        }
+      ],
+      "fixes_verified": [
+        "health_check mock correctly described as GET /info (not GET /)",
+        "read() mock correctly described as GET /{tx_id} with no /tx/ prefix or /data suffix",
+        "is_local() bypass handled via new_for_test constructor with force_irys field — present in What to do step 4, TDD Anchor, and Details"
+      ]
+    },
+    "8": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 8,
+          "section": "Reviewers",
+          "issue": "Reviewer report paths still use absolute filesystem paths — NOT FIXED from iter-1.",
+          "fix": "Replace with: work/mnemonic-core/logs/working/task-8/code-reviewer-1.json (and similarly for security-auditor and test-reviewer)"
+        }
+      ],
+      "fixes_verified": [
+        "TDD Anchor now lists exactly 8 tests matching the Acceptance Criteria count: test_write_memo_success, test_read_memo_success, test_read_memo_not_found, test_airdrop_success, test_get_tx_signers, test_confirm_tx_retry_exhaustion, test_health_check_ok, test_rpc_error_handling",
+        "Retry loop tokio time pause hint present in Details: #[tokio::test(flavor = \"current_thread\", start_paused = true)] with tokio::time::pause() explanation"
+      ]
+    },
+    "9": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 9,
+          "section": "Verification Steps",
+          "issue": "cargo clippy -p mnemonic-core -- -D warnings still only appears in Smoke section, not in Automated — NOT FIXED from iter-1. Clippy is static analysis requiring no deployment and belongs in Automated.",
+          "fix": "Add `cargo clippy -p mnemonic-core -- -D warnings` — zero warnings to the Automated section (alongside the existing cargo test and cargo build lines)"
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 9,
+          "section": "Reviewers",
+          "issue": "Reviewer report paths still use absolute filesystem paths — NOT FIXED from iter-1.",
+          "fix": "Replace with: work/mnemonic-core/logs/working/task-9/code-reviewer-1.json (and similarly for security-auditor and test-reviewer)"
+        }
+      ],
+      "fixes_verified": [
+        "Target file correctly references mcp/src/main.rs (not tools.rs) for mod lineage update in What to do step 6 and Details",
+        "Direction enum correctly defined with 3 variants: Ancestors, Descendants, Both (matching TDD Anchor test_traverse_direction_enum and Acceptance Criteria)",
+        "rusqlite version correctly set to 0.34 in Details Cargo.toml block"
+      ]
+    }
+  },
+  "summary": "0 approved, 4 need fixes. All findings are minor — no critical or major issues. The new content fixes requested in iter-2 briefing were all applied correctly (get_balance, mcp.rs context, lineage timing note, health_check path, read path, is_local bypass, 8-test count, tokio pause hint, main.rs target, Direction 3 variants, rusqlite 0.34). However, the four minor findings from iter-1 were not addressed: reviewer paths remain as absolute /home/claude/... paths in all four tasks, Required Skills path in task 6 remains absolute, cargo build missing from task 7 Automated, and cargo clippy remains in Smoke only in task 9.",
+  "stats": {
+    "tasks_checked": 4,
+    "issues_found": 7,
+    "critical": 0,
+    "major": 0,
+    "minor": 7
+  }
+}

--- a/work/mnemonic-core/logs/tasks/template-batch2-review.json
+++ b/work/mnemonic-core/logs/tasks/template-batch2-review.json
@@ -1,0 +1,130 @@
+{
+  "validator": "task-validator",
+  "batch": 2,
+  "iteration": 1,
+  "tasks_checked": [6, 7, 8, 9, 10],
+  "tasks": {
+    "6": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 6,
+          "section": "Reviewers",
+          "issue": "Reviewer report paths use absolute filesystem paths (/home/claude/.openclaw/...) instead of project-root-anchored paths. Template specifies: work/{feature}/logs/working/task-{N}/{reviewer}-{round}.json",
+          "fix": "Replace absolute paths with: work/mnemonic-core/logs/working/task-6/code-reviewer-1.json (and similarly for other reviewers)"
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 6,
+          "section": "Required Skills",
+          "issue": "Skill path uses absolute path /home/claude/.claude/skills/code-writing/SKILL.md instead of tilde-relative ~/.claude/skills/code-writing/SKILL.md as used in the template",
+          "fix": "Change to: /skill:code-writing — [SKILL.md](~/.claude/skills/code-writing/SKILL.md)"
+        }
+      ]
+    },
+    "7": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 7,
+          "section": "Verification Steps",
+          "issue": "Automated section omits cargo build -p mnemonic-mcp. The AC explicitly checks this and What to do step 8 mentions it, but it is absent from Verification Steps Automated, making it harder for the executing agent to know to run it during implementation.",
+          "fix": "Add to Automated: cargo build -p mnemonic-mcp — compiles successfully after import updates"
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 7,
+          "section": "Reviewers",
+          "issue": "Reviewer report paths use absolute filesystem paths instead of project-root-anchored paths",
+          "fix": "Replace absolute paths with: work/mnemonic-core/logs/working/task-7/{reviewer}-1.json"
+        }
+      ]
+    },
+    "8": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 8,
+          "section": "Reviewers",
+          "issue": "Reviewer report paths use absolute filesystem paths instead of project-root-anchored paths",
+          "fix": "Replace absolute paths with: work/mnemonic-core/logs/working/task-8/{reviewer}-1.json"
+        }
+      ]
+    },
+    "9": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 9,
+          "section": "Verification Steps",
+          "issue": "cargo clippy -p mnemonic-core -- -D warnings is placed in Smoke rather than Automated. Clippy is a static analysis tool run locally without any deployment and belongs in Automated alongside cargo test.",
+          "fix": "Move cargo clippy command to Automated section"
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 9,
+          "section": "Reviewers",
+          "issue": "Reviewer report paths use absolute filesystem paths instead of project-root-anchored paths",
+          "fix": "Replace absolute paths with: work/mnemonic-core/logs/working/task-9/{reviewer}-1.json"
+        }
+      ]
+    },
+    "10": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 10,
+          "section": "TDD Anchor",
+          "issue": "TDD Anchor entries describe files rather than individual test cases. Format should be `tests/path::test_name — description`. The entries use file paths like core/tests/integration_cbor.rs with a high-level description instead of per-test anchors (e.g., core/tests/integration_cbor.rs::test_schema_encode_decode — schema encoding round-trips correctly).",
+          "fix": "Replace file-level entries with individual test anchors in the format `core/tests/integration_cbor.rs::test_name — what it verifies` for each of the 5 known CBOR tests and the 1 proptest"
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 10,
+          "section": "Context Files",
+          "issue": "Source files to read (mcp/tests/integration_cbor.rs, mcp/tests/proptest_canonical.rs, mcp/benches/decompress.rs, mcp/benches/cbor_codec.rs, core/Cargo.toml, core/src/lib.rs) are listed as plain text with backticks rather than as markdown links [name](path)",
+          "fix": "Convert each to markdown link format: [integration_cbor.rs](../../mcp/tests/integration_cbor.rs) etc."
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 10,
+          "section": "Reviewers",
+          "issue": "Reviewer report paths use absolute filesystem paths instead of project-root-anchored paths",
+          "fix": "Replace absolute paths with: work/mnemonic-core/logs/working/task-10/{reviewer}-1.json"
+        }
+      ]
+    }
+  },
+  "cross_task": {
+    "dependency_chain": "valid — 5→6→7→8→9→10, wave numbers match dependency order, no cycles",
+    "wave_consistency": "valid — each task wave equals task number; depends_on references task with wave = current_wave - 1",
+    "shared_resources": "not applicable — tech-spec explicitly states Shared Resources: None",
+    "merge_candidates": "none — each task is a single-module extraction with cohesive file changes",
+    "split_candidates": "none — multi-file changes in tasks 6-9 are all required for a single extraction outcome",
+    "over_decomposition": "not applicable — 5 tasks covering 5 distinct module extractions is proportional to feature size (L)"
+  },
+  "status": "approved",
+  "summary": "5 approved, 0 need fixes. All tasks pass critical and major checks. 8 minor findings across all 5 tasks, all in two categories: (1) reviewer paths using absolute filesystem paths rather than project-root-relative paths (affects all 5 tasks), and (2) task-specific content gaps (TDD Anchor format in task 10, missing build step in task 7 Verification Steps, clippy placement in task 9, context file link format in task 10). No section omissions, no AC/TDD carry-forward losses, no frontmatter errors, no dependency violations.",
+  "stats": {
+    "tasks_checked": 5,
+    "issues_found": 8,
+    "critical": 0,
+    "major": 0,
+    "minor": 8
+  }
+}

--- a/work/mnemonic-core/logs/tasks/template-batch3-review-iter2.json
+++ b/work/mnemonic-core/logs/tasks/template-batch3-review-iter2.json
@@ -1,0 +1,70 @@
+{
+  "validator": "task-validator",
+  "batch": "3-iter2",
+  "iteration": 2,
+  "tasks": {
+    "12": {
+      "status": "approved",
+      "findings": []
+    },
+    "13": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 13,
+          "section": "Context Files",
+          "issue": "Audit scope files listed as backtick code spans (`core/src/**/*.rs`, `mcp/src/**/*.rs`, `Cargo.toml`, `core/Cargo.toml`, `mcp/Cargo.toml`) rather than markdown links. Checklist requires all context files as `[name](path)` links.",
+          "fix": "Convert to markdown links where a specific file is referenced. For glob patterns that cannot be linked, add a brief explanatory note — e.g. `All .rs files under core/src/` — and list any specific anchor files (e.g. `core/src/lib.rs`) as proper links."
+        }
+      ]
+    },
+    "14": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "critical",
+          "category": "structure",
+          "task": 14,
+          "section": "Required Skills",
+          "issue": "Skill path points to workspace-local `.claude/skills/security-auditor/SKILL.md` (line 15: `/home/claude/.openclaw/workspace/mnemonic-refactored/.claude/skills/security-auditor/SKILL.md`), which does not exist. The `security-auditor` skill lives at `~/.claude/skills/security-auditor/SKILL.md` (global skills directory). The implementing agent will fail to load the skill.",
+          "fix": "Change the SKILL.md link to `~/.claude/skills/security-auditor/SKILL.md` (or its absolute equivalent `/home/claude/.claude/skills/security-auditor/SKILL.md`)."
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 14,
+          "section": "Reviewers",
+          "issue": "Reviewers section still contains stale text: 'No reviewers for Audit Wave tasks.' The wave name was changed from 'Audit Wave' to numeric 12, so this prose reference is now inconsistent.",
+          "fix": "Change to: 'No reviewers — this IS the audit task. The security-auditor agent is the executor.' or simply 'No downstream reviewers for this audit task.'"
+        }
+      ]
+    },
+    "15": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 15,
+          "section": "Reviewers",
+          "issue": "Reviewers section still says 'No reviewers for Audit Wave tasks.' The wave label was updated to numeric 12 but this prose reference to 'Audit Wave' was not cleaned up.",
+          "fix": "Change to: 'No downstream reviewers for this audit task.' or equivalent prose not referencing 'Audit Wave'."
+        }
+      ]
+    },
+    "16": {
+      "status": "approved",
+      "findings": []
+    }
+  },
+  "summary": "3 approved (12, 15, 16), 1 needs fix (14), 1 approved with minor findings (13). Task 14 has a critical broken skill path: Required Skills links to a non-existent workspace-local path for security-auditor SKILL.md. All wave numeric fixes (13→12, 14→12, 15→12, 16→13) were correctly applied. Task 12 documentation-writing skill path and reviewer path are correct.",
+  "stats": {
+    "tasks_checked": 5,
+    "issues_found": 4,
+    "critical": 1,
+    "major": 0,
+    "minor": 3
+  }
+}

--- a/work/mnemonic-core/logs/tasks/template-batch3-review.json
+++ b/work/mnemonic-core/logs/tasks/template-batch3-review.json
@@ -1,0 +1,140 @@
+{
+  "validator": "task-validator",
+  "batch": 3,
+  "iteration": 1,
+  "tasks_checked": [11, 12, 13, 14, 15],
+  "tasks": {
+    "11": {
+      "status": "approved",
+      "findings": [
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 11,
+          "section": "TDD Anchor",
+          "issue": "TDD Anchor entries use cargo CLI commands (`cargo build -p mnemonic-mcp`, `cargo test --workspace`) instead of the required format `tests/path::test_name — description`. The section heading is present for a code task but contains no test path entries.",
+          "fix": "Either remove the TDD Anchor section (since this task introduces no new test logic — it is an import cleanup pass) and add a note that the compile+test chain serves as the anchor, OR keep only entries that map to actual test functions in the codebase. For a pure rewiring task with no new tests, deletion is cleaner."
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 11,
+          "section": "Reviewers",
+          "issue": "Reviewer paths use absolute filesystem paths (`/home/claude/.openclaw/workspace/mnemonic-refactored/work/mnemonic-core/logs/working/task-11/...`) rather than feature-path-anchored relative paths (`work/mnemonic-core/logs/working/task-11/...`). Absolute paths are machine-specific and will break in other environments.",
+          "fix": "Replace absolute paths with paths anchored to feature_path: `work/mnemonic-core/logs/working/task-11/code-reviewer-1.json`, etc."
+        }
+      ]
+    },
+    "12": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "critical",
+          "category": "content",
+          "task": 12,
+          "section": "Required Skills",
+          "issue": "The `documentation-writing` skill is listed in frontmatter `skills` but the Required Skills section links to the wrong SKILL.md. The path used is `/home/claude/.openclaw/workspace/mnemonic-refactored/.claude/skills/project-knowledge/SKILL.md` (project-knowledge skill), not the documentation-writing skill at `~/.claude/skills/documentation-writing/SKILL.md`.",
+          "fix": "Replace the SKILL.md link with: `/skill:documentation-writing` — [SKILL.md](/home/claude/.claude/skills/documentation-writing/SKILL.md)"
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 12,
+          "section": "Reviewers",
+          "issue": "Reviewer path uses absolute filesystem path (`/home/claude/.openclaw/workspace/mnemonic-refactored/work/mnemonic-core/logs/working/task-12/code-reviewer-1.json`) rather than feature-path-anchored path.",
+          "fix": "Use `work/mnemonic-core/logs/working/task-12/code-reviewer-1.json`."
+        }
+      ]
+    },
+    "13": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "critical",
+          "category": "frontmatter",
+          "task": 13,
+          "section": "Frontmatter",
+          "issue": "`wave` field value is the string `\"Audit Wave\"` instead of a number ≥ 1. The template requires `wave` to be a YAML integer.",
+          "fix": "Assign a numeric wave value. Since tasks 13/14/15 depend on tasks 11 and 12 (wave 11), the audit wave should be `wave: 13` (or another number greater than 11). Coordinate with tasks 14 and 15 to use the same number."
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 13,
+          "section": "Required Skills",
+          "issue": "Skill SKILL.md path uses a hardcoded absolute path (`/home/claude/.claude/skills/code-reviewing/SKILL.md`). While the path appears correct, absolute paths are environment-specific.",
+          "fix": "Use tilde-anchored path: `~/.claude/skills/code-reviewing/SKILL.md`."
+        }
+      ]
+    },
+    "14": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "critical",
+          "category": "frontmatter",
+          "task": 14,
+          "section": "Frontmatter",
+          "issue": "`wave` field value is the string `\"Audit Wave\"` instead of a number ≥ 1. The template requires `wave` to be a YAML integer.",
+          "fix": "Assign a numeric wave value consistent with tasks 13 and 15 (e.g., `wave: 13` if that is the audit wave number chosen)."
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 14,
+          "section": "Required Skills",
+          "issue": "Skill SKILL.md path uses absolute path. Not portable across environments.",
+          "fix": "Use tilde-anchored path: `~/.claude/skills/security-auditor/SKILL.md`."
+        }
+      ]
+    },
+    "15": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "critical",
+          "category": "frontmatter",
+          "task": 15,
+          "section": "Frontmatter",
+          "issue": "`wave` field value is the string `\"Audit Wave\"` instead of a number ≥ 1. The template requires `wave` to be a YAML integer.",
+          "fix": "Assign a numeric wave value consistent with tasks 13 and 14 (e.g., `wave: 13`)."
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 15,
+          "section": "Required Skills",
+          "issue": "Skill SKILL.md path uses absolute path. Not portable across environments.",
+          "fix": "Use tilde-anchored path: `~/.claude/skills/test-master/SKILL.md`."
+        }
+      ]
+    }
+  },
+  "cross_task_findings": [
+    {
+      "severity": "major",
+      "category": "decomposition",
+      "tasks": [13, 14, 15],
+      "issue": "All three audit tasks (13, 14, 15) declare `depends_on: [11, 12]` and use `wave: \"Audit Wave\"` — meaning they are intended to run in the same wave. Since they each read different file scopes and produce no code changes, running them in parallel is correct. However, the non-numeric wave value prevents automated wave scheduling. After fixing to a numeric wave value, ensure all three use the same number to preserve the intended parallelism.",
+      "fix": "Set `wave: 13` on tasks 13, 14, and 15. Confirm task 16 (Pre-deploy QA) has `wave: 14` (currently `wave: \"Final Wave\"` — also needs fixing, though outside this batch)."
+    },
+    {
+      "severity": "minor",
+      "category": "decomposition",
+      "tasks": [11, 12],
+      "issue": "Tasks 11 and 12 both have `wave: 11` and `depends_on: [10]`, which is correct for parallel execution. The Details section of task 12 notes that task 11 runs in the same wave but touches different files, which is valid. No merge or split recommendation needed.",
+      "fix": "No action required."
+    }
+  ],
+  "status": "changes_required",
+  "stats": {
+    "tasks_checked": 5,
+    "approved": 1,
+    "needs_fix": 4,
+    "issues_found": 10,
+    "critical": 4,
+    "major": 1,
+    "minor": 5
+  },
+  "summary": "1 approved (task 11), 4 need fixes (tasks 12, 13, 14, 15). Critical issues: wrong SKILL.md link in task 12 Required Skills; non-numeric `wave` field in tasks 13, 14, 15. Minor issues: TDD Anchor format in task 11; absolute reviewer paths in tasks 11-12; absolute SKILL.md paths in tasks 13-15."
+}

--- a/work/mnemonic-core/logs/tasks/template-batch4-review.json
+++ b/work/mnemonic-core/logs/tasks/template-batch4-review.json
@@ -1,0 +1,61 @@
+{
+  "validator": "task-validator",
+  "batch": 4,
+  "iteration": 1,
+  "tasks": {
+    "16": {
+      "status": "needs_fix",
+      "findings": [
+        {
+          "severity": "critical",
+          "category": "frontmatter",
+          "task": 16,
+          "section": "Frontmatter",
+          "issue": "wave field is a string 'Final Wave' instead of a number >= 1. The template specifies wave must be a numeric value (e.g., wave: 4). String wave values cannot be used for dependency ordering or parallel execution scheduling.",
+          "fix": "Replace 'wave: Final Wave' with a numeric value. Based on the task sequence (Audit Wave tasks 13-15 are the preceding wave, which also use string values — see cross-task note), assign wave: 4 or higher. Recommend wave: 4 if Audit Wave tasks are wave: 3, and tasks 11-12 are wave: 2, etc. Verify consistent numeric wave assignment across all tasks."
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 16,
+          "section": "Context Files",
+          "issue": "Code files in Context Files section are listed as plain text strings (e.g., 'core/src/**/*.rs') rather than markdown links. Template requires all files as markdown links '[name](path)'.",
+          "fix": "Convert plain text file references to markdown links where possible. For glob patterns, either link to the directory (e.g., [core/src/](../../../core/src/)) or acknowledge that glob patterns cannot be linked and list representative concrete files as links instead."
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 16,
+          "section": "Details",
+          "issue": "Details section does not use the canonical subsection structure from the template: Files, Dependencies, Edge cases, Implementation hints. The section has custom subsections instead ('What this task verifies', 'Verification scope', 'User-spec acceptance criteria', etc.). While the content is substantive, the 'Dependencies' subsection label is missing entirely.",
+          "fix": "Add a labeled '**Dependencies:**' subsection listing task dependencies (tasks 13, 14, 15) and any external tools required (cargo, grep). Keep existing content. Edge cases subsection is present and well-written — no change needed there."
+        },
+        {
+          "severity": "minor",
+          "category": "content",
+          "task": 16,
+          "section": "Post-completion",
+          "issue": "Post-completion checklist is missing the standard template item: '- [ ] If deviated from spec — describe deviation and reason'. Only decisions.md entry, not_verifiable deferral, and spec update items are present.",
+          "fix": "Add '- [ ] If any deviations from spec were found during QA — describe deviation and reason in decisions.md entry'."
+        },
+        {
+          "severity": "minor",
+          "category": "decomposition",
+          "task": 16,
+          "section": "Frontmatter",
+          "issue": "Cross-task note: tasks 13, 14, 15 also use string wave values ('Audit Wave') instead of numeric values. The dependency chain between task 16 (wave: 'Final Wave') and tasks 13-15 (wave: 'Audit Wave') cannot be numerically validated. The conceptual ordering is correct but the numeric constraint (wave of dependent > wave of dependency) is unverifiable with string values.",
+          "fix": "When fixing wave: 'Final Wave' in task 16, also fix tasks 13-15 to use numeric wave values. Suggested: tasks 1-11 use waves 1-11 as defined in tech-spec; tasks 12 shares wave 11; tasks 13-15 use wave 12 (Audit Wave); task 16 uses wave 13 (Final Wave)."
+        }
+      ]
+    }
+  },
+  "stats": {
+    "tasks_checked": 1,
+    "issues_found": 5,
+    "critical": 1,
+    "major": 0,
+    "minor": 4
+  },
+  "status": "changes_required",
+  "summary": "0 approved, 1 needs fix. 1 critical issue: wave field is a string ('Final Wave') instead of a required numeric value >= 1. 4 minor issues: glob patterns in Context Files not formatted as markdown links, Details section missing labeled Dependencies subsection, Post-completion missing deviation item, cross-task wave string issue in tasks 13-15."
+}

--- a/work/mnemonic-core/logs/userspec/adequacy-review.json
+++ b/work/mnemonic-core/logs/userspec/adequacy-review.json
@@ -1,0 +1,70 @@
+{
+  "status": "changes_required",
+  "findings": [
+    {
+      "category": "feasibility",
+      "severity": "critical",
+      "issue": "Crate name mismatch: user-spec says `turboquant-plus-rs = \"0.1.0\"` but the current git dependency resolves to crate name `turboquant` (Cargo.toml package name is `turboquant`, repo is `sivo4kin/turboquant-rs`). `turboquant-plus-rs` on crates.io is a different crate with potentially different API surface.",
+      "why_matters": "Switching from `turboquant` (git) to `turboquant-plus-rs` (crates.io) is not a simple dep source change -- it is a different crate entirely. The compress.rs code imports `turboquant::CompressedVectors` and other types. If `turboquant-plus-rs` has different type names, struct fields, or function signatures, the first migration step fails and cascades through the entire plan. Both crates exist on crates.io (`turboquant = \"0.1.1\"`, `turboquant-plus-rs = \"0.1.0\"`, `turboquant-rs = \"0.4.1\"`), so the spec must clarify exactly which one replaces the git dep and confirm API compatibility.",
+      "fix": "Verify which crates.io package is the correct replacement: (a) compare the API of `turboquant-plus-rs 0.1.0` against the current git checkout's API surface (especially `CompressedVectors`, quantize/dequantize functions, `ndarray` version); (b) update the spec with the correct crate name; (c) if `turboquant-plus-rs` is genuinely correct, add a risk note that the API may differ from the git dep and the compress.rs module may need adaptation."
+    },
+    {
+      "category": "overengineering",
+      "severity": "major",
+      "issue": "User-spec contains implementation details that belong in tech-spec: specific trait names (AttestationStore, LineageStore), internal module paths (core/src/storage/, core/src/lineage/), specific enum type (Direction), specific field type (chain_valid: Option<bool>), error propagation mechanics (? operator), workspace resolver setting (resolver = \"2\"), and codec/sign.rs dependency choice (solana-sdk for Keypair/Signature).",
+      "why_matters": "User-spec defines WHAT and WHY, not HOW. The 'Technical decisions' section (lines 59-65) prescribes implementation approach that should be evaluated in tech-spec where alternatives can be weighed. Baking trait names and module paths into user-spec prevents the implementing agent from discovering better decompositions during implementation. Acceptance criteria that reference internal types (line 36: `Direction` enum, `chain_valid: Option<bool>`) also cross the boundary.",
+      "fix": "Move the entire 'Technical decisions' section to tech-spec. In user-spec, replace with behavioral requirements: (1) 'payment methods must not be accessible from core public API', (2) 'lineage traversal must report validation status accurately, not return hardcoded true', (3) 'lineage direction must be type-safe, not raw strings', (4) 'DB errors in lineage operations must propagate to callers, not be silently swallowed'. Rewrite acceptance criterion line 36 as behavioral: 'lineage module errors propagate correctly; validation status is computed, not hardcoded; direction parameter is type-safe'."
+    },
+    {
+      "category": "underengineering",
+      "severity": "major",
+      "issue": "No edge cases listed for either user flow. The spec describes two scenarios (Rust developer using core, MCP server backward compatibility) but neither has edge cases. For an L-sized feature, this is a significant gap.",
+      "why_matters": "Without edge cases, the implementing agent will make assumptions about behavior in failure scenarios. Unaddressed edge cases for Scenario 1: what if fastembed model download fails on first FastEmbedder::try_new()? What if load_or_create_keypair receives a path to a directory instead of a file? What if compress is called with an embedding of wrong dimension? Unaddressed edge cases for Scenario 2: what if the existing SQLite DB was created by an older version? What if MCP receives concurrent tool calls that both write to SQLite? What if the keypair file permissions prevent reading?",
+      "fix": "Add an 'Edge cases' subsection under each scenario. For Scenario 1 (library consumer): (1) FastEmbedder model not downloaded yet, (2) invalid keypair path, (3) dimension mismatch between embedder output and compressor, (4) empty string input to embed. For Scenario 2 (MCP backward compat): (1) existing DB from current monolith version continues working, (2) concurrent tool calls, (3) DB file locked by another process. Even brief bullet points suffice -- the goal is to force the tech-spec to address them."
+    },
+    {
+      "category": "underengineering",
+      "severity": "major",
+      "issue": "Payment-method exclusion list in acceptance criteria is incomplete. The grep criterion (line 41) checks only for `create_api_key` and `deduct_balance`, but code-research shows additional payment methods: `get_owner_pubkey`, `get_balance`, `credit_deposit`, `mark_x402_nonce`, `record_attestation_cost`, `get_pnl_stats`. Additionally, `verify_usdc_transfer` in solana.rs is payment-specific but would migrate to core along with the rest of solana.rs.",
+      "why_matters": "If only two method names are grep-checked, the remaining payment methods could silently leak into core. The `verify_usdc_transfer` function in solana.rs is used exclusively by the payment gate but lives in the solana module -- it would migrate to core unless explicitly excluded. This violates the stated intent of keeping payment logic in MCP.",
+      "fix": "Expand the grep exclusion criterion to include all payment-related methods: `create_api_key`, `deduct_balance`, `credit_deposit`, `mark_x402_nonce`, `record_attestation_cost`, `get_pnl_stats`, `get_owner_pubkey`, `get_balance`. Also decide whether `verify_usdc_transfer` belongs in core (as a general Solana utility) or stays in MCP (as payment logic) and document the decision."
+    },
+    {
+      "category": "feasibility",
+      "severity": "major",
+      "issue": "Architecture.md module names diverge from the spec. Current architecture.md describes core/src/ with directories `attest/`, `storage/`, `arweave/`, `solana/`, `wasm/`. The spec introduces `codec/` and `lineage/` (acceptance criterion line 39 requires grep to find these in architecture.md). The relationship between existing `attest/` and new `codec/` is not explained.",
+      "why_matters": "Acceptance criterion 10 requires `grep -E 'codec/|lineage/' architecture.md` to succeed. The current architecture.md does not contain these strings. The spec does not explicitly list 'update architecture.md' as a migration step, which means the agent might treat it as an afterthought rather than validating the directory structure matches reality.",
+      "fix": "Add an explicit constraint: 'architecture.md Project Structure section must be updated to reflect the actual core/src/ directory layout after migration, replacing attest/ with codec/ and adding lineage/'. Clarify whether `attest/` is renamed to `codec/` or if they coexist."
+    },
+    {
+      "category": "underengineering",
+      "severity": "minor",
+      "issue": "No tokio dependency strategy for core. The arweave.rs and solana.rs modules use async functions (including `tokio::time::sleep` in solana.rs confirm_tx). Moving them to core means core either depends on tokio or needs refactoring.",
+      "why_matters": "Pulling tokio into a library crate is a heavyweight decision that affects compile times and constrains consumers. The spec should state whether core depends on tokio directly, uses feature-gated async, or expects the consumer to provide the runtime. The solana.rs `confirm_tx` function explicitly uses `tokio::time::sleep`, which is not runtime-agnostic.",
+      "fix": "Add a constraint: 'core async functions must work with any tokio-compatible runtime provided by the consumer' or 'core depends on tokio as a required dependency for native builds'. Also note that `tokio::time::sleep` in solana.rs ties core to tokio specifically -- consider replacing with a polling approach or making the sleep strategy injectable."
+    },
+    {
+      "category": "underengineering",
+      "severity": "minor",
+      "issue": "No acceptance criterion for cargo clippy. Project patterns.md requires `cargo clippy --workspace -- -D warnings` on every commit, but the spec only gates on `cargo test` and `cargo build`.",
+      "why_matters": "Extracting ~4400 lines into a new crate commonly triggers clippy warnings (unused imports, dead code during transition, type complexity). Without an explicit clippy gate, the PR may pass tests but violate project quality standards defined in patterns.md.",
+      "fix": "Add acceptance criterion: `cargo clippy -p mnemonic-core -- -D warnings` passes with zero warnings."
+    },
+    {
+      "category": "sizing",
+      "severity": "minor",
+      "issue": "The 7-step sequential migration (codec -> identity -> embed -> compress -> db/storage -> arweave/solana -> lineage) plus httpmock test creation, benchmark migration, HashEmbedder removal, lineage bug fixes, and architecture.md update is at the upper bound of L. No fallback checkpoint is defined.",
+      "why_matters": "If the turboquant crate switch or httpmock test creation encounters unexpected friction, the iteration risks exceeding budget. With no defined checkpoint, the feature is all-or-nothing.",
+      "fix": "Add a checkpoint: 'If after step 4 (compress migration) the iteration budget is strained, db/storage, arweave/solana, and lineage can be deferred to iteration 1b. The core crate is usable for codec, identity, embed, and compress at that checkpoint.' This keeps each checkpoint shippable."
+    },
+    {
+      "category": "better_alternative",
+      "severity": "minor",
+      "issue": "SQLite implementations (AttestationStore, lineage functions) are placed inside core, but SQLite is inherently native-only and will require feature-gating in iteration 2 (WASM). Placing them in a separate crate or behind a feature flag from the start would avoid iteration-2 surgery.",
+      "why_matters": "In iteration 2, WASM compilation will fail if rusqlite is not gated. If SQLite code is deeply integrated into core/src/storage/ and core/src/lineage/ without feature flags, iteration 2 must refactor core's module structure. Patterns.md already states: 'Feature-gate anything requiring network or OS I/O behind #[cfg(not(target_arch = \"wasm32\"))]'.",
+      "fix": "This is a design consideration for tech-spec, not a blocker. Note in constraints: 'SQLite-dependent modules should be structured to allow WASM exclusion in iteration 2 (e.g., behind a cargo feature or cfg gate). Tech-spec should plan for this.' Alternatively, user-spec can simply note that iteration 2 may restructure storage, which is acceptable."
+    }
+  ],
+  "worst_category": "feasibility",
+  "summary": "The spec is well-structured and the native-only extraction approach is sound. Deferring WASM to iteration 2 eliminates the largest previous risk category. However, there is a critical crate name mismatch (the spec says `turboquant-plus-rs` but the current codebase uses `turboquant` -- these are different crates on crates.io) that would break the first migration step. Additionally, implementation details leak from user-spec into tech-spec territory, edge cases are absent for an L-sized feature, and the payment-method exclusion grep is incomplete (catches 2 of ~8 payment methods)."
+}

--- a/work/mnemonic-core/logs/userspec/interview.yml
+++ b/work/mnemonic-core/logs/userspec/interview.yml
@@ -1,0 +1,332 @@
+# Interview Plan for Feature Planning
+#
+# Tracks progress of adaptive discovery interview for a new feature/bug/refactoring.
+# Updated after EACH user response with scoring, values, and remaining gaps.
+#
+# Scoring: 0-100% (how well we understand this aspect)
+# Status: pending → partial → complete
+# Required: true = must reach threshold, false = cover if relevant
+
+# ============================================================================
+# Interview Metadata (Session Recovery)
+# ============================================================================
+interview_metadata:
+  started: "2026-04-20 00:00:00"
+  last_updated: "2026-04-20 12:00:00"
+  status: "completed"  # approved by user 2026-04-20
+  can_resume: true
+  current_question_num: 0
+  feature_size: "L"  # S | M | L
+
+# ============================================================================
+# Conversation History (for session recovery)
+# ============================================================================
+# Preserves complete Q&A. Update after EVERY user response.
+#
+conversation_history: []
+# Format:
+# - question_num: 1
+#   timestamp: "2025-11-12 15:20:33"
+#   topic: "user_problem"
+#   agent_question: |
+#     [Full question text]
+#   user_answer: |
+#     [Full answer text]
+#   summary: "Brief summary"
+
+# ============================================================================
+# Phase 1: High-Level Feature Understanding
+# ============================================================================
+# Interview Cycle 1 scope
+phase1_feature_overview:
+
+  feature_name:
+    score: 95
+    status: "complete"
+    value: "mnemonic-core"
+    gaps: ""
+    required: true
+
+  feature_description:
+    score: 92
+    status: "complete"
+    value: "Extract all core logic from mnemonic-protocol/mcp monolith into mnemonic-core Rust lib crate (dual-target: native + wasm32). Modules: embed, compress, identity, db, arweave, solana, codec, lineage. Step-by-step migration, cargo test green after each step. WASM exports: whoami/sign_memory/recall/verify via wasm/mod.rs. Storage trait abstraction: AttestationStore + LineageStore in core; SQLite impl native-only; WebStorage impl for wasm32. Payment/billing methods (create_api_key, deduct_balance etc) stay in mcp/. HashEmbedder removed. turboquant-plus-rs = '0.1.0' from crates.io. Fix 2 major lineage.rs bugs. Benchmarks + proptest migrate to core/. arweave/solana get httpmock tests. pricing.rs stays in mcp unchanged. MCP becomes thin binary. codec/sign.rs uses solana-sdk (WASM-compatible for crypto). architecture.md updated after migration."
+    gaps: ""
+    required: true
+
+  work_type:
+    score: 90
+    status: "complete"
+    value: "feature"
+    gaps: ""
+    required: true
+
+  user_problem:
+    score: 88
+    status: "complete"
+    value: "All three motivations confirmed: (a) webapp without backend - WASM in browser so no server needed (feasibility TBD, rusqlite blocks this, needs SQLite-WASM or in-memory strategy); (b) reuse - other projects can depend on mnemonic-core without MCP; (c) publication - @mnemonic/core on npm + crates.io as standalone protocol artifact. User is uncertain if (a) is achievable with full persistence."
+    gaps: ""
+    required: true
+
+  target_users:
+    score: 60
+    status: "partial"
+    value: "Developers building AI agents; projects wanting to embed mnemonic protocol logic; webapp (browser WASM)"
+    gaps: ""
+    required: false
+
+  success_criteria:
+    score: 88
+    status: "complete"
+    value: "Level 2: cargo test -p mnemonic-core passes; wasm-pack build --target web builds successfully; mnemonic-mcp compiles using core as workspace dep. Publishing to crates.io/npm is a separate later task."
+    gaps: ""
+    required: true
+
+  constraints:
+    score: 90
+    status: "complete"
+    value: "Step-by-step migration (codec→identity→embed→compress→db→arweave/solana→lineage), cargo test green after each step. Workspace: root Cargo.toml [core, mcp]. WASM target: in-memory only (no rusqlite), browser localStorage for any webapp persistence. Local mode (SQLite) is under question - needs separate research on whether it's needed at all. WASM download efficiency needs research (is WASM worth bundling or per-session?). turboquant dependency: published as 'turboquant-plus-rs' on crates.io. MCP API can change but protocol logic preserved."
+    gaps: ""
+    required: true
+
+  testing_strategy:
+    score: 88
+    status: "complete"
+    value: "Three levels: (1) unit tests per module - embed, compress, identity, db, lineage each tested independently (existing tests in lineage.rs carry over); (2) integration test - mnemonic-mcp with new core dep, all 5 MCP tools work in local mode; (3) WASM smoke test - wasm-pack test --headless --chrome, whoami() returns valid pubkey. turboquant-rs publish is prerequisite parallel task."
+    gaps: ""
+    required: true
+
+# ============================================================================
+# Phase 2: User Experience & Scenarios
+# ============================================================================
+# Interview Cycle 2 scope (together with Phase 3)
+phase2_user_experience:
+
+  user_stories:
+    score: 72
+    status: "partial"
+    value: "Developer adds mnemonic-core to Cargo.toml, calls identity/embed/compress/codec APIs. Webapp loads WASM, generates keypair on first run, saves to localStorage, reuses on next visit. MCP binary depends on core as workspace member."
+    gaps: "Happy path for each migration stage not fully described"
+    required: true
+
+  acceptance_criteria:
+    score: 90
+    status: "complete"
+    value: |
+      - cargo test -p mnemonic-core passes (incl. 8 lineage tests)
+      - wasm-pack build --target web in core/ compiles without errors
+      - wasm-pack test --headless --chrome: whoami() returns valid Ed25519 pubkey
+      - cargo build -p mnemonic-mcp compiles with core as workspace dep
+      - MCP local mode: tools/list returns 5 tools, mnemonic_whoami responds
+      - CI blocks PR on any above failure
+      - Cargo.toml uses turboquant-plus-rs from crates.io (not git)
+      - lineage.rs: traverse_lineage propagates errors, chain_valid is Option<bool>
+      - HashEmbedder removed (does not allow embedding decompression - useless)
+      - architecture.md updated to reflect codec/ and lineage/ in core/src/
+    gaps: ""
+    required: true
+
+  edge_cases:
+    score: 88
+    status: "complete"
+    value: |
+      - WASM keypair: generate new Ed25519 keypair if not in localStorage, reuse if exists
+      - localStorage overflow: return error "storage full", caller handles gracefully
+      - localStorage serialization: JSON strings per attestation, keyed by attestation_id
+      - OpenAI embedder in WASM via reqwest wasm feature (browser fetch API)
+      - fastembed: native-only feature gate, excluded from wasm32 target
+      - No embedder in WASM (no OpenAI key): recall returns Err("no embedder configured")
+      - pricing.rs stays in mcp/ unchanged (no core imports)
+      - codec/sign.rs uses solana-sdk keypair (WASM-compatible for crypto ops)
+      - Benchmarks + proptest_canonical migrate to core/benches/ and core/tests/
+      - arweave.rs + solana.rs: httpmock tests added during migration
+    gaps: ""
+    required: true
+
+  error_scenarios:
+    score: 87
+    status: "complete"
+    value: "CI blocks merge if: WASM build fails, mcp fails to compile with new core dep, cargo test fails. turboquant API compatibility: pin turboquant-plus-rs = '0.1.0' in Cargo.toml, CI cargo test catches breakage. WASM recall with no embedder: returns error 'no embedder configured' (option a). Error handling: anyhow::Result throughout core, convert to JsValue only at wasm/ boundary."
+    gaps: ""
+    required: true
+
+  verification_strategy:
+    score: 75
+    status: "partial"
+    value: "Per-module cargo test after each migration step. After all modules: wasm-pack test --headless --chrome (whoami returns valid pubkey). Integration: mcp in local mode, tools/list returns 5 tools, mnemonic_whoami responds. CI on every PR."
+    gaps: ""
+    required: true
+
+  ui_ux_requirements:
+    score: 0
+    status: "pending"
+    value: ""
+    gaps: "Specific UI/UX requirements if applicable"
+    required: false
+
+  risks:
+    score: 90
+    status: "complete"
+    value: |
+      1. turboquant-plus-rs API divergence: checked crates.io v0.1.0 - ndarray ^0.16 matches old MCP dep, swap is safe. First step of migration.
+      2. HashEmbedder removed: WASM has OpenAI embedder (reqwest wasm feature = browser fetch) or no embedder. No embedder → recall returns error "no embedder configured". Acceptable for demo.
+      3. localStorage WASM storage: Storage trait in core, SQLite impl native-only, web_sys::Storage impl for wasm32. localStorage sync = good, 5-10MB limit acceptable for demo.
+      4. turboquant-plus-rs missing repository field on crates.io - not blocking, fix later.
+    gaps: ""
+    required: true
+
+  technical_decisions:
+    score: 90
+    status: "complete"
+    value: |
+      - Storage trait abstraction: AttestationStore + LineageStore traits in core; SQLite impl behind cfg(not(wasm32)); web_sys::Storage impl for wasm32
+      - Payment methods (create_api_key, deduct_balance, etc): stay in mcp/, not part of core API
+      - wasm/mod.rs exports: whoami(), sign_memory(), recall(), verify() — all returning JsValue or String
+      - HashEmbedder: removed (doesn't allow decompression, useless)
+      - turboquant-plus-rs = '0.1.0' from crates.io (not git), verified API-compatible
+      - lineage.rs: Direction enum (not &str), chain_valid: Option<bool>, errors propagated
+      - codec/sign.rs: keep solana-sdk (WASM-compatible for crypto), no need for ed25519-dalek refactor
+      - Publishing (crates.io + npm): separate task, not in this scope
+    gaps: ""
+    required: false
+
+  deploy_approach:
+    score: 0
+    status: "pending"
+    value: ""
+    gaps: "How to deploy: CI/CD, manual, Docker? What needs setup?"
+    required: false
+
+  manual_user_actions:
+    score: 0
+    status: "pending"
+    value: ""
+    gaps: "Steps user must do manually (create bot, get API keys, configure service)"
+    required: false
+
+# ============================================================================
+# Phase 3: Integration & Technical Context
+# ============================================================================
+# Interview Cycle 2 scope (together with Phase 2)
+phase3_integration:
+
+  integration_points:
+    score: 85
+    status: "complete"
+    value: "mnemonic-core is consumed by: (1) mnemonic-mcp as workspace dep path='../core'; (2) mnemonic-webapp via wasm-pack WASM build. Old mnemonic-protocol/mcp becomes archive. Clean cut - no git history migration needed."
+    gaps: ""
+    required: true
+
+  dependencies:
+    score: 88
+    status: "complete"
+    value: "turboquant-plus-rs = '0.1.0' (crates.io, verified compatible). ndarray ^0.16, solana-sdk 2.2, rusqlite (native-only), reqwest (split: blocking native, async wasm feature), fastembed (native optional feature), web_sys (wasm32 target). No new dependencies needed."
+    gaps: ""
+    required: false
+
+  technical_constraints:
+    score: 0
+    status: "pending"
+    value: ""
+    gaps: "Technical limitations, performance, security"
+    required: false
+
+  data_requirements:
+    score: 0
+    status: "pending"
+    value: ""
+    gaps: "What data needed, where from, how stored"
+    required: false
+
+  migration_needs:
+    score: 0
+    status: "pending"
+    value: ""
+    gaps: "Migration plan for existing users/data"
+    required: false
+
+# ============================================================================
+# Phase 4: Completion
+# ============================================================================
+phase4_completion:
+  userspec_file: ""  # work/{feature}/user-spec.md
+  status: "pending"  # pending | created | approved
+
+# ============================================================================
+# Decision Rules
+# ============================================================================
+decision_rules:
+
+  required_threshold: 85
+  optional_threshold: 50
+
+  # Stop criteria (BOTH must be true to exit a cycle)
+  stop_criteria:
+    - "All required items in current cycle scope score >= 85%"
+    - "Structural: every required item has non-empty value, no TBD, gaps empty or conscious limitations"
+
+  priority_order:
+    - "Required items with score < 85% (lowest score first)"
+    - "Optional items mentioned by user in context"
+    - "Other optional items if user seems knowledgeable"
+
+  question_strategy:
+    - "3-4 questions per batch about different gaps"
+    - "Run as many batches as needed — batch size is NOT cycle limit"
+    - "Propose solutions based on PK, not just ask questions"
+    - "Challenge with substance: counterexamples, code references, unexplored scenarios"
+    - "After each response: update scores, values, gaps, conversation_history, save"
+
+# ============================================================================
+# Interview Progress
+# ============================================================================
+progress:
+  current_phase: "phase1_feature_overview"
+  questions_asked: 0
+  last_question: ""
+  total_required_score: 0
+  total_optional_score: 0
+  completion_estimate: "0%"
+  user_detail_level: "unknown"  # brief | moderate | detailed
+
+# ============================================================================
+# Notes
+# ============================================================================
+notes: |
+  - turboquant dependency: published on crates.io as "turboquant-plus-rs" by the owner. Cargo.toml dep must be updated from git to crates.io version.
+  - SEPARATE TASK (not in this scope): research turboquant vs turboquant-rs crates — compare efficiency, API, maintenance, choose best.
+  - SEPARATE RESEARCH (not in this scope): WASM bundle efficiency — is it better to download WASM once (PWA/cache) or keep in-memory per session? Also evaluate if SQLite local mode is needed at all.
+  - lineage.rs: 2 major bugs to fix during migration (silent error swallowing in traverse_lineage, chain_valid hardcoded true).
+  - lineage.rs: needs LineageStore trait abstraction to be WASM-compatible (DAG logic in core, SQLite impl in mcp or native feature gate).
+
+# ============================================================================
+# USAGE INSTRUCTIONS
+# ============================================================================
+#
+# 1. INIT: Created by init-feature-folder.sh at work/{feature}/logs/userspec/interview.yml
+#    Set metadata.started, metadata.status: in_progress
+#
+# 2. INITIAL SCORING: After user's free-form description, score ALL items
+#    Detailed 80-95%, brief 50-70%, vague 20-40%, not mentioned 0%
+#
+# 3. INTERVIEW LOOP (save after EVERY response):
+#    a) Find required items with score < 85% in current cycle scope
+#    b) Ask 3-4 questions about different gaps
+#    c) Propose solutions based on PK
+#    d) User answers
+#    e) Update: conversation_history, scores, values, gaps, metadata
+#    f) Save immediately
+#    g) Check stop criteria (score >= 85% AND structural: value filled, no TBD, gaps resolved)
+#    h) Not done → repeat. Done → next cycle.
+#
+# 4. CYCLES:
+#    Cycle 1: phase1_feature_overview items
+#    Cycle 2: phase2_user_experience + phase3_integration items
+#    Cycle 3: ALL items still below threshold (cleanup pass)
+#
+# 5. RESUME: If metadata.status is "in_progress"
+#    Load, show conversation summary, resume from current state
+#
+# 6. COMPLETION: After user approves user-spec.md
+#    Set phase4_completion.status: approved
+#    Set metadata.status: completed

--- a/work/mnemonic-core/logs/userspec/quality-review.json
+++ b/work/mnemonic-core/logs/userspec/quality-review.json
@@ -1,0 +1,74 @@
+{
+  "status": "changes_required",
+  "checks": {
+    "completeness": "pass",
+    "edge_cases": "pass",
+    "acceptance_criteria": "pass",
+    "contradictions": "pass",
+    "template_compliance": "fail",
+    "size_check": "warning"
+  },
+  "findings": [
+    {
+      "check": "template_compliance",
+      "severity": "critical",
+      "issue": "'Как проверить' section contains only the 'Агент проверяет' subsection. The required 'Пользователь проверяет' subsection is completely absent. The template mandates both subsections. Without it, there is no documented manual verification path for a human reviewer — for an L-size feature this is a meaningful gap since some checks (e.g. confirming MCP round-trip behavior end-to-end) require human judgment.",
+      "location": "## Как проверить — отсутствует подраздел '### Пользователь проверяет'",
+      "fix": "Add a '### Пользователь проверяет' subsection below '### Агент проверяет'. Minimum content: (1) Запустить mnemonic-mcp в local mode, выполнить sign_memory через CLI/stdio — убедиться что content возвращается при recall; (2) Проверить что ~/.mnemonic/attestations.db существует и содержит записи после sign_memory; (3) Убедиться что cargo test вывод содержит '8 passed' для lineage-тестов."
+    },
+    {
+      "check": "completeness",
+      "severity": "major",
+      "issue": "The interview.yml conversation_history is empty (conversation_history: []) and questions_asked: 0, yet status is 'completed' and all scores are populated. The interview was pre-seeded with values rather than built through actual Q&A dialogue. This means there is no verifiable record that the user actually confirmed the scope reduction from dual-target (native+WASM) to native-only — a significant scope change from the original feature_description which described full WASM extraction.",
+      "location": "logs/userspec/interview.yml — conversation_history: [], questions_asked: 0",
+      "fix": "Update interview.yml to reflect actual session provenance: set a brief conversation_history entry documenting the source (e.g. 'Spec created from existing codebase analysis; user confirmed native-only scope for iteration 1 via [date/channel]'). This ensures future agents can trace the scope decision and avoids false audit confidence."
+    },
+    {
+      "check": "completeness",
+      "severity": "major",
+      "issue": "The interview extensively covered the WASM 'no embedder configured' error path (recall() without OpenAI key in WASM returns Err) and localStorage overflow ('storage full') error. The spec correctly scopes WASM to iteration 2, but the NATIVE-side equivalent is not addressed: what does recall() return when no embedder is configured in native mode (e.g. no fastembed model downloaded, no OPENAI_API_KEY set)? The interview error_scenarios value mentions this only for WASM context. For a user depending on mnemonic-core natively, this is an observable behavior that should be defined.",
+      "location": "Как должно работать — Сценарий 1 (разработчик на Rust); Критерии приёмки",
+      "fix": "Add a sentence to Сценарий 1 describing behavior when no embedder is available (e.g. 'Если ни fastembed модель, ни OPENAI_API_KEY не настроены, embed() возвращает Err — caller обязан обрабатывать'). Optionally add an acceptance criterion: 'embed() без настроенного embedder возвращает Err, не паникует — проверяется unit-тестом с пустым конфигом'."
+    },
+    {
+      "check": "size_check",
+      "severity": "minor",
+      "issue": "11 acceptance criteria exceeds the >10 warning threshold. For an L-size feature this is expected and justified by scope, but the threshold is formally exceeded per check rules.",
+      "location": "Критерии приёмки — 11 пунктов",
+      "fix": "No action required if all 11 criteria reflect real acceptance gates. Consider whether criterion 5 (CI blocks PR) is an acceptance criterion or an infrastructure requirement — moving it to 'Ограничения' or 'Тестирование' would reduce count to 10."
+    }
+  ],
+  "interview_coverage": {
+    "covered": [
+      "Step-by-step migration order: codec → identity → embed → compress → db → arweave/solana → lineage",
+      "turboquant-plus-rs = '0.1.0' from crates.io (not git), API-verified compatible",
+      "lineage.rs bug fixes: Direction enum, chain_valid Option<bool>, error propagation in traverse_lineage",
+      "HashEmbedder removal (cannot decompress embeddings, useless)",
+      "httpmock tests for arweave.rs and solana.rs (happy path + network error)",
+      "Payment methods (create_api_key, deduct_balance, etc.) stay in mcp/, do not migrate to core",
+      "Benchmarks and proptest migrate to core/benches/ and core/tests/",
+      "architecture.md update: codec/ and lineage/ appear in Project Structure description of core/src/",
+      "Storage trait abstraction: AttestationStore + LineageStore traits in core, SQLite impl in core/src/storage/ and core/src/lineage/",
+      "Workspace structure: root Cargo.toml [core, mcp], resolver = '2'",
+      "crates.io/npm publication is explicitly out of scope (separate task after iteration 2)",
+      "codec/sign.rs keeps solana-sdk (WASM-compatible for crypto, noted as relevant to iteration 2)",
+      "Integration: all 5 MCP tools work in local mode after migration",
+      "CI blocks PR on cargo test or cargo build failure",
+      "Three test levels: unit per module, integration MCP local mode, no E2E in iteration 1",
+      "SQLite backward compatibility: no schema changes, existing ~/.mnemonic/attestations.db continues to work",
+      "pricing.rs stays in mcp/ unchanged",
+      "Rust developer scenario: imports mnemonic_core::identity, embed, compress — no HTTP deps",
+      "MCP-as-wrapper scenario: 5 tools work identically, internal changes invisible to callers",
+      "Risk: turboquant API divergence — mitigated by changing dep first and running cargo test",
+      "Risk: zero arweave/solana test coverage — mitigated by adding httpmock tests during migration",
+      "Risk: payment methods leaking into core — mitigated by grep criterion in acceptance + CI"
+    ],
+    "missing": [
+      "WASM topics (wasm-pack build, localStorage, web_sys::Storage, WASM keypair, OpenAI in WASM via reqwest, fastembed native-only gate, recall without embedder in WASM, wasm/mod.rs exports) — legitimately excluded: spec explicitly scopes WASM to iteration 2, Ограничения clearly states 'WASM-таргет ... вне scope этой итерации'",
+      "Native-side 'no embedder configured' error behavior — discussed in interview only in WASM context but the native equivalent is not defined in the spec (see major finding in completeness check)",
+      "WASM bundle efficiency research and SQLite local mode research — correctly absent: interview.yml notes mark these as SEPARATE RESEARCH out of scope",
+      "turboquant vs turboquant-rs comparison — correctly absent: interview.yml notes mark this as SEPARATE TASK out of scope"
+    ]
+  },
+  "summary": "Спек качественный и хорошо проработан для native-only итерации 1. Одна критическая проблема: отсутствует обязательный подраздел 'Пользователь проверяет' в секции 'Как проверить'. Две значимые (major) проблемы: пустой conversation_history при 'completed' статусе интервью не позволяет верифицировать согласование scope-reduction с native-only; поведение embed() при отсутствии embedder в native-режиме не определено. После добавления 'Пользователь проверяет' спек готов к апрувалу."
+}

--- a/work/mnemonic-core/logs/working/audit/code-auditor.json
+++ b/work/mnemonic-core/logs/working/audit/code-auditor.json
@@ -1,0 +1,131 @@
+{
+  "auditor": "code-auditor",
+  "task": 13,
+  "verdict": "issues-found",
+  "scope": "final-state-holistic",
+  "files_reviewed": [
+    "Cargo.toml",
+    "core/Cargo.toml",
+    "mcp/Cargo.toml",
+    "core/src/lib.rs",
+    "core/src/codec/mod.rs",
+    "core/src/codec/schema.rs",
+    "core/src/codec/canonical.rs",
+    "core/src/codec/hash.rs",
+    "core/src/codec/sign.rs",
+    "core/src/identity/mod.rs",
+    "core/src/embed/mod.rs",
+    "core/src/compress/mod.rs",
+    "core/src/storage/mod.rs",
+    "core/src/storage/traits.rs",
+    "core/src/storage/sqlite.rs",
+    "core/src/arweave/mod.rs",
+    "core/src/solana/mod.rs",
+    "core/src/lineage/mod.rs",
+    "core/tests/integration_cbor.rs",
+    "core/tests/proptest_canonical.rs",
+    "core/benches/cbor_codec.rs",
+    "core/benches/decompress.rs",
+    "mcp/src/main.rs",
+    "mcp/src/mcp.rs",
+    "mcp/src/tools.rs",
+    "mcp/src/payment.rs",
+    "mcp/src/pricing.rs",
+    "mcp/src/config.rs"
+  ],
+  "findings": [
+    {
+      "severity": "critical",
+      "location": "core/src/embed/mod.rs:22-63 + core/Cargo.toml:32",
+      "issue": "The `local-embed` feature does not compile. `cargo clippy --workspace --all-features` (and `cargo build --features local-embed`) fails with E0639 (`InitOptions` is `#[non_exhaustive]` in fastembed 5.x and cannot be constructed with a struct literal) and E0596 (`TextEmbedding::embed` now takes `&mut self`, but our trait method is `&self`). Because `local-embed` is opt-in, the default `cargo build --workspace` is green and every per-task verification passed — but fastembed is the documented default embedder for the product (\"open, verifiable default\" per patterns.md, and the DEFAULT `EMBED_PROVIDER` is `fastembed` in config.rs:70). Shipping mnemonic-core to crates.io in this state means anyone enabling `local-embed` gets a hard compile failure. Not caught by any CI gate because the workspace clippy does not include `--all-features`.",
+      "suggestion": "Pin fastembed to a compatible 4.x version (or update the API call: `InitOptions::new(EmbeddingModel::AllMiniLML6V2)` via the new builder; change `Embedder::embed` to `&mut self` OR wrap `TextEmbedding` in `RefCell` / `Mutex` to preserve the `&self` signature). Add `cargo clippy --workspace --all-features -- -D warnings` to the standard verification gate so future feature-gated regressions surface before merge."
+    },
+    {
+      "severity": "major",
+      "location": "core/src/storage/sqlite.rs:31-68, 95-111 + core/src/storage/traits.rs:62-70",
+      "issue": "Payment-domain schema + migrations leak into core. Tech Spec Decision 2 states \"payment methods stay in mcp/\", yet `core/src/storage/sqlite.rs` defines the full payment schema (`api_keys`, `payment_events`, `x402_nonces`, `attestation_costs`) and owns the `migrate_payment_events_unique_index` helper with its DELETE-then-CREATE-UNIQUE-INDEX logic. Separately, the `LineageStore` trait (`save_edge` / `get_edges` / `clear_edges` over a `lineage_edges` table) in core/src/storage/ is a vestigial stub left over from Task 6 — it is never consumed by mcp, contains a `TODO(task-9)` comment that was never followed up, and defines a DIFFERENT lineage table (`lineage_edges`) from the one `core/src/lineage/` actually uses (`artifact_lineage`). Two parallel lineage schemas coexist in core for the same conceptual DAG. This is classic cross-wave drift: Task 6 produced a trait + schema it couldn't predict Task 9 would supersede, and nobody re-unified them in Task 11's \"final rewiring\".",
+      "suggestion": "Two distinct cleanups: (a) move the payment table DDL (api_keys, payment_events, x402_nonces, attestation_costs, plus the `migrate_payment_events_unique_index` migration) out of core and into an mcp-side init step (e.g. `mcp/src/payment.rs::init_payment_schema(&SqliteStore)` run once at startup) — core should expose only the attestations + lineage schema. (b) Delete the `LineageStore` trait and the `lineage_edges` CREATE/SELECT/INSERT in sqlite.rs, and have `core/src/lineage/` be the single lineage surface (already takes `&Connection`). If a trait is genuinely wanted, rewrite it around the real lineage module API and wire it in."
+    },
+    {
+      "severity": "major",
+      "location": "core/src/storage/sqlite.rs:246, 271",
+      "issue": "`AttestationStore::search` and `LineageStore::get_edges` use `filter_map(|r| r.ok())` on `query_map` iterators — the exact pattern Task 9 fixed in lineage.rs (see decisions.md Task 9 summary: \"get_parents / get_children now collect rows into rusqlite::Result<Vec<_>> instead of filter_map(|r| r.ok())\"). Task 6 introduced the identical anti-pattern into the sqlite store and it wasn't cleaned up when Task 9 set the convention. Row-level DB errors are silently dropped. `search()` swallows a schema-drift or corrupted-blob failure as \"zero results\". This is also a cross-wave coherence failure.",
+      "suggestion": "Replace both sites with the Task 9 pattern: `let collected: rusqlite::Result<Vec<_>> = rows.collect(); Ok(collected?)`. Apply the same convention guard across the codebase."
+    },
+    {
+      "severity": "major",
+      "location": "mcp/src/mcp.rs:75-76",
+      "issue": "`unsafe impl Send for McpState {} / unsafe impl Sync for McpState {}` — load-bearing `unsafe` with only a comment justification. `SqliteStore` contains `rusqlite::Connection` which is `!Send`; the surrounding `Mutex<SqliteStore>` does NOT make the contained `!Send` type Send (`Mutex<T>: Sync` requires `T: Send`, it does not create Send from nothing). The unsafe impl is a workaround for axum's `State<Arc<McpState>>` requiring Send + Sync. This is pre-existing (likely copied from the original monolith) but the extraction is a natural moment to fix it — every other module cleaned up its pre-existing quirks (lineage Direction enum, db error propagation, etc.). If the store is really only touched with short critical sections and never `.await` is held across a lock, use `tokio::task::spawn_blocking` around DB ops, or switch to `tokio::sync::Mutex`, or use `parking_lot::Mutex` and move the `Connection` into a dedicated thread behind a channel. At minimum the `unsafe impl` should have a SAFETY comment that references the specific invariants being upheld.",
+      "suggestion": "Replace the unsafe impls with one of: (a) a dedicated `StoreHandle` that owns the connection in a worker thread and exposes a `async` API over a channel, (b) `std::sync::Mutex<rusqlite::Connection>` held via a Pool type where Connection is re-opened per call, or (c) a minimum remediation: add a `// SAFETY: ...` comment articulating the specific invariants (no await held across lock, Connection is used only inside `.lock()` critical sections, all public methods are called from the axum handlers which already ensure no await across the guard)."
+    },
+    {
+      "severity": "major",
+      "location": "core/src/solana/mod.rs:29 + mcp/src/payment.rs:241-244",
+      "issue": "`SolanaClient::rpc(&self, method, params)` is fully `pub` (not `#[doc(hidden)]`), exposing a general-purpose RPC escape hatch on the stable API surface. The only reason it's public is Task 8's cross-crate call: `verify_usdc_transfer` in mcp/payment.rs reaches into core and issues `client.rpc(\"getTransaction\", ...)` itself. That leaks a payment-layer JSON-RPC shape into a public method on the core client. Decisions.md Task 8 flagged this deviation: \"Made `rpc` `pub` (task said 'no need to make rpc public'...)\". For a library that's intended for crates.io, this is a permanent stain on the public API.",
+      "suggestion": "Either (a) add a high-level method on `SolanaClient` like `get_token_balances(tx_sig) -> Vec<TokenBalance>` that `verify_usdc_transfer` can call, letting `rpc` revert to `pub(crate)` or at least `#[doc(hidden)] pub` — matching the convention established for `codec::sign::sign_cose` (#[doc(hidden)] pub), or (b) move `verify_usdc_transfer` back into `SolanaClient` as a payment-aware helper method (reverses the Task 8 extraction but closes the surface — the original spec decision to move it was architecturally motivated, but the concrete result is worse). Option (a) is preferable."
+    },
+    {
+      "severity": "minor",
+      "location": "mcp/src/config.rs:19",
+      "issue": "Stale comment: `/// \"hash\" (default, offline) or \"openai\" (requires OPENAI_API_KEY)`. The `hash` provider was removed in Task 4 (HashEmbedder eliminated); current valid values per `embed::build_embedder` are `fastembed` and `openai`, and the `from_env` default is `fastembed` (line 70). The doc string misleads operators who read config.rs to understand `EMBED_PROVIDER`.",
+      "suggestion": "Update to `/// \"fastembed\" (default, open-weights, requires --features local-embed) or \"openai\" (requires OPENAI_API_KEY)`."
+    },
+    {
+      "severity": "minor",
+      "location": "core/Cargo.toml:20, 27, 30, 21",
+      "issue": "Unused dependencies in core: `thiserror = \"2\"`, `spl-memo = \"6\"`, `futures = \"0.3\"`, and `uuid = { version = \"1\", features = [\"v4\"] }`. `grep -rn \"thiserror\\|spl_memo\\|futures::\\|uuid::\" core/src/` returns zero matches. `uuid` is still used by mcp/tools.rs and mcp/payment.rs (which already declares it in mcp/Cargo.toml). `spl-memo` is no longer needed because the moved `solana/mod.rs` uses a string constant for `MemoSq4gqABAX...` rather than `spl_memo::id()`. `futures` and `thiserror` were never wired up. These add to compile time and lock file weight without providing value. Not caught because cargo does not emit a warning for declared-but-unused deps.",
+      "suggestion": "Remove the four unused deps from `core/Cargo.toml`. If any are truly needed for future work, add a comment justifying the declaration. Consider adding `cargo machete` or `cargo udeps` to CI to catch this automatically going forward."
+    },
+    {
+      "severity": "minor",
+      "location": "core/src/storage/sqlite.rs:249",
+      "issue": "`results.sort_by(|a, b| b.relevance_score.partial_cmp(&a.relevance_score).unwrap())` panics if any `relevance_score` is NaN. `relevance_score` is computed from `query_embedding`, stored `emb`, and their norms — if a stored embedding is all zeros (e_norm == 0.0) the code sets score=0.0 (fine), but if the query embedding contains NaN (caller bug or corrupted DB row) `partial_cmp` returns None and we panic. The core library is consumed by third parties who can't audit their own embedder outputs — a NaN-in-query crashing the server is a poor failure mode.",
+      "suggestion": "Use `partial_cmp(...).unwrap_or(std::cmp::Ordering::Equal)` — NaN-to-equal is the standard Rust idiom for total-ordering on floats and preserves relative ordering of valid scores. Alternatively: `f32::total_cmp` if we want NaNs sorted to the end deterministically."
+    },
+    {
+      "severity": "minor",
+      "location": "core/src/codec/mod.rs:9-12 vs core/src/storage/mod.rs:6-8",
+      "issue": "Inconsistent module-surface conventions. `storage/mod.rs` re-exports its key types (`AttestationStore`, `LineageStore`, `SqliteStore`, `AttestationRow`, `SearchResult`) at the module root. `codec/mod.rs` only declares submodules (`pub mod schema; pub mod canonical; pub mod hash; pub mod sign;`) with no re-exports — consumers have to write `mnemonic_core::codec::sign::sign_artifact`, `mnemonic_core::codec::schema::MEMORY_V1`, etc. (see mcp/tools.rs:11-16). Cross-task coherence drift: Task 2 (codec) chose one convention, Task 6 (storage) chose another, no one unified them in Task 11's final rewiring.",
+      "suggestion": "Pick one convention and apply uniformly. For a crates.io-published library, re-exporting in `mod.rs` (the storage pattern) is conventional — it shortens call sites and lets you rearrange internals without API churn. Add `pub use self::{schema::*, canonical::*, hash::*, sign::*};` at the codec root (or curated re-exports like storage does)."
+    },
+    {
+      "severity": "minor",
+      "location": "core/src/codec/schema.rs:155",
+      "issue": "`pub fn validate_artifact` is defined on the public API surface but never called from production code (only from its own inline test). It's documentation + dead-code on the surface. The companion `to_canonical_cbor` already enforces field presence indirectly via `cbor_field_order`, so `validate_artifact` is also conceptually redundant.",
+      "suggestion": "Either (a) wire it into `sign_artifact` as a pre-flight check (makes the library fail-fast on malformed inputs — strictly an API improvement), or (b) mark it `#[doc(hidden)] pub` / demote to `pub(crate)` until a real consumer emerges. (a) is recommended."
+    },
+    {
+      "severity": "minor",
+      "location": "core/src/codec/sign.rs:54",
+      "issue": "`#[doc(hidden)] pub fn sign_cose` was added in Task 10 round 2 specifically to let `core/benches/cbor_codec.rs` isolate the COSE stage. The review revisit: the `#[doc(hidden)]` attribute is correct (it's a benchmark-only extraction point, not a product API), but this is the kind of item that grows into accidental public API when a future contributor removes `#[doc(hidden)]` \"because the function is already pub\". The doc comment on line 51-53 does explain intent. Justified, but fragile.",
+      "suggestion": "Consider moving `sign_cose` to a crate-level `#[cfg(any(test, feature = \"__bench\"))]` helper so it's simply not in the prod build. Alternatively, accept the `#[doc(hidden)] pub` and add a `#[allow(unused)] #[cfg(test)]` assertion elsewhere that prevents accidental upgrade to a documented surface."
+    },
+    {
+      "severity": "nit",
+      "location": "core/src/embed/mod.rs:212",
+      "issue": "`#[allow(dead_code)] pub(crate) fn l2_normalize(vec: &mut [f32])` — only caller is the `#[cfg(test)] MockEmbedder::embed`, so in non-test builds it's genuinely dead. The `allow(dead_code)` is correct for the cfg shape but awkward; a cleaner fix is `#[cfg(test)]` on the function itself.",
+      "suggestion": "Change to `#[cfg(test)] fn l2_normalize(...)` and drop the `allow(dead_code)`. Symmetry with the surrounding `#[cfg(test)] pub struct MockEmbedder`."
+    },
+    {
+      "severity": "nit",
+      "location": "core/src/arweave/mod.rs:347-357",
+      "issue": "`test_network_timeout` asserts `client.write_bytes(b\"data\", ...)` returns `Err` but the comment admits it's exercising the arlocal path (is_local=true, bypass=false), not the Irys path — i.e. the test is named for a scenario it doesn't actually hit. The failure it detects is the arlocal POST timing out, not the Irys upload timing out.",
+      "suggestion": "Rename to `test_arlocal_unreachable_returns_err` or add a second test using `new_for_test` (bypass_local_routing=true) with a non-listening port to actually hit the Irys path and assert the expected error message. Current test is correct as a smoke-test of error propagation; only the name/intent comment misleads."
+    }
+  ],
+  "strengths": [
+    "Module extraction fully respected the payment-logic boundary for imperative code: no payment functions (create_api_key, deduct_balance, credit_deposit, mark_x402_nonce, record_attestation_cost, get_pnl_stats, get_owner_pubkey, verify_usdc_transfer) leaked into core/src/ — grep confirms. HashEmbedder is fully absent.",
+    "Task 9's lineage cleanup is high-quality: Direction is a proper enum with serde tags, chain_valid: Option<bool> has explicit None semantics documented inline, DB error propagation is tested via the negative-schema test, and cycle detection + MAX_DEPTH guard are sound.",
+    "Task 11's payment concurrency hardening (round 2 + round 3) is the strongest code in the workspace: atomic IMMEDIATE transactions around balance + ledger writes, partial UNIQUE index on tx_sig with a legacy-dedup migration, WAL + busy_timeout pragmas, and 7 unit tests including two true concurrent (Barrier-synchronized multi-thread) tests that would have caught all three TOCTOU findings.",
+    "httpmock tests for arweave (6) and solana (8) raised these modules from zero coverage to realistic behavioral coverage, including retry-exhaustion with `start_paused` virtual time, error-path JSON shapes, and the get_tx_signers jsonParsed account-key walk.",
+    "Workspace structure is clean: Cargo.toml root is minimal (just `members = [\"core\", \"mcp\"]` + resolver), core has a sensible dev/prod dep split, mcp's Cargo.toml was trimmed in Task 11 to only the deps actually imported (axum, tower-http, reqwest, clap, tracing-subscriber, dotenvy, tempfile).",
+    "Documentation trail is excellent: decisions.md is detailed per-task, round-by-round, and the Task 11 entry explicitly lists deferred follow-ups (CORS origin, admin/stats auth, sign_memory 10-arg refactor, MCP round-trip smoke test) rather than quietly dropping them. This is unusually good hygiene for a multi-agent workflow.",
+    "Default `cargo build --workspace`, `cargo test --workspace`, `cargo clippy --workspace --all-targets -- -D warnings` are all green on a cold target dir. 90 tests across 4 binaries pass, no flakes observed, per-package clippy also clean."
+  ],
+  "verification": {
+    "cargo_build": "pass",
+    "cargo_test": "90 passed / 0 failed (75 core unit + 5 integration_cbor + 3 proptest_canonical + 7 mcp unit)",
+    "cargo_clippy": "clean with default features. FAILS with --all-features due to fastembed 5.x API incompatibility (see critical finding)."
+  },
+  "notes": "Audit ran in isolated worktree agent-a1f0c7a9 branched from main at commit 880ee42 (PR #5 merge). No code changes were made. The worktree is clean; the JSON report is written to the MAIN working-directory path per task instructions. The `local-embed` compile failure is the one genuinely blocking finding — everything else is normal extraction-residue that can ship and be cleaned in iteration 2. The lineage/payment schema leak into core is architecturally the next-most-important to address before any crates.io publication: a downstream consumer pulling mnemonic-core will receive a SQLite schema that creates four payment-specific tables they don't need and can't opt out of."
+}

--- a/work/mnemonic-core/logs/working/audit/security-auditor.json
+++ b/work/mnemonic-core/logs/working/audit/security-auditor.json
@@ -1,0 +1,94 @@
+{
+  "auditor": "security-auditor",
+  "task": 14,
+  "verdict": "issues-found",
+  "scope": "final-state-holistic-owasp",
+  "summary": {
+    "critical": 0,
+    "major": 0,
+    "minor": 4,
+    "nit": 3
+  },
+  "findings": [
+    {
+      "severity": "minor",
+      "location": "core/src/identity/mod.rs:7-21 (load_or_create_keypair)",
+      "issue": "Ed25519 keypair is written to disk as a 64-byte JSON array via `std::fs::write` with no explicit permission bits set. The file inherits the process umask — on typical systems that is 0644 (world-readable). The server's Solana signing key is the root of trust for every attestation (COSE_Sign1 signer, Arweave ANS-104 signer, SPL Memo signer). Any local user on the host that can read ~/.mnemonic/id.json can clone the agent identity and forge attestations.",
+      "owasp_category": "A02: Cryptographic Failures",
+      "suggestion": "After `std::fs::write(path, ...)`, set permissions explicitly: `#[cfg(unix)] std::fs::set_permissions(path, std::os::unix::fs::PermissionsExt::from_mode(0o600))?`. Additionally, when the keypair file already exists, check its mode on load and `tracing::warn!` if it is group/world-readable so operators see the problem before production rollout. This was flagged in task-1 round 1 as pre-existing and was not addressed during the refactor — it should be called out again as an unresolved major-ish item that should be fixed before on-chain production use.",
+      "cwe": "CWE-732"
+    },
+    {
+      "severity": "minor",
+      "location": "core/src/embed/mod.rs:86-112 (OpenAIEmbedder::embed)",
+      "issue": "`OpenAIEmbedder::embed` uses `reqwest::blocking::Client::new()` inside the non-async `Embedder::embed` signature. The call is executed from inside `tools::sign_memory`, which is an async function awaited from the tokio runtime (via axum handlers). Blocking reqwest internally calls `tokio::task::block_on` on its own runtime — running it from a tokio worker thread can block the worker. Under concurrent sign_memory load with `EMBED_PROVIDER=openai`, all tokio workers may become occupied in blocking HTTP calls, leading to a tokio stall / liveness loss (a DoS-equivalent). core/Cargo.toml still declares `reqwest = { features = [\"json\", \"blocking\"] }` specifically for this call site.",
+      "owasp_category": "A04: Insecure Design (liveness / DoS risk)",
+      "suggestion": "Either (a) wrap the OpenAI call in `tokio::task::spawn_blocking` at the call site in tools.rs, or (b) make `Embedder::embed` async and switch `OpenAIEmbedder` to the non-blocking `reqwest::Client`. Option (b) is cleaner — the trait is under the project's control, and the only implementations are `OpenAIEmbedder` and `FastEmbedder`; making the signature async propagates naturally. This was flagged in task-1 round 1 as pre-existing; the refactor moved the code to core/ without touching it.",
+      "cwe": "CWE-833"
+    },
+    {
+      "severity": "minor",
+      "location": "core/src/embed/mod.rs:104-111 (OpenAIEmbedder::embed error branch)",
+      "issue": "On OpenAI API failure (HTTP error, non-2xx, malformed JSON) `OpenAIEmbedder::embed` returns `vec![0.0; self.dim]` — an all-zero embedding — and only logs `tracing::error!`. The signing pipeline then compresses + signs an attestation whose embedding is semantically meaningless. Downstream `recall` queries will silently match against garbage vectors. While not a direct security vector, it is an integrity gap: an on-chain attestation (signed + hashed) is created with invalid semantic content the caller cannot distinguish from a real one. Under an adversarial outage (e.g. DNS spoofing of api.openai.com) this could be exploited to cause a uniformly zero-vector collision pattern in the recall index.",
+      "owasp_category": "A08: Software and Data Integrity Failures",
+      "suggestion": "Change `Embedder::embed` to return `Result<Vec<f32>, _>`; propagate the error up to tools::sign_memory so the tool call fails cleanly and funds are refunded via the existing refund path (already wired in main.rs). Zero-filling is silent data corruption and should not survive the async-embed refactor.",
+      "cwe": "CWE-754"
+    },
+    {
+      "severity": "minor",
+      "location": "mcp/src/main.rs:481-497 (axum CorsLayer) and /admin/stats route (lines 489, 294-327)",
+      "issue": "CORS is configured with `allow_origin(Any).allow_methods(Any).allow_headers(Any)` at the router level, applied to every route including /deposit, /api-keys, /admin/stats, and /balance. Separately, /admin/stats has no authentication whatsoever — any network caller who can reach the HTTP port receives full P&L data (attestations count, revenue, cost breakdown, margin, current pricing, Irys lamports, SOL/USDC rate). Both items are pre-existing findings from task-1 round 1 and were carried through to round 3 of task-11 as deferred follow-ups. Restating here to confirm they are still unresolved in the final state. Acceptable because: (a) the service is single-operator self-hosted, (b) no cookie-based credentials so CORS is the lesser concern, (c) admin/stats leaks aggregate numbers not keys. But an operator running this behind a public IP without a reverse-proxy-level auth shim is exposed.",
+      "owasp_category": "A05: Security Misconfiguration / A01: Broken Access Control",
+      "suggestion": "Track in a follow-up ticket titled 'pre-production: admin auth + CORS allowlist'. Minimum fix: gate /admin/stats on an env-configurable bearer token (`ADMIN_TOKEN`), and restrict CORS to a config-driven origin list with `Any` allowed only when `MCP_DEV_CORS=1` is set. No code change requested in this audit.",
+      "cwe": "CWE-306"
+    },
+    {
+      "severity": "nit",
+      "location": "mcp/src/payment.rs:191-196 (check_x402 error string) and mcp/src/payment.rs:533-546 (mark_x402_nonce error)",
+      "issue": "When x402 verification fails or a nonce is replayed, the full tx_sig is echoed back into the 401 response body (`\"x402 payment not valid: tx {tx_sig} does not transfer ...\"` and `\"x402 payment already used: {tx_sig}\"`). The caller submitted that tx_sig so they already know it, but echoing it into the Unauthorized message means it also ends up in any upstream reverse-proxy access log / error-response store that captures response bodies. Full Solana signatures are correlation handles: if the same tx_sig was reused from another identity, logs of the two servers can be joined. Minor info-disclosure.",
+      "owasp_category": "A09: Security Logging and Monitoring Failures",
+      "suggestion": "Return a generic \"x402 payment rejected\" to clients and log the tx_sig via `tracing::warn!` server-side only, mirroring the pattern applied to the deposit-rejected flow in round 2 (main.rs:264-275).",
+      "cwe": "CWE-532"
+    },
+    {
+      "severity": "nit",
+      "location": "core/src/storage/sqlite.rs:114-130 (SqliteStore::open / WAL mode)",
+      "issue": "WAL mode creates two companion files, `<dbname>-wal` and `<dbname>-shm`, which SQLite writes using the process umask. If the operator sets a restrictive mode on `attestations.db` itself but runs the service with the default umask, the WAL/SHM files may end up world-readable and leak recent balance mutations and api_keys. This was flagged in task-11 round 3 as a deployment concern, not a code defect. Calling it out again here so it stays in the follow-up list after task-14.",
+      "owasp_category": "A05: Security Misconfiguration",
+      "suggestion": "Either (a) explicitly `chmod 0o600` the DB directory and both companion files after open, or (b) document the umask requirement in the deployment runbook and/or set a restrictive umask in `main()` before `SqliteStore::open`. No code change requested in this audit.",
+      "cwe": "CWE-732"
+    },
+    {
+      "severity": "nit",
+      "location": "core/src/arweave/mod.rs:267-280 (prng_fill used in write_arlocal)",
+      "issue": "`write_arlocal` fills the 512-byte `signature` and 256-byte `owner` fields with a linear-congruential PRNG seeded only on `SystemTime::now().as_nanos()`. The resulting SHA-256 of the sig bytes is used as the tx_id. This path is dev/local-only (guarded by `is_local()` which checks for `localhost` / `127.0.0.1`). However, the PRNG output is predictable to a local attacker who can observe the process start time and collision rate. Because arlocal is not a trust boundary (it's a local dev server by definition), this is not a production risk. Flagging only to document the intent: if `prng_fill` is ever reused elsewhere (e.g. for real signature material in a future refactor), it must be replaced with a CSPRNG.",
+      "owasp_category": "A02: Cryptographic Failures (dev-only, not exploitable in production)",
+      "suggestion": "Add a doc comment on `prng_fill` stating 'INSECURE — dev-only stub for arlocal tx_id padding. Do not use for real signature material.' to prevent future misuse. No behavioral change needed.",
+      "cwe": "CWE-338"
+    }
+  ],
+  "strengths": [
+    "Payment-layer atomicity is now fully correct. `credit_deposit`, `deduct_balance`, and `refund_balance` all wrap their INSERT+UPDATE sequences in `BEGIN IMMEDIATE`/`COMMIT` with explicit rollback on every error branch. The partial UNIQUE index on `payment_events(tx_sig) WHERE tx_sig IS NOT NULL` is the idempotency gate for deposits, with a one-shot in-place dedup migration on startup so legacy DBs do not refuse to boot. The three concurrent-execution tests (`credit_deposit_concurrent_same_tx_sig_applies_once`, `deduct_balance_concurrent_cannot_overdraw`, `deduct_balance_audit_insert_failure_rolls_back_balance`) are methodologically sound — they use file-backed stores with dual connections and a `Barrier` for lockstep, plus a BEFORE-INSERT trigger to simulate audit-row failure. This is a strong regression guard.",
+    "No hardcoded secrets found in `core/src/` or `mcp/src/`. All credentials (`OPENAI_API_KEY`, `TREASURY_PUBKEY`, `SOLANA_RPC_URL`, `ARWEAVE_URL`) come from env via `config.rs::env_or` with safe defaults (empty strings or localhost URLs). The USDC mint address `EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v` hardcoded as a default is a public mainnet contract, not a secret. Cargo.toml declares no `git = \"...\"` dependencies and uses published crates.io versions exclusively.",
+    "All SQL in `core/src/storage/sqlite.rs`, `core/src/lineage/mod.rs`, and `mcp/src/payment.rs` uses `rusqlite::params![]` parameterization. Two potential-looking string interpolations were verified: `get_pnl_stats` builds `interval = format!(\"-{days} days\")` where `days: u64` is an integer, then passes it as a bound parameter (not interpolated into SQL); this is safe. No raw SQL string concatenation from user input anywhere.",
+    "x402 nonce replay protection is atomic. `mark_x402_nonce` uses INSERT with the `x402_nonces.tx_sig PRIMARY KEY` constraint and correctly catches `ConstraintViolation` to surface a 'payment already used' error. The deposit flow verifies the Solana USDC transfer + USDC-mint + treasury-recipient policy AND verifies the API key owner is a signer of the deposit tx (`main.rs:259`) before crediting — preventing front-running where an observer could credit another party's tx_sig to their own key.",
+    "`random_bytes` now fails loudly if `/dev/urandom` is unreadable. The SHA-256(timestamp+PID+counter) fallback that task-11 round 1 flagged as weak has been removed entirely. API key generation now propagates an error up to the HTTP 500 handler rather than silently producing a predictable key.",
+    "The COSE_Sign1 signing pipeline (core/src/codec/sign.rs) is implemented correctly: canonical CBOR per schema-defined field order → blake3 hash → COSE_Sign1 with EdDSA (COSE alg -8) over the RFC 9052 Sig_structure. The `signature.len() == 64` guard before `.unwrap()` in `verify_artifact` means the unwrap is infallible. Canonical CBOR is deterministic (RFC 8949 S4.2: sorted keys for nested maps, no indefinite lengths, timestamps as CBOR tag 1). A roundtrip determinism test runs 1000 iterations (`test_canonical_cbor_deterministic_1000x`). No crypto footguns found: no legacy algorithm fallback, no MD5/SHA-1, no homemade hash, no custom elliptic curve.",
+    "`httpmock` test hygiene is clean. No real mainnet URLs (`api.mainnet-beta.solana.com`, `api.devnet.solana.com`, `uploader.irys.xyz`, `api.coingecko.com`) appear in `#[cfg(test)]` blocks in `core/src/`. All test clients are constructed with `MockServer::start().base_url()` (127.0.0.1 with a dynamic port). All test keypairs use `Keypair::new()` — freshly generated ephemeral keys, no funded-keypair seeds or hardcoded secret bytes. The `ArweaveClient::new_for_test` constructor explicitly sets `bypass_local_routing=true` so tests cannot accidentally hit production Irys even through the routing gate.",
+    "Cargo.toml dependency surface is narrow and healthy. `rusqlite 0.34 bundled`, `blake3 1.8`, `coset 0.3.8`, `ciborium 0.2.2`, `solana-sdk 2.3.1`, `reqwest 0.12.28`, `ring 0.17.14`, `rustls 0.23.38` are all current. `turboquant-plus-rs 0.1.0` remains a low-history crate (noted in task-1); no CVEs. No `openssl-sys` with system-linked OpenSSL — everything uses rustls + ring via reqwest's default features. No abandoned crates.",
+    "Storage trait design isolates payment code to mcp/. `grep -r 'create_api_key|deduct_balance|credit_deposit|mark_x402_nonce|record_attestation_cost|get_pnl_stats|get_owner_pubkey|verify_usdc_transfer' core/src/` is empty. `SqliteStore::conn()` is public so mcp/src/payment.rs can build its own parameterized queries without bypassing the trait abstraction. The `AttestationStore` and `LineageStore` trait-level rustdoc explicitly states authorization is caller's responsibility.",
+    "Error messages are non-leaky. The deposit-rejected path no longer echoes owner_pubkey or tx_sig prefixes to clients (round-2 fix still in place at main.rs:264-275). Refund failures now log via `tracing::warn!` rather than being silently discarded with `let _ =`.",
+    "Transport separation is sensible. stdio transport (Claude Code local) skips the payment gate entirely (`main.rs:437-477`) — correct since local stdio clients are by definition trusted and there is no network exposure. HTTP transport applies payment gate to `mnemonic_sign_memory` only when `payment_mode != none` AND `storage_mode != local` — other tools (whoami, verify, prove_identity, recall) are gated at zero cost, preventing grief-free scraping of the attestation search endpoint without also allowing free signing."
+  ],
+  "residual_risks_accepted_as_followups": [
+    "CORS allow_origin(Any) on all routes (pre-existing, tracked in task-1 and task-11 round-2 follow-ups)",
+    "/admin/stats has no authentication (pre-existing, tracked in task-1 and task-11 round-2 follow-ups)",
+    "Keypair file written without explicit chmod 0o600 (pre-existing in identity::load_or_create_keypair, flagged in task-1 round-1 and reiterated here — should become an explicit follow-up line item for pre-production)",
+    "OpenAIEmbedder uses reqwest::blocking in async context (pre-existing, tracked in task-1 round-1 follow-ups)",
+    "WAL/SHM file permissions depend on process umask (noted in task-11 round-3 as deployment doc gap)",
+    "Auto-dedup migration of legacy duplicate tx_sig rows is silent — no tracing::warn! when rows are removed (noted in task-11 round-3 as a minor logging gap)",
+    "SOLANA_RPC_URL and ARWEAVE_URL loaded from env with no scheme/hostname allowlist (pre-existing SSRF-adjacent gap from task-1 round-1; operator-controlled input, still tracked)",
+    "turboquant-plus-rs 0.1.0 is a low-history self-published crate (supply-chain monitoring item from task-1 round-1)"
+  ],
+  "notes": "The final state resolves every substantive issue raised during the per-task security reviews (TOCTOU on credit_deposit and deduct_balance, weak random_bytes fallback, deposit 403 info leak, refund tx_sig collision, deduct_balance audit-trail atomicity, legacy-DB migration safety). The payment-integrity property — balance cannot be overdrawn, deposits cannot be applied twice, every balance mutation has a matching audit row that is written atomically with the mutation — is now provably correct under concurrency, with multithreaded tests that exercise a shared file-backed DB via Barrier-synchronized threads.\n\nThe remaining findings are a mix of (a) pre-existing items that predate the refactor and were explicitly deferred as follow-ups (CORS, admin auth, keypair permissions, OpenAI blocking client, WAL file permissions, SSRF-adjacent URL validation) and (b) two additional minor items that surfaced during the holistic review: OpenAI embed zero-fill on failure (integrity gap, could become a signature footgun under adversarial network conditions) and the x402 error messages echoing the tx_sig to clients (minor info-disclosure / log-correlation handle).\n\nNo critical or major findings. Verdict is issues-found because of the four minor items, but every finding is either a pre-existing deferred item tracked in decisions.md or a narrow nit with no immediate exploitation path. The refactor itself introduced no new vulnerabilities: it moved code into core/ without expanding the trust-boundary surface, it correctly isolated payment logic in mcp/, and it materially improved payment atomicity and nonce handling. The feature is safe to ship for a single-operator self-hosted deployment; production-grade multi-tenant or public-internet deployment should close the four minor items (keypair permissions, OpenAI blocking client, admin auth, CORS allowlist) first.\n\nAudit covered all files in core/src/ and mcp/src/ as well as Cargo.toml / Cargo.lock. OWASP Top 10 2021 coverage: A01 (deferred admin_stats), A02 (keypair permissions minor, random_bytes resolved), A03 (no findings — all SQL parameterized), A04 (TOCTOU resolved, OpenAI blocking DoS minor), A05 (deferred CORS, deferred WAL perms), A06 (no findings — all deps current), A07 (no findings), A08 (OpenAI zero-fill on failure minor), A09 (x402 tx_sig echo nit), A10 (deferred URL validation). Cryptography: COSE_Sign1 + Ed25519 + blake3 + canonical CBOR implementation is correct and deterministic."
+}

--- a/work/mnemonic-core/logs/working/audit/test-auditor.json
+++ b/work/mnemonic-core/logs/working/audit/test-auditor.json
@@ -1,0 +1,226 @@
+{
+  "auditor": "test-auditor",
+  "task": 15,
+  "agent": "test-master",
+  "verdict": "issues-found",
+  "scope": "test-quality-and-coverage-final-state",
+  "summary": "83 tests registered (75 lib unit + 5 integration_cbor + 3 proptest_canonical), all passing. Test pyramid is healthy (~90.4% unit). All eleven acceptance criteria are passing or partial; none are full FAIL on count. The qualitative audit, however, surfaces one major and several minor quality gaps that the count-based criteria mask: (1) storage tests use the concrete `SqliteStore` directly and are NOT contract tests against `&dyn AttestationStore` / `&dyn LineageStore` as the spec requires; (2) the compress MSE threshold is a hardcoded magic number `0.05` rather than a named `const MAX_ROUNDTRIP_MSE` as the spec requires; (3) two compress edge-case tests (`test_compress_empty_embedding`, `test_compress_single_element`) wrap the call in `catch_unwind` and then discard the result with `let _ = result;` — they pass regardless of whether the implementation panics, succeeds, or returns garbage (litmus-test failures, Category 1 empty tests); (4) concurrent-SQLite-access coverage exists for the payment tables in mcp but is missing for the `AttestationStore` / `LineageStore` surface in core; (5) the lineage MAX_DEPTH=64 boundary test is missing (cycle detection covers a 3-node loop but does not verify the 64- vs 65-node boundary); (6) the lineage cycle-detection test does not exercise a direct self-reference (A->A); (7) `test_network_timeout` in arweave is misnamed (verified in code-auditor task 13). No test contains a real mainnet URL, no funded keypair, no `#[ignore]` directives. Both benchmark files are correctly wired to the criterion harness with no network deps. MockEmbedder is correctly `#[cfg(test)]`-gated and returns deterministic L2-normalized vectors. Verdict: issues-found, but all test code that exists is real, the test suite is comprehensive enough to ship, and no finding is blocking pre-deploy QA.",
+  "files_reviewed": [
+    "core/src/codec/mod.rs",
+    "core/src/codec/schema.rs",
+    "core/src/codec/canonical.rs",
+    "core/src/codec/hash.rs",
+    "core/src/codec/sign.rs",
+    "core/src/identity/mod.rs",
+    "core/src/embed/mod.rs",
+    "core/src/compress/mod.rs",
+    "core/src/storage/traits.rs",
+    "core/src/storage/sqlite.rs",
+    "core/src/arweave/mod.rs",
+    "core/src/solana/mod.rs",
+    "core/src/lineage/mod.rs",
+    "core/tests/integration_cbor.rs",
+    "core/tests/proptest_canonical.rs",
+    "core/benches/decompress.rs",
+    "core/benches/cbor_codec.rs",
+    "core/Cargo.toml"
+  ],
+  "test_counts": {
+    "by_module": {
+      "codec": 24,
+      "identity": 4,
+      "embed": 9,
+      "compress": 7,
+      "storage": 7,
+      "arweave": 6,
+      "solana": 8,
+      "lineage": 10
+    },
+    "lib_unit_tests": 75,
+    "integration_cbor": 5,
+    "proptest_canonical": 3,
+    "total_registered": 83,
+    "unit_percent_of_total": 90.4,
+    "passed": 83,
+    "failed": 0,
+    "ignored": 0
+  },
+  "criteria_results": [
+    {
+      "id": 1,
+      "criterion": "MockEmbedder is #[cfg(test)]-gated and returns deterministic normalized vectors -- no real fastembed in unit tests",
+      "verdict": "PASS",
+      "evidence": "core/src/embed/mod.rs:122-146 -- struct, impl MockEmbedder, and impl Embedder for MockEmbedder are all #[cfg(test)]-gated. embed() is deterministic (sequential floats), unit-normalized via l2_normalize(), zero-dim returns empty vec. Tests `mock_embedder_unit_norm` (asserts norm ~= 1.0) and `mock_embedder_deterministic` (asserts equal output for repeated input) verify the contract. No #[cfg(test)] block in core/src/ imports FastEmbedder; the only fastembed usage is in `build_embedder` behind `#[cfg(feature = \"local-embed\")]`."
+    },
+    {
+      "id": 2,
+      "criterion": "Arweave httpmock test count >= 6, all 6 scenarios present (write, read, write_bytes, health_check, timeout, malformed)",
+      "verdict": "PASS",
+      "evidence": "core/src/arweave/mod.rs:283-372 -- 6 #[tokio::test] functions: test_write_success (line 286), test_read_success (line 305), test_write_bytes_success (line 320), test_health_check_success (line 336), test_network_timeout (line 348), test_malformed_json_response (line 360). All use `MockServer::start()` with dynamic ports; no real Irys URL appears in any test (the `uploader.irys.xyz` matches in the file are at line 23 (production default URL constant) and line 3 (module doc comment), both in non-test code). Note: test_network_timeout is misnamed -- it actually exercises the arlocal path (is_local=true, bypass=false) and not the Irys path -- already documented as a nit by code-auditor (task 13)."
+    },
+    {
+      "id": 3,
+      "criterion": "Solana httpmock test count >= 7, all 7 scenarios present (write_memo, read_memo, airdrop, get_tx_signers, confirm_tx retry, health_check, RPC error)",
+      "verdict": "PASS",
+      "evidence": "core/src/solana/mod.rs:199-330 -- 8 #[tokio::test] functions: test_write_memo_success, test_read_memo_success, test_read_memo_not_found, test_airdrop_success, test_get_tx_signers, test_confirm_tx_retry_exhaustion (uses #[tokio::test(start_paused = true)] for virtual time), test_health_check_ok, test_rpc_error_handling. All 7 required scenarios covered plus a bonus (read_memo_not_found). No real mainnet/devnet RPC URLs found in test code; all clients use `MockServer::start().base_url()`. All test keypairs are `Keypair::new()` (ephemeral)."
+    },
+    {
+      "id": 4,
+      "criterion": "Storage contract tests >= 4, exercising both AttestationStore and LineageStore trait methods",
+      "verdict": "PARTIAL",
+      "evidence": "core/src/storage/sqlite.rs:301-401 -- 7 tests present (test_save_and_find_by_tx, test_count_by_signer, test_search_ranking, test_find_by_tx_not_found, test_duplicate_attestation_id, test_lineage_save_and_get, test_lineage_clear). Count >= 4 PASSES. However, every test calls methods directly on the concrete `SqliteStore` (e.g. `store.save_attestation(...)`, `store.save_edge(...)`) rather than through `&dyn AttestationStore` / `&dyn LineageStore` references. The tech spec explicitly states: 'cast it to `&dyn AttestationStore` and `&dyn LineageStore`, and call each trait method through the trait reference (not the concrete type). This ensures the trait object is usable.' These are NOT contract tests -- they are concrete-impl tests. A future implementor of either trait would gain no compile-time or behavioral assurance from this suite. See finding TEST-STORAGE-CONTRACT-1 below."
+    },
+    {
+      "id": 5,
+      "criterion": "Edge cases present for embed (empty, zero-dim), compress (zero-len, single-elem), storage (concurrent, no-results, duplicate), arweave/solana (malformed, 5xx, timeout), lineage (cycle, MAX_DEPTH)",
+      "verdict": "PARTIAL",
+      "evidence": "PRESENT: embed::tests::empty_string_input (line 271), embed::tests::zero_dimension_configuration (line 280), compress::tests::test_compress_empty_embedding (line 210), compress::tests::test_compress_single_element (line 219), storage::sqlite::tests::test_find_by_tx_not_found (line 356), storage::sqlite::tests::test_duplicate_attestation_id (line 363), arweave::tests::test_malformed_json_response (line 360) and test_network_timeout (line 348), solana::tests::test_rpc_error_handling (line 315), lineage::tests::test_cycle_detection (line 313, A->B->C and attempt to add cycle). MISSING: (a) Concurrent SQLite-access test on AttestationStore/LineageStore. The payment-side (mcp/src/payment.rs) has three barrier-synchronized concurrent tests against api_keys + payment_events but the core attestations + artifact_lineage tables have NO concurrent test. (b) MAX_DEPTH=64 boundary -- no test inserts a 64-node chain (must succeed) or a 65-node chain (must return depth-exceeded). (c) Direct self-reference cycle (A->A) -- cycle test only covers transitive A->B->C->A pattern. (d) HTTP 5xx scenario for arweave/solana -- timeout and malformed-JSON are present, explicit 500/503 responses are not. (e) compress empty/single-element tests are present by name but assert nothing meaningful (see TEST-COMPRESS-EDGE-1 below)."
+    },
+    {
+      "id": 6,
+      "criterion": "Lineage test count = 10 (9 original + 1 error propagation); all use Direction enum and Option<bool> chain_valid",
+      "verdict": "PASS",
+      "evidence": "core/src/lineage/mod.rs:262-382 -- 10 #[test] functions (test_record_and_get_parents, test_get_children, test_validate_parents_ok, test_validate_parents_not_found, test_validate_too_many_parents, test_cycle_detection, test_no_false_cycle, test_root_artifact_empty_parents, test_traverse_ancestors, test_db_error_propagation). test_traverse_ancestors uses `Direction::Ancestors` enum variant (line 358) and asserts `result.chain_valid == None` (line 364). test_db_error_propagation opens a Connection without the schema, calls get_parents and traverse_lineage, asserts both return Err -- correctly verifying error propagation per the round-2 contract. No string-literal direction usage anywhere."
+    },
+    {
+      "id": 7,
+      "criterion": "Compress MSE fidelity test present with named threshold constant",
+      "verdict": "FAIL",
+      "evidence": "core/src/compress/mod.rs:198-207 -- test_compress_roundtrip_mse exists and computes MSE correctly. However, the threshold is the literal `0.05`: `assert!(mse < 0.05, \"MSE {mse} exceeds 0.05 threshold for 384-dim 4-bit\");`. The tech spec explicitly requires: 'Threshold constant should be named (e.g., `const MAX_ROUNDTRIP_MSE: f32 = 0.01`).' Decisions.md task 5 acknowledges: 'MSE threshold set to 0.05 instead of 0.01 (spec target) because 4-bit quantization on this vector produces MSE ~0.029.' The numeric value is reasonable; the absence of a named constant is the violation. Two other tests also use magic number thresholds: test_compress_decompress_roundtrip uses `mse < 0.1` (line 163) and test_compression_ratio uses `ratio > 3.0` (line 184)."
+    },
+    {
+      "id": 8,
+      "criterion": "core/tests/integration_cbor.rs and core/tests/proptest_canonical.rs exist",
+      "verdict": "PASS",
+      "evidence": "Both files exist and pass. integration_cbor.rs: 5 tests (test_full_sign_verify_roundtrip, test_determinism_across_multiple_keypairs, test_all_artifact_schemas, test_cbor_is_smaller_than_json, test_tampered_cose_detected). proptest_canonical.rs: 3 proptests (canonical_cbor_is_deterministic, different_content_different_hash, sign_artifact_content_hash_matches_blake3_of_canonical_cbor). All 8 imported via `mnemonic_core::codec::*` (no inline helper duplication). `cargo test -p mnemonic-core` -> 5 + 3 = 8 passed."
+    },
+    {
+      "id": 9,
+      "criterion": "core/benches/decompress.rs and core/benches/cbor_codec.rs use criterion harness, no network deps",
+      "verdict": "PASS",
+      "evidence": "core/benches/decompress.rs:34-35 -- `criterion_group!(benches, bench_decompress); criterion_main!(benches);`. core/benches/cbor_codec.rs:87-94 -- `criterion_group!(benches, bench_cbor_canonicalization, bench_blake3_hash, bench_cose_sign, bench_full_pipeline); criterion_main!(benches);`. core/Cargo.toml [[bench]] entries both have `harness = false`. No reqwest/http/network imports in either file -- only `criterion`, `mnemonic_core::codec::*`, `mnemonic_core::compress::*`, and `solana_sdk::Keypair`. `cargo bench -p mnemonic-core --no-run` -> both bench binaries compiled cleanly."
+    },
+    {
+      "id": 10,
+      "criterion": "No #[ignore] without justification comment",
+      "verdict": "PASS",
+      "evidence": "`grep -rn '#\\[ignore\\]' core/src/ core/tests/` -> no matches. The audit criterion is vacuously satisfied because there are no #[ignore] tests at all in the audit scope."
+    },
+    {
+      "id": 11,
+      "criterion": "Unit tests > 70% of total test count (pyramid balance)",
+      "verdict": "PASS",
+      "evidence": "75 lib unit tests / 83 total = 90.4%. Above the 70% threshold. Distribution: 75 unit (lib.rs unittests) + 5 integration (tests/integration_cbor.rs) + 3 proptest (tests/proptest_canonical.rs) = 83. 0 E2E (acceptable per spec). 0 doc-tests (acceptable -- core is not a documented public-API crate yet)."
+    },
+    {
+      "id": 12,
+      "criterion": "No test file contains real mainnet URLs or funded keypairs",
+      "verdict": "PASS",
+      "evidence": "`grep -rn 'uploader.irys.xyz\\|mainnet.*solana\\|api.mainnet-beta' core/` -> only 2 matches, both in core/src/arweave/mod.rs at line 3 (module doc comment describing production behavior) and line 23 (default `upload_url` field value in `ArweaveClient::new`). Neither is inside a #[cfg(test)] block. All test clients are constructed with `MockServer::start()` (dynamic 127.0.0.1 port) or for solana via `SolanaClient::new(server.base_url())`. All test keypairs are `Keypair::new()` (ephemeral). No funded-keypair seeds, no hardcoded secret bytes, no `Keypair::from_bytes(&[...])` with embedded private material."
+    }
+  ],
+  "findings": [
+    {
+      "id": "TEST-STORAGE-CONTRACT-1",
+      "severity": "major",
+      "title": "Storage tests are concrete-impl tests, not trait contract tests",
+      "location": "core/src/storage/sqlite.rs:301-401",
+      "category": "wrong_test_type",
+      "description": "All seven tests in `storage::sqlite::tests` invoke methods on the concrete `SqliteStore` value (e.g. `let store = SqliteStore::in_memory().unwrap(); store.save_attestation(...);`). They never cast the store to `&dyn AttestationStore` or `&dyn LineageStore` and never call methods through the trait reference. The tech spec explicitly defines storage tests as contract tests in section 'Audit storage contract tests': 'cast it to `&dyn AttestationStore` and `&dyn LineageStore`, and call each trait method through the trait reference (not the concrete type). This ensures the trait object is usable.' The current tests will pass even if a future trait method is added that the SqliteStore impl forgot to override (because the inherent impl shadows the trait), and a future second backend (e.g. PostgresStore) gets zero contract guarantees from the existing suite. This is a Category 4 pyramid violation: trait abstraction without trait-level testing.",
+      "recommendation": "Refactor each test to bind the store via the trait reference. Concrete pattern for `test_save_and_find_by_tx`:\n```rust\nlet store = SqliteStore::in_memory().unwrap();\nlet attestations: &dyn AttestationStore = &store;\nattestations.save_attestation(\"att-1\", \"content\", ...).unwrap();\nlet found = attestations.find_by_tx(\"sol_tx_1\").unwrap();\nassert!(found.is_some());\n```\nApply the same pattern to test_lineage_save_and_get and test_lineage_clear (cast to `&dyn LineageStore`). Add at least one new test that exercises BOTH trait references on the same store value to guarantee a single backend can satisfy both contracts simultaneously: `let store = SqliteStore::in_memory().unwrap(); let a: &dyn AttestationStore = &store; let l: &dyn LineageStore = &store; a.save_attestation(...); l.save_edge(...);`. Litmus test for the new tests: removing one of the trait impls (or making a method signature drift from the trait) must cause compile failure, not silent shadow-binding to the inherent impl."
+    },
+    {
+      "id": "TEST-COMPRESS-MSE-CONST-1",
+      "severity": "major",
+      "title": "Compress MSE roundtrip threshold is a magic number, not a named constant",
+      "location": "core/src/compress/mod.rs:206 (also lines 163, 184)",
+      "category": "anti_pattern",
+      "description": "The acceptance criterion #7 explicitly requires: 'Compress MSE fidelity test present with named threshold constant'. The current test contains `assert!(mse < 0.05, \"MSE {mse} exceeds 0.05 threshold for 384-dim 4-bit\");` -- the literal `0.05` is duplicated inside the assertion expression and the format string. If a future contributor tightens the bound (or quantization improves and the bound can be tightened), they must edit two places. There is also no documentation of what 0.05 represents semantically -- it appears in decisions.md as 'spec target was 0.01 but 4-bit on this vector produces ~0.029' but the source code itself does not capture that rationale. Two adjacent tests have the same anti-pattern: test_compress_decompress_roundtrip uses `mse < 0.1` (line 163), test_compression_ratio uses `ratio > 3.0` (line 184). This is a Category 6 anti-pattern (magic values).",
+      "recommendation": "Add to the top of `core/src/compress/mod.rs` (or in the inline tests module if the constant is test-only):\n```rust\n/// Maximum acceptable mean-squared error after a compress/decompress roundtrip\n/// for a 384-dim embedding compressed with 4-bit MSE quantization.\n///\n/// 0.05 reflects the actual measured ceiling for `turboquant_plus_rs::TurboQuant`\n/// on the deterministic seeded sample vector (`(i as f32 * 0.007).sin()`); the\n/// observed MSE is approximately 0.029 (decisions.md task 5). Tightening below\n/// 0.029 would require a higher bit-width or a different quantizer.\nconst MAX_ROUNDTRIP_MSE_4BIT_384: f32 = 0.05;\n```\nReplace `mse < 0.05` with `mse < MAX_ROUNDTRIP_MSE_4BIT_384` and update the format string to interpolate the constant. Apply the same treatment to `MAX_ROUNDTRIP_MSE_GENERIC: f32 = 0.1` (test_compress_decompress_roundtrip) and `MIN_COMPRESSION_RATIO_4BIT: f32 = 3.0` (test_compression_ratio). Litmus test: removing the actual `c.compress(&original); c.decompress(&compressed);` calls must still cause the test to fail -- it does today (the assertion would compare uninitialized data), but a named constant makes the failure mode explicit if someone refactors."
+    },
+    {
+      "id": "TEST-COMPRESS-EDGE-1",
+      "severity": "major",
+      "title": "compress empty/single-element edge-case tests assert nothing (litmus-test failures)",
+      "location": "core/src/compress/mod.rs:209-225",
+      "category": "empty_test",
+      "description": "Both `test_compress_empty_embedding` and `test_compress_single_element` follow this exact pattern:\n```rust\n#[test]\nfn test_compress_empty_embedding() {\n    let result = std::panic::catch_unwind(|| {\n        let c = EmbeddingCompressor::new(0, 4, 42);\n        c.compress(&[]);\n    });\n    let _ = result; // documents behavior without asserting panic/success\n}\n```\nThe test catches any panic, then immediately discards the `Result<(), Box<dyn Any>>` with `let _ = result;`. The test passes whether the implementation panics, returns garbage, hangs (well, then it wouldn't return at all, but the assertion logic is identical), or works correctly. Litmus test: replace the body of `EmbeddingCompressor::compress` with `panic!(\"forced\")` -- both tests STILL PASS because catch_unwind catches the panic and the result is discarded. Replace the body with `std::process::exit(0)` -- tests PASS (well, the process exits cleanly so the test runner reports success). The comment `// documents behavior without asserting panic/success` is honest about the intent but the result is a Category 1 empty test: the test exists for coverage-line accounting but provides zero regression guarantee.",
+      "recommendation": "Decide what the contract is and assert it. Two reasonable choices:\n\nOption (a) -- 'must not panic, may return garbage':\n```rust\n#[test]\nfn test_compress_empty_embedding_does_not_panic() {\n    let c = EmbeddingCompressor::new(0, 4, 42);\n    let compressed = c.compress(&[]); // must return without panicking\n    assert_eq!(compressed.dim, 0);\n    assert_eq!(compressed.mse_indices_packed.len(), 0);\n}\n```\n\nOption (b) -- 'must return Err' (requires changing the API to fallible):\n```rust\n#[test]\nfn test_compress_empty_embedding_returns_err() {\n    let c = EmbeddingCompressor::new(0, 4, 42);\n    let result = c.try_compress(&[]);\n    assert!(matches!(result, Err(CompressError::ZeroDim)));\n}\n```\n\nOption (a) is the lower-risk change because it does not require a public API change. If the actual current behavior is to panic, the test must use `std::panic::catch_unwind` AND assert the result is `Err`: `assert!(result.is_err(), \"expected panic on zero-dim, got Ok\");` -- the current `let _ = result;` provides no signal either way. Apply the same fix to test_compress_single_element."
+    },
+    {
+      "id": "TEST-STORAGE-CONCURRENT-1",
+      "severity": "minor",
+      "title": "No concurrent-access test for AttestationStore / LineageStore on a shared file-backed DB",
+      "location": "core/src/storage/sqlite.rs (tests module) -- gap",
+      "category": "missing_coverage",
+      "description": "Acceptance criterion #5 explicitly lists 'storage (concurrent, no-results, duplicate)' as a required edge case. mcp/src/payment.rs has three multithreaded tests for the payment tables (`credit_deposit_concurrent_same_tx_sig_applies_once`, `deduct_balance_concurrent_cannot_overdraw`, `deduct_balance_audit_insert_failure_rolls_back_balance`) using barrier-synchronized threads against a `SqliteStore::open(path)` shared file. But the AttestationStore / LineageStore surface in core has zero concurrent-access coverage. The WAL + busy_timeout pragmas configured in `SqliteStore::open` (sqlite.rs:114-130) were added as a pre-emptive concurrency hardening for the payment side; whether they hold for `save_attestation` + `search` (which use the same Connection mutex pattern) is untested.",
+      "recommendation": "Add one test under `storage::sqlite::tests`:\n```rust\n#[test]\nfn test_concurrent_save_attestation_two_writers_same_file() {\n    let tmp = tempfile::NamedTempFile::new().unwrap();\n    let path = tmp.path().to_path_buf();\n    let n = 50;\n    let barrier = std::sync::Arc::new(std::sync::Barrier::new(2));\n    let p1 = path.clone(); let b1 = barrier.clone();\n    let p2 = path.clone(); let b2 = barrier.clone();\n    let h1 = std::thread::spawn(move || {\n        let s = SqliteStore::open(&p1).unwrap();\n        b1.wait();\n        for i in 0..n { s.save_attestation(&format!(\"a-{i}\"), \"c\", \"h\", &[], &format!(\"sol-1-{i}\"), \"ar\", \"signer1\", \"2026-01-01\", &[1.0, 0.0]).unwrap(); }\n    });\n    let h2 = std::thread::spawn(move || {\n        let s = SqliteStore::open(&p2).unwrap();\n        b2.wait();\n        for i in 0..n { s.save_attestation(&format!(\"b-{i}\"), \"c\", \"h\", &[], &format!(\"sol-2-{i}\"), \"ar\", \"signer2\", \"2026-01-01\", &[1.0, 0.0]).unwrap(); }\n    });\n    h1.join().unwrap(); h2.join().unwrap();\n    let s = SqliteStore::open(&path).unwrap();\n    assert_eq!(s.count(\"signer1\").unwrap(), n);\n    assert_eq!(s.count(\"signer2\").unwrap(), n);\n}\n```\nLitmus test: removing the WAL pragma from `SqliteStore::open` (line 119) should make this test flake under `busy_timeout` exhaustion. Two concurrent writers with no WAL are a classic SQLITE_BUSY scenario."
+    },
+    {
+      "id": "TEST-LINEAGE-MAX-DEPTH-1",
+      "severity": "minor",
+      "title": "MAX_DEPTH=64 boundary test missing",
+      "location": "core/src/lineage/mod.rs (tests module) -- gap",
+      "category": "missing_coverage",
+      "description": "Acceptance criterion #5 lists 'lineage (cycle, MAX_DEPTH)' as required edge cases. cycle is covered (test_cycle_detection -- transitive A->B->C, attempt to add cycle). MAX_DEPTH is referenced in the implementation (lineage/mod.rs:128: `if depth > MAX_DEPTH { return Err(\"...\"); }` and traverse_lineage uses `max_depth: usize` as a parameter, line 190) but no test verifies the boundary. The tech spec is explicit: 'MAX_DEPTH boundary: insert a lineage chain of exactly MAX_DEPTH=64 nodes, verify traversal succeeds. Insert 65-node chain, verify it returns depth-exceeded error or truncates gracefully.' The current behavior is therefore unverified and a regression in MAX_DEPTH bookkeeping (off-by-one) would slip through.",
+      "recommendation": "Add two tests:\n```rust\n#[test]\nfn test_validate_at_max_depth_succeeds() {\n    let conn = setup_db();\n    // Build a chain of MAX_DEPTH=64 nodes: art:0 -> art:1 -> ... -> art:63\n    for i in 1..=MAX_DEPTH {\n        record_parents(&conn, &format!(\"art:{i}\"), &[ParentRef { artifact_id: format!(\"art:{}\", i-1), role: None }], \"t\").unwrap();\n    }\n    // Adding art:64 with parent art:63 produces a chain of length MAX_DEPTH+1; should error\n    let parents = vec![ParentRef { artifact_id: format!(\"art:{MAX_DEPTH}\"), role: None }];\n    let err = validate_parents(&conn, \"art:over_limit\", &parents, &mock_exists).unwrap_err();\n    assert!(err.contains(\"MAX_DEPTH\") || err.contains(\"depth\"), \"got: {err}\");\n}\n\n#[test]\nfn test_traverse_respects_max_depth_parameter() {\n    let conn = setup_db();\n    for i in 1..=10 {\n        record_parents(&conn, &format!(\"art:{i}\"), &[ParentRef { artifact_id: format!(\"art:{}\", i-1), role: None }], \"t\").unwrap();\n    }\n    let node_fn = |id: &str| Some(LineageNode { artifact_type: \"memory.v1\".into(), content_hash: format!(\"h_{id}\"), producer: \"t\".into(), created_at: \"2026\".into(), verified: true });\n    let r = traverse_lineage(&conn, \"art:10\", 3, Direction::Ancestors, &node_fn).unwrap();\n    assert!(r.depth_traversed <= 3);\n}\n```\nLitmus test for the first: changing `if depth > MAX_DEPTH` to `if depth > MAX_DEPTH + 1` (off-by-one) must cause the test to fail."
+    },
+    {
+      "id": "TEST-LINEAGE-SELF-REF-1",
+      "severity": "minor",
+      "title": "Lineage cycle-detection test does not exercise direct self-reference (A -> A)",
+      "location": "core/src/lineage/mod.rs:312-323 (test_cycle_detection)",
+      "category": "missing_coverage",
+      "description": "The current cycle test builds A->B->C and then attempts to add C as a parent of A (transitive cycle). It does NOT test the simplest cycle: a node listing itself as its own parent. The tech spec lists 'self-reference cycle detection' under edge cases (in the Details section: 'a lineage graph where node A points to B, B points to A. The traversal must not infinite-loop' AND in section 7 acceptance: 'self-reference cycle detection'). The transitive case is covered, the self case is not -- if `validate_parents` short-circuits on `parents.contains(&new_id)` rather than running the BFS, an off-by-one in the recursive guard could let `A -> A` slip through.",
+      "recommendation": "Add:\n```rust\n#[test]\nfn test_self_reference_is_cycle() {\n    let conn = setup_db();\n    let parents = vec![ParentRef { artifact_id: \"art:A\".into(), role: None }];\n    let err = validate_parents(&conn, \"art:A\", &parents, &mock_exists).unwrap_err();\n    assert!(err.contains(\"CYCLE_DETECTED\") || err.contains(\"SELF\"), \"got: {err}\");\n}\n```\nLitmus test: removing the `if parent.artifact_id == new_id { return Err(\"CYCLE_DETECTED: self-reference\") }` short-circuit (if any exists) must cause this test to fail. If validate_parents currently relies entirely on the BFS to detect this, the BFS path needs to handle the case where the BFS starts at the node it's checking against."
+    },
+    {
+      "id": "TEST-EMBED-EMPTY-STRING-WEAK-1",
+      "severity": "minor",
+      "title": "embed::tests::empty_string_input does not actually test the empty-string branch",
+      "location": "core/src/embed/mod.rs:271-277",
+      "category": "anti_pattern",
+      "description": "The test calls `MockEmbedder::new(64).embed(\"\")` and asserts the output is 64-dim and unit-norm. But MockEmbedder::embed (lines 134-141) ignores the `_text: &str` argument entirely -- the output is the same for `\"\"` as for any other input. The test therefore verifies the output dimension and norm of a fixed sequential vector, NOT the empty-string handling of the actual production embedders (FastEmbedder, OpenAIEmbedder), which is what an 'empty string input' edge case is supposed to verify. Litmus test: remove the empty-string test entirely; coverage of MockEmbedder behavior is unchanged because mock_embedder_correct_dimension (line 225) and mock_embedder_unit_norm (line 231) already cover the same assertions for non-empty input. The test name promises a behavioral guarantee the mock cannot provide.",
+      "recommendation": "Either (a) rename to `mock_embedder_ignores_input_text` and add a comment explaining it's only documenting the mock's deterministic behavior, OR (b) move this edge case into an integration-test or `#[cfg(feature = \"local-embed\")]` test that exercises FastEmbedder::embed(\"\") and asserts the real provider returns a non-NaN, finite, unit-norm 384-dim vector. Option (b) is correct per the spec but requires the local-embed compile failure (code-auditor critical finding) to be fixed first. Option (a) is the immediate correction. If kept, the test should also cross-check against a non-empty input to prove the empty case isn't special-cased: `assert_eq!(e.embed(\"\"), e.embed(\"non-empty\"));` -- this would be a more honest documentation of the mock's behavior."
+    },
+    {
+      "id": "TEST-ARWEAVE-TIMEOUT-MISNAMED-1",
+      "severity": "nit",
+      "title": "test_network_timeout exercises arlocal path, not Irys timeout",
+      "location": "core/src/arweave/mod.rs:347-357",
+      "category": "anti_pattern",
+      "description": "Already flagged as a nit in code-auditor task 13 finding (line 347-357 of arweave/mod.rs). The test points the client at `http://127.0.0.1:1` (a port nothing listens on), then asserts `health_check` returns false and `write_bytes` returns Err. Because is_local=true (loopback) and bypass_local_routing=false, the client takes the arlocal POST path -- so the test is exercising arlocal-server-unreachable, not Irys-upload-timeout. The name suggests the latter, the implementation does the former. Repeating here for completeness; not adding new content beyond what code-auditor already documented.",
+      "recommendation": "Either rename to `test_arlocal_unreachable_returns_err` or add a second test with `ArweaveClient::new_for_test(...)` (which sets bypass_local_routing=true) pointed at `http://127.0.0.1:1` so it actually hits the Irys path. The current test is correct as a smoke test of error propagation; only the name and intent comment mislead."
+    }
+  ],
+  "verification": {
+    "cargo_test_no_run": "pass -- 3 binaries compiled (lib unittests, integration_cbor, proptest_canonical)",
+    "cargo_test_list": "83 tests registered (75 + 5 + 3); see test_counts.by_module for distribution",
+    "cargo_test": "83 passed / 0 failed / 0 ignored",
+    "cargo_bench_no_run": "pass -- both bench binaries (decompress, cbor_codec) compiled",
+    "grep_mockembedder": "core/src/embed/mod.rs:122-146 -- struct, new(), and impl Embedder are #[cfg(test)] gated",
+    "grep_real_endpoints": "0 matches in #[cfg(test)] blocks; only matches are in non-test default-URL constant and module doc comment",
+    "grep_ignore_attribute": "0 matches in core/src/ and core/tests/",
+    "grep_hashembedder": "0 matches in core/src/ (HashEmbedder fully removed in task 4)",
+    "grep_criterion_macros": "criterion_group + criterion_main both present in decompress.rs and cbor_codec.rs"
+  },
+  "strengths": [
+    "MockEmbedder is a textbook example of a #[cfg(test)] gated test double: deterministic, normalized output, configurable dim, returns empty vec for dim=0 instead of panicking, never compiled into release builds. Three tests verify the contract directly (dimension, norm, determinism) and two more test the cosine_similarity utility against MockEmbedder output.",
+    "Lineage test refactor is high quality. Direction is exercised through the enum variant (no string literals slipped through), chain_valid is asserted as `Option<bool>` with explicit `None` semantics, and test_db_error_propagation directly exercises the error-propagation contract by opening a Connection without the schema and asserting both get_parents and traverse_lineage surface Err. This is the negative-path test the round-2 fix in task 9 was designed to lock in.",
+    "Solana httpmock coverage is the strongest of any module. test_confirm_tx_retry_exhaustion uses `#[tokio::test(start_paused = true)]` to virtualize time so retry-with-backoff exhaustion runs in microseconds rather than the production retry budget. test_get_tx_signers exercises the full jsonParsed account-key walk. test_rpc_error_handling exercises the JSON-RPC `{\"error\": {...}}` shape. All keypairs are ephemeral.",
+    "Integration tests properly use library imports. integration_cbor.rs and proptest_canonical.rs both consume `mnemonic_core::codec::*` directly (no inline duplication of canonical CBOR / hash / sign helpers, no `#[path = \"...\"]` includes). This is the cleanest possible setup for an extracted-crate integration suite.",
+    "Benchmark hygiene is correct. Both bench files use criterion_group + criterion_main, declare `harness = false` in core/Cargo.toml, isolate measured stages from setup (cose_sign pre-computes canonical CBOR outside b.iter), use `black_box` consistently, and have zero network or filesystem I/O. cbor_codec.rs even isolates four stages (canonicalize, hash, COSE sign, full pipeline) into separate groups.",
+    "Test pyramid is healthily inverted toward unit tests (90.4% unit). No E2E tests, which is correct for a core crate (E2E lives at the mcp boundary). Five integration tests for the full sign->verify->tamper roundtrip and three proptests for canonical-cbor / blake3 invariants is the right amount of coverage at the integration layer.",
+    "No #[ignore] tests anywhere in the audit scope. The earlier follow-up note in task-11 round-2 about a 'cold-init timing regression guard (#[ignore] perf test)' was deferred and not added -- so the codebase has zero #[ignore] debt, which is unusual and worth noting positively."
+  ],
+  "residual_risks_accepted_as_followups": [
+    "Storage tests do not cast to trait references (TEST-STORAGE-CONTRACT-1) -- not blocking pre-deploy but should be addressed before any second backend (PostgresStore, RemoteStore) is added; in the meantime the trait abstraction provides no contract guarantee.",
+    "Compress MSE threshold remains a magic number (TEST-COMPRESS-MSE-CONST-1) -- cosmetic refactor, no behavioral impact; the test still detects MSE regressions, just with a less self-documenting failure message.",
+    "compress empty/single-element edge tests pass under any implementation (TEST-COMPRESS-EDGE-1) -- if the goal is just to document that the calls don't hang the test runner, the current code accomplishes that; if the goal is regression detection, it does not.",
+    "Concurrent SQLite access not covered for the AttestationStore / LineageStore tables (TEST-STORAGE-CONCURRENT-1) -- payment side is fully covered, attestation side is implicitly covered by the same Connection mutex but not directly tested.",
+    "MAX_DEPTH=64 boundary not directly tested (TEST-LINEAGE-MAX-DEPTH-1) -- the implementation has the guard, the spec lists it as required, no test verifies the off-by-one.",
+    "Direct self-reference cycle (A->A) not tested (TEST-LINEAGE-SELF-REF-1) -- transitive cycle is tested.",
+    "embed::tests::empty_string_input is misnamed for what it actually verifies (TEST-EMBED-EMPTY-STRING-WEAK-1) -- the mock ignores its input text, so the test is really mock_embedder_with_zero_length_input."
+  ],
+  "notes": "Audit ran in /home/claude/.openclaw/workspace/mnemonic-refactored/work/mnemonic-core. No code changes were made. The eight findings above are all post-extraction quality gaps that the count-based acceptance criteria masked: the count-based gates are passing or partial (5 of 12 are partial-due-to-edge-case-gaps, 7 of 12 are full PASS, 1 of 12 is FAIL on the named-constant criterion #7). Verdict is issues-found rather than blocking because (a) all 83 tests pass on the default cargo test invocation, (b) every required scenario from acceptance #2 (arweave 6/6) and #3 (solana 8/7+) is present and meaningful, (c) the lineage refactor is comprehensively tested with both happy and error paths, (d) MockEmbedder is correctly gated and the test pyramid is healthy. The two non-trivial findings to address before pre-deploy QA (task 16) verifies the audit fixes are: TEST-STORAGE-CONTRACT-1 (the trait-vs-concrete issue is structural and the cleanest moment to fix it is now, before any external code depends on the AttestationStore/LineageStore traits) and TEST-COMPRESS-EDGE-1 (the empty-test pattern in compress is the only litmus-test failure in the suite -- every other test has a real assertion). Both can be addressed by editing existing test functions; no new test infrastructure is required."
+}

--- a/work/mnemonic-core/logs/working/task-1/code-reviewer-1.json
+++ b/work/mnemonic-core/logs/working/task-1/code-reviewer-1.json
@@ -1,0 +1,24 @@
+{
+  "task": 1,
+  "reviewer": "code-reviewer",
+  "round": 1,
+  "status": "approved",
+  "findings": [
+    {
+      "severity": "minor",
+      "location": "mcp/Cargo.toml:16-37",
+      "description": "mcp/Cargo.toml retains many dependencies that are also declared in core/Cargo.toml (solana-sdk, spl-memo, bs58, sha2, hex, base64, rusqlite, bincode, chrono, anyhow, thiserror, uuid, serde, serde_json, reqwest, futures, ciborium, coset, blake3, ndarray). These are legitimately kept for now because mcp/src/ still contains the full domain source files (compress.rs, embed.rs, db.rs, etc.) awaiting extraction in Tasks 2-9. This is expected for a scaffold task, but the duplication should be cleaned up progressively as each module is extracted. No action required in this task."
+    },
+    {
+      "severity": "minor",
+      "location": "core/Cargo.toml:6",
+      "description": "core/Cargo.toml includes a 'description' field which is good practice. However, the [lib] section at line 7 is declared with no explicit 'name' or 'path' — this relies on Cargo's convention of deriving the lib name from the package name ('mnemonic-core' → crate name 'mnemonic_core'). This is correct and idiomatic but worth noting that future consumers import it as 'mnemonic_core::'. No change needed."
+    },
+    {
+      "severity": "minor",
+      "location": "patterns.md (project patterns reference)",
+      "description": "patterns.md states: 'All providers implement the Embedder trait in core/src/embed/mod.rs. Never call a concrete provider directly from business logic — always go through the trait. This keeps the hash fallback and WASM-safe stub transparent to callers.' The phrase 'hash fallback' refers to HashEmbedder which the tech-spec and user-spec both mandate removing in Task 4. The patterns.md itself is flagged in Task 12 for cleanup. This is a documentation inconsistency that will be resolved in a later task — not a code defect in this task's scope."
+    }
+  ],
+  "summary": "All five focus areas pass review. (1) Workspace root Cargo.toml is correctly structured with members=[\"core\",\"mcp\"] and resolver=\"2\", no [package] section present. (2) core/Cargo.toml contains all 20 required dependencies from the tech-spec dependency list including turboquant-plus-rs=\"0.1.0\", tokio with [time,rt], fastembed as optional under local-embed feature, and all dev-dependencies (httpmock, tempfile, proptest, criterion, tokio with macros+rt-multi-thread). (3) Both turboquant:: occurrences in mcp/src/compress.rs are correctly renamed to turboquant_plus_rs:: — line 8 (use statement) and line 158 (CompressedVectors struct literal) — and no legacy turboquant:: references remain anywhere in mcp/src/. (4) mcp/Cargo.toml correctly adds mnemonic-core={path=\"../core\"}, adds turboquant-plus-rs=\"0.1.0\", and removes solana-client=\"2.2\" and solana-transaction-status=\"2.2\" (confirmed these were not used in any mcp/src/ file other than the source solana.rs — grep across mcp/src/ returns no matches for either crate). (5) core/src/lib.rs declares exactly 8 pub mod stubs matching the required set: codec, identity, embed, compress, storage, arweave, solana, lineage. Each has a corresponding empty core/src/<module>/mod.rs file present. The scaffold is clean and ready for Wave 2 extraction tasks."
+}

--- a/work/mnemonic-core/logs/working/task-1/security-auditor-1.json
+++ b/work/mnemonic-core/logs/working/task-1/security-auditor-1.json
@@ -1,0 +1,99 @@
+{
+  "task": 1,
+  "reviewer": "security-auditor",
+  "round": 1,
+  "status": "approved",
+  "findings": [
+    {
+      "severity": "major",
+      "category": "A01: Broken Access Control",
+      "title": "Admin stats endpoint lacks authentication",
+      "location": "mcp/src/main.rs:289-321",
+      "description": "GET /admin/stats exposes P&L data (attestation counts, revenue, cost breakdown) with no authentication check. Any unauthenticated caller who can reach the HTTP port can read this financial data. The route is registered at the router level with no middleware guard.",
+      "impact": "Exposure of business-sensitive financial and operational metrics to any network peer that can reach the MCP port. In a cloud deployment with a public IP this is a direct information leak.",
+      "recommendation": "Gate /admin/stats behind a pre-shared admin token checked in a middleware or in the handler itself, e.g. validate an Authorization header against a value loaded from env (ADMIN_TOKEN). Alternatively, bind the admin endpoints to a separate listener on a non-public interface.",
+      "cwe": "CWE-306"
+    },
+    {
+      "severity": "major",
+      "category": "A05: Security Misconfiguration",
+      "title": "CORS configured to allow all origins, methods, and headers",
+      "location": "mcp/src/main.rs:487-491",
+      "description": "The Axum CORS layer is configured with .allow_origin(Any).allow_methods(Any).allow_headers(Any). This means any browser page on the internet can make credentialed cross-origin requests to the MCP server. For a server that handles payments and attestation signing, this is a significant misconfiguration.",
+      "impact": "A malicious web page can trigger sign_memory or deposit calls from a victim's browser context, or read balance information, if the victim has the MCP server accessible on a local port (common in dev). For publicly deployed servers this widens the attack surface substantially.",
+      "recommendation": "Restrict allowed origins to a known list (e.g. only the dashboard domain). If wildcard is needed for developer convenience, guard it behind a build-time feature flag and ensure it is never used in production. At minimum restrict allowed methods to POST for /mcp and GET for /balance.",
+      "cwe": "CWE-942"
+    },
+    {
+      "severity": "major",
+      "category": "A10: SSRF",
+      "title": "ArweaveClient base_url accepted from environment with no validation — SSRF risk",
+      "location": "mcp/src/arweave.rs:18-23, mcp/src/config.rs:54",
+      "description": "ARWEAVE_URL is loaded directly from environment and passed into ArweaveClient::new() without validation. The is_local() check at line 70 only decides between arlocal and Irys code paths — it does not prevent an operator-supplied URL that points to an internal network endpoint (e.g. http://169.254.169.254/ on AWS, http://metadata.google.internal/ on GCP). While this is operator-controlled and not directly user-controlled, a misconfigured or compromised deployment variable becomes an SSRF vector. Additionally, SOLANA_RPC_URL has the same property.",
+      "impact": "If an attacker can influence ARWEAVE_URL or SOLANA_RPC_URL (e.g. via a compromised secrets manager, a CI/CD injection, or a misconfigured .env), the server will make HTTP requests to arbitrary internal hosts, potentially leaking cloud metadata or accessing internal services.",
+      "recommendation": "Validate the URL scheme (must be https in production, or http only for localhost/127.0.0.1) and optionally allowlist valid hostnames. Log a startup warning if a non-HTTPS Arweave URL is configured in non-local mode.",
+      "cwe": "CWE-918"
+    },
+    {
+      "severity": "major",
+      "category": "A02: Cryptographic Failures",
+      "title": "Keypair stored as plain JSON array on disk with no file permission enforcement",
+      "location": "mcp/src/identity.rs:17-19",
+      "description": "load_or_create_keypair writes the 64-byte Ed25519 private key as a JSON array using std::fs::write, which creates the file with the process umask (typically 0644 or 0022, resulting in world-readable files on many systems). No explicit mode-600 permission is set on the file after creation.",
+      "impact": "On a multi-user system or a container with a permissive umask, any local process can read the keypair file and extract the server's signing key. This key is used for all attestations and Arweave uploads — compromise means an attacker can forge attestations.",
+      "recommendation": "After writing the keypair, explicitly set file permissions to 0o600 using std::fs::set_permissions(&path, std::os::unix::fs::PermissionsExt::from_mode(0o600)). Also add a startup check that warns (or errors) if the file has group/world-readable permissions.",
+      "cwe": "CWE-732"
+    },
+    {
+      "severity": "minor",
+      "category": "best-practice",
+      "title": "turboquant-plus-rs is a low-activity crate — supply-chain risk worth monitoring",
+      "location": "core/Cargo.toml:25, mcp/Cargo.toml:66",
+      "description": "turboquant-plus-rs 0.1.0 resolves from the crates.io registry (checksum 92a035fc... confirmed in Cargo.lock). The crate is legitimate and resolves correctly. However, it has a very low version number (0.1.0) and minimal public history, which is typical of self-published crates that may not receive security patches. No CVEs are currently known.",
+      "impact": "If the crate author publishes a malicious update or the crate is abandoned, the project depends on a dependency with no community auditing.",
+      "recommendation": "Pin to the exact version in Cargo.toml (already done — version = '0.1.0'). Consider vendoring the crate or adding a cargo-deny rule to block future unexpected version bumps. Periodically run cargo audit to detect if any advisories are published.",
+      "cwe": "CWE-1395"
+    },
+    {
+      "severity": "minor",
+      "category": "best-practice",
+      "title": "rusqlite 'bundled' feature compiles SQLite from source — acceptable but increases build surface",
+      "location": "core/Cargo.toml:28",
+      "description": "The bundled feature vendors a specific SQLite version into the binary. The resolved rusqlite version is 0.34.0 (checksum 37e34486). This is a well-maintained crate. The bundled approach is safe and commonly used in Rust projects. The bundled SQLite is SQLite 3.x which has a strong security track record. No known vulnerabilities in the bundled version at this time.",
+      "impact": "Minimal. The bundled SQLite will not receive OS-level security patches automatically, but rusqlite releases track SQLite releases reasonably well.",
+      "recommendation": "Track rusqlite releases and update when new SQLite security advisories are published. Run cargo audit periodically. No immediate action required.",
+      "cwe": null
+    },
+    {
+      "severity": "minor",
+      "category": "A09: Security Logging and Monitoring",
+      "title": "Payment failure refund path uses credit_deposit with tx_sig='refund:...' which is not a real nonce — could bypass idempotency check",
+      "location": "mcp/src/main.rs:111-119",
+      "description": "When a tool call fails after funds were deducted, main.rs calls store.credit_deposit(key, cost, 'refund:<error>') to return funds. However, credit_deposit checks tx_sig uniqueness to prevent replay (line 167 of db.rs). Using a synthetic string like 'refund:error_message' means the same error message for the same key would cause the second refund to fail silently (the _ = store.credit_deposit(...) result is discarded). The user would permanently lose funds in that edge case.",
+      "impact": "Funds lost silently if two identical tool failures occur for the same key. No security escalation — this is a correctness issue with a payment-integrity impact.",
+      "recommendation": "Use a unique refund nonce per attempt, e.g. format!('refund:{}:{}', uuid::Uuid::new_v4(), attestation_id). Also surface the error instead of discarding with _.",
+      "cwe": "CWE-459"
+    },
+    {
+      "severity": "minor",
+      "category": "best-practice",
+      "title": "reqwest blocking feature enabled in core — potential deadlock in async contexts",
+      "location": "core/Cargo.toml:29",
+      "description": "core/Cargo.toml declares reqwest with features = ['json', 'blocking']. The blocking client (used in OpenAIEmbedder::embed in mcp/src/embed.rs:132) spawns a thread pool internally. Calling a blocking reqwest method from inside a tokio async task without tokio::task::spawn_blocking can deadlock the tokio runtime. The current call site in embed.rs is reached from sign_memory which is an async function.",
+      "impact": "Under concurrent load, the Mnemonic MCP server could deadlock when using OpenAI embeddings if all tokio worker threads are consumed by blocking calls. This is a denial-of-service risk.",
+      "recommendation": "Wrap the blocking reqwest call in tokio::task::spawn_blocking: let result = tokio::task::spawn_blocking(move || { /* blocking reqwest call */ }).await?. Alternatively, refactor OpenAIEmbedder to use the async reqwest client.",
+      "cwe": "CWE-833"
+    },
+    {
+      "severity": "minor",
+      "category": "A04: Insecure Design",
+      "title": "HashEmbedder present in mcp/ source being copied — tech-spec mandates its removal",
+      "location": "mcp/src/embed.rs:72-108",
+      "description": "The tech-spec (Decision 4) and acceptance criteria mandate that HashEmbedder be absent in core/src/. Task 1 copies mcp/src/ files verbatim. HashEmbedder is still present in mcp/src/embed.rs. While the acceptance criteria apply to core/, having HashEmbedder in mcp/ means future extraction tasks will carry it forward unless it is explicitly removed during the embed extraction wave. This is a pre-condition risk, not a current violation.",
+      "impact": "If HashEmbedder is accidentally exported from core/ during Task 4, attestations generated with it would be non-verifiable, undermining the core security property of the system.",
+      "recommendation": "No action required for Task 1 scope — HashEmbedder removal is deferred to Task 4. Flag for the Task 4 implementer to remove it from mcp/src/embed.rs during extraction. Add a TODO comment or grep-check in the Task 4 acceptance criteria.",
+      "cwe": null
+    }
+  ],
+  "summary": "Task 1 is approved. No critical findings (no hardcoded secrets, no private keys in source, turboquant-plus-rs resolves correctly from crates.io at the expected checksum, all SQL uses rusqlite parameterized queries, turboquant:: import rename completed cleanly with zero remaining references). Four major findings are identified that should be addressed before production deployment: unauthenticated admin stats endpoint, overly permissive CORS, SSRF-adjacent URL validation gap for ARWEAVE_URL/SOLANA_RPC_URL, and insecure keypair file permissions on creation. These issues pre-exist in the source being migrated and are out of scope for Task 1's scaffold-only mandate, but are flagged here for tracking. Four minor findings cover supply-chain monitoring, tokio blocking deadlock risk, rusqlite bundled tracking, and HashEmbedder removal reminder. The workspace scaffold itself (Cargo.toml, core stubs, dependency declarations) is clean."
+}

--- a/work/mnemonic-core/logs/working/task-1/test-reviewer-1.json
+++ b/work/mnemonic-core/logs/working/task-1/test-reviewer-1.json
@@ -1,0 +1,36 @@
+{
+  "task": 1,
+  "reviewer": "test-reviewer",
+  "round": 1,
+  "status": "approved",
+  "findings": [
+    {
+      "severity": "minor",
+      "location": "mcp/Cargo.toml",
+      "description": "mcp/Cargo.toml retains turboquant-plus-rs and ndarray as direct runtime deps even though no mcp/ module directly uses compression logic after core is introduced. These deps are properly in core/Cargo.toml as well. This is not a test issue but is worth noting as minor dead-dep noise that could produce spurious coverage gaps when test tooling maps dep ownership."
+    },
+    {
+      "severity": "minor",
+      "location": "core/Cargo.toml",
+      "description": "dev-dependency tokio is declared twice: once in [dependencies] with features [time, rt] and once in [dev-dependencies] with features [macros, rt-multi-thread]. Cargo merges features so this works, but the duplication is non-obvious and could confuse future contributors adding test features. No test correctness impact for Task 1 (no tests written), but worth documenting for when #[tokio::test] blocks are added in later tasks."
+    }
+  ],
+  "summary": "Task 1 is a scaffold-only task and its TDD gate is compilation, not Rust test functions. This is correct and appropriate: no new logic was introduced, so no new behavioral tests are warranted. All 59 pre-existing mnemonic-mcp tests pass after the turboquant import rename (51 unit tests + 5 integration_cbor + 3 proptest_canonical = 59 total, all green). Both cargo build -p mnemonic-core and cargo build -p mnemonic-mcp succeed. The compile-level TDD anchors defined in the task file are satisfied. The dev-dependency set in core/Cargo.toml (httpmock, tempfile, proptest, criterion, tokio with macros/rt-multi-thread) is correct and complete for the test infrastructure required in waves 2-10. Two minor findings noted: redundant turboquant-plus-rs dep in mcp/ and a tokio dev-dep split across [dependencies] and [dev-dependencies]; neither affects test correctness for this task.",
+  "metrics": {
+    "filesReviewed": 6,
+    "litmusTest": {
+      "checked": 0,
+      "passed": 0,
+      "failed": 0,
+      "note": "No new test functions written for this task — litmus test not applicable. The TDD gate is compilation (cargo build exits 0)."
+    },
+    "coverageAssessment": "adequate",
+    "pyramidBalance": {
+      "unit": 51,
+      "integration": 8,
+      "e2e": 0,
+      "assessment": "healthy",
+      "note": "Counts reflect pre-existing mnemonic-mcp tests preserved by this task. No new tests added — appropriate for scaffold-only wave."
+    }
+  }
+}

--- a/work/mnemonic-core/logs/working/task-10/code-reviewer-round1.json
+++ b/work/mnemonic-core/logs/working/task-10/code-reviewer-round1.json
@@ -1,0 +1,27 @@
+{
+  "reviewer": "code-reviewer",
+  "round": 1,
+  "task": 10,
+  "verdict": "approved",
+  "findings": [
+    {
+      "severity": "minor",
+      "location": "core/benches/cbor_codec.rs:51-62",
+      "issue": "bench_cose_sign and bench_full_pipeline measure identical work. bench_cose_sign calls sign_artifact with the full artifact, which internally runs canonical CBOR + blake3 + COSE_Sign1. bench_full_pipeline does exactly the same call. There is no observable difference in what the two groups measure.",
+      "suggestion": "Either (a) rename bench_cose_sign to reflect that it measures the full sign pipeline at input sizes [100,500,2000] and drop bench_full_pipeline as redundant, or (b) keep both but give bench_cose_sign a pre-computed cbor input so it isolates only the COSE signing step (call to_canonical_cbor outside the iter closure and pass the bytes to a lower-level sign helper if one is exported). This is a benchmark quality issue, not a correctness issue — both will compile and produce numbers, but the numbers will be indistinguishable."
+    },
+    {
+      "severity": "nit",
+      "location": "core/benches/cbor_codec.rs:31",
+      "issue": "bench_cbor_canonicalization calls to_canonical_cbor with &MEMORY_V1 inside iter, which includes the schema field-order lookup. The schema reference is a static borrow so it costs nothing at runtime, but the MEMORY_V1 reference is not wrapped in black_box, meaning the compiler could theoretically constant-fold it. In practice Criterion's black_box on the artifact argument is sufficient, but being explicit about both arguments would be more defensible.",
+      "suggestion": "Change the call to: to_canonical_cbor(black_box(&artifact), black_box(&MEMORY_V1)).unwrap()"
+    },
+    {
+      "severity": "nit",
+      "location": "core/tests/proptest_canonical.rs:57-75",
+      "issue": "different_content_different_hash uses disjoint regex ranges ([a-z] vs [A-Z]) to guarantee content_a != content_b, and the comment explains this correctly. However the old mcp version included an explicit equality guard (if content_a != content_b) to handle the edge case where proptest generates equal strings. The new version drops the guard, relying on the disjoint ranges instead. This is correct — lowercase and uppercase ASCII ranges cannot overlap — but the assumption is implicit. A one-line comment confirming the ranges are disjoint would make future readers confident the guard is intentionally absent.",
+      "suggestion": "Add: // Ranges [a-z] and [A-Z] are disjoint; content_a and content_b can never be equal."
+    }
+  ],
+  "notes": "Position on the sign_artifact substitution in bench_full_pipeline: the substitution is the right call. The original mcp bench hand-rolled COSE_Sign1 construction using raw coset primitives, but that inline code was a verbatim reimplementation of what sign_artifact does — same HeaderBuilder chain, same tbs_data call, same Keypair.sign_message, same CoseSign1Builder rebuild. The task spec explicitly directs replacing inline helpers that duplicate library exports, and sign_artifact is exactly the library export that encapsulates this pipeline. Benchmarking via sign_artifact is not a signal loss: it measures the real production code path, which is what a full-pipeline benchmark should measure. The only genuine signal loss is that bench_cose_sign now overlaps bench_full_pipeline almost completely (both call sign_artifact end-to-end), which is a benchmark design issue flagged as a minor finding above but does not block approval.\n\nAll acceptance criteria from tasks/10.md are satisfied: four files moved to correct locations, all inline helpers replaced with mnemonic_core imports (codec_helpers module in integration_cbor.rs gone, inline to_canonical_cbor/json_to_cbor in proptest_canonical.rs and cbor_codec.rs gone, #[path] hack in decompress.rs replaced with use mnemonic_core::compress::EmbeddingCompressor), mcp/Cargo.toml cleanly stripped of criterion, proptest, and both [[bench]] entries, core/Cargo.toml has both [[bench]] targets with harness=false plus both dev-deps, no use super::* patterns, and the Cargo.lock confirms the dependency migration is complete. The proptest test different_content_different_hash is strictly stronger than the old version (which had a conditional guard that silently skipped the assertion when strings were equal) — the new version is guaranteed to assert on every run. Cross-file consistency is clean: all imported symbols (to_canonical_cbor, hash_bytes, sign_artifact, verify_artifact, get_schema, EmbeddingCompressor, all schema constants) exist and are exported from their respective modules with matching signatures."
+}

--- a/work/mnemonic-core/logs/working/task-10/code-reviewer-round2.json
+++ b/work/mnemonic-core/logs/working/task-10/code-reviewer-round2.json
@@ -1,0 +1,62 @@
+{
+  "reviewer": "code-reviewer",
+  "round": 2,
+  "task": 10,
+  "verdict": "approved",
+  "status": "approved",
+  "summary": "All three round-1 findings are correctly addressed: bench_cose_sign now isolates the COSE stage via the extracted sign_cose primitive, black_box wraps both args in every bench iter closure, and the disjoint-ranges comment is present. The sign_artifact refactor is a clean extraction with identical observable behavior. The strengthened proptest and stricter CBOR size assertion are sound improvements with no regressions introduced.",
+  "criticalIssues": [],
+  "suggestions": [
+    {
+      "file": "core/src/codec/sign.rs",
+      "line": 54,
+      "severity": "minor",
+      "category": "maintainability",
+      "suggestion": "sign_cose is marked #[doc(hidden)] pub, which is the right call to discourage external callers while still exporting for the bench crate. One future concern: if a downstream consumer in the same workspace imports this symbol, the hidden doc annotation provides no compile-time barrier. Consider whether a pub(crate) or a dedicated #[cfg(any(test, bench))] guard would be more accurate — though this is a judgment call and the current approach is acceptable for bench isolation.",
+      "benefit": "Makes the intended visibility contract machine-enforced rather than documentation-only, reducing the chance that sign_cose is used as a stable public API by future contributors.",
+      "optional": true
+    },
+    {
+      "file": "core/src/codec/sign.rs",
+      "line": 69,
+      "severity": "minor",
+      "category": "performance",
+      "suggestion": "sign_cose calls canonical_cbor.to_vec() twice (lines 72 and 85) to populate both the unsigned and signed CoseSign1Builder. Each call is a heap allocation plus memcpy of the full payload. The first allocation (unsigned, line 72) is discarded immediately after tbs_data is computed. Consider cloning once for the signed builder or — if the coset API permits — reusing the unsigned builder by calling .signature() on a consuming method. This is a micro-optimization but inside a hot bench loop it adds measurable allocator overhead to what is supposed to be a pure COSE-only measurement.",
+      "benefit": "Eliminates one spurious heap allocation per signing call, keeping bench_cose_sign's measured cost strictly attributable to COSE construction and Ed25519 signing.",
+      "optional": true
+    }
+  ],
+  "roundOneFindingsResolution": {
+    "minor_bench_cose_sign_redundancy": {
+      "status": "resolved",
+      "approach": "Option (b): extracted sign_cose primitive. bench_cose_sign now pre-computes canonical CBOR outside iter and calls sign_cose inside. bench_full_pipeline calls sign_artifact end-to-end. The two groups now measure genuinely distinct pipeline stages.",
+      "assessment": "Correct and complete. The bench groups are now distinguishable: cose_sign measures COSE_Sign1 build + Ed25519 only; full_pipeline measures the entire chain including canonicalization and hashing."
+    },
+    "nit_black_box_schema": {
+      "status": "resolved",
+      "assessment": "black_box(&MEMORY_V1) added in bench_cbor_canonicalization. Additionally applied to &MEMORY_V1 and &kp in bench_full_pipeline and bench_cose_sign. Consistent and correct."
+    },
+    "nit_disjoint_ranges_comment": {
+      "status": "resolved",
+      "assessment": "Comment '// Ranges [a-z] and [A-Z] are disjoint; content_a and content_b can never be equal.' added verbatim as suggested."
+    }
+  },
+  "signCosePrimitiveAnalysis": {
+    "signatureAssessment": "sign_cose(canonical_cbor: &[u8], keypair: &Keypair) -> Result<Vec<u8>, String> is appropriate. Borrows both inputs (no unnecessary copies at call site), returns owned bytes for the serialized COSE_Sign1. Error type String is consistent with sign_artifact's existing error contract.",
+    "docHiddenAssessment": "#[doc(hidden)] pub is the idiomatic Rust approach for 'exported for sibling crates/benches, not intended as stable public API'. Correct choice. The accompanying rustdoc comment clearly states the primary consumer is benchmarks and directs production callers to sign_artifact.",
+    "maintenanceRisk": "Low. sign_cose is a pure function with no state. If sign_artifact's COSE construction ever changes, sign_cose is the single place to update and sign_artifact automatically inherits the fix. This is strictly better than the pre-refactor layout where the COSE logic lived inline in sign_artifact.",
+    "outputIdenticalityVerification": "sign_artifact now calls sign_cose(&canonical_cbor, keypair) and stores the returned Vec<u8> as cose_bytes. The field assignment order in SignedArtifact { cose_bytes, content_hash, canonical_cbor } is unchanged. The only textual change inside sign_cose relative to the prior inline code is canonical_cbor.clone() -> canonical_cbor.to_vec(), which is semantically identical on a &[u8] receiver. Output is byte-identical."
+  },
+  "additionalObservations": [
+    "proptest sign_artifact_content_hash_matches_blake3_of_canonical_cbor is a genuine behavioral improvement: it exercises the sign pipeline from three angles (stored hash vs stored cbor, stored cbor vs independent canonicalization, stored hash vs independently hashed cbor) and replaces a weaker determinism-only check. No issues.",
+    "test_cbor_is_smaller_than_json strict inequality is sound for the test payload (ISO-8601 timestamp encoded as CBOR tag-1 + binary integer, plus elimination of JSON structural characters). The tightened assertion is correct and the explanatory comment is accurate.",
+    "decisions.md round-2 section accurately describes all changes made. No discrepancies between the documented approach and the actual diff."
+  ],
+  "metrics": {
+    "filesReviewed": 5,
+    "criticalIssuesCount": 0,
+    "majorIssuesCount": 0,
+    "minorIssuesCount": 2,
+    "testCoverageAssessment": "excellent"
+  }
+}

--- a/work/mnemonic-core/logs/working/task-10/test-reviewer-round1.json
+++ b/work/mnemonic-core/logs/working/task-10/test-reviewer-round1.json
@@ -1,0 +1,33 @@
+{
+  "reviewer": "test-reviewer",
+  "round": 1,
+  "task": 10,
+  "verdict": "changes-requested",
+  "findings": [
+    {
+      "severity": "major",
+      "location": "core/benches/cbor_codec.rs:51-62 and core/benches/cbor_codec.rs:64-79",
+      "issue": "bench_cose_sign and bench_full_pipeline now measure identical operations. bench_cose_sign calls sign_artifact (which internally runs canonical CBOR + blake3 + COSE signing), and bench_full_pipeline also calls sign_artifact with the same inputs and sizes. These two benchmark groups produce identical numbers and one is redundant. The original bench distinguished isolated COSE signing (taking pre-computed cbor bytes as input) from the full pipeline. That distinction was lost in the refactor: bench_cose_sign used to take cbor as a pre-computed input and measure only the COSE build+sign step; now it conflates all three stages.",
+      "suggestion": "Restore the isolated COSE-only benchmark by splitting sign_artifact's stages. If the library exposes a lower-level sign function that takes pre-computed CBOR bytes (or if sign_artifact can be restructured to expose that), use it in bench_cose_sign. Alternatively, move the CBOR precomputation outside the bench_cose_sign closure: compute cbor before b.iter() and measure only the signing step inside the closure. If the library does not expose a CBOR-bytes-in signing primitive, rename bench_cose_sign to bench_sign_full to be honest, and remove bench_full_pipeline as genuinely redundant."
+    },
+    {
+      "severity": "minor",
+      "location": "core/benches/cbor_codec.rs:38-48",
+      "issue": "bench_blake3_hash computes the CBOR bytes outside the b.iter() closure (correct), but the artifact construction and CBOR encoding for each size group are done at setup time. This is fine. However, a 10000-byte content artifact is included in the canonicalization and hash benchmarks but omitted from bench_cose_sign and bench_full_pipeline (which stop at 2000). The asymmetry in size coverage is unexplained and means throughput at high content sizes is only measured for the cheaper operations.",
+      "suggestion": "Either add 10000-byte cases to bench_cose_sign and bench_full_pipeline (with a comment that it runs slower, acceptable for a bench), or add a comment explaining why large payloads were excluded from signing benchmarks (e.g., not realistic for on-chain artifacts). The current silent asymmetry makes the benchmark results misleading."
+    },
+    {
+      "severity": "minor",
+      "location": "core/tests/integration_cbor.rs:134-163",
+      "issue": "test_cbor_is_smaller_than_json uses a +50 byte tolerance in its assertion (cbor_bytes.len() <= json_bytes.len() + 50). This means CBOR could be up to 50 bytes *larger* than JSON and the test would still pass. If the library's canonical encoder adds unexpected overhead (e.g., a schema tag or header) and regresses to JSON-comparable size, this test provides no signal. The test intent says 'CBOR should be smaller or comparable' but the assertion accepts CBOR being larger.",
+      "suggestion": "Tighten the assertion to match the actual intent. If CBOR is expected to be smaller, assert cbor_bytes.len() < json_bytes.len(). If comparable is acceptable, define a ratio bound (e.g., assert cbor_bytes.len() as f64 / json_bytes.len() as f64 <= 1.1). The current +50 absolute slack is especially fragile for small payloads where +50 bytes could be a 30% regression."
+    },
+    {
+      "severity": "nit",
+      "location": "core/tests/proptest_canonical.rs:36-54",
+      "issue": "hash_is_deterministic calls to_canonical_cbor twice and hashes both results, but it never asserts that the CBOR bytes themselves are equal — only the hashes. The canonical_cbor_is_deterministic test already covers CBOR byte equality, so this test's unique contribution is that hash(same_cbor) == hash(same_cbor), which is trivially true for any deterministic hash function and adds near-zero marginal coverage beyond what canonical_cbor_is_deterministic already proves.",
+      "suggestion": "Remove hash_is_deterministic, or replace it with a test that adds distinct value: e.g., verify that hash_bytes of the canonical CBOR matches what sign_artifact records as content_hash, closing the loop between the hash and signing layers. That would be a true behavioral assertion not covered by the other two proptests."
+    }
+  ],
+  "notes": "DROPPED content_a != content_b GUARD: The teammate's reasoning is correct. The proptest strategies '[a-z]{10,50}' and '[A-Z]{10,50}' draw from disjoint character sets — any string from the lowercase alphabet and any string from the uppercase alphabet are guaranteed to differ. The original guard was defensive code written for an inline to_canonical_cbor where accidental collision was theoretically possible via shared code paths; here the two regex sets are mathematically disjoint. Dropping the guard is safe, and the unconditional prop_assert_ne is a stronger assertion (it never silently skips). No issue here.\n\nTAMPER TEST catch_unwind -> Result::Err: This is an improvement. The original test called catch_unwind around an infallible-looking verify_cose that contained unwrap() calls and could panic on parse errors. The new test uses verify_artifact which returns Result, and the match handles both Err (parse failure) and Ok with valid=false (signature mismatch) explicitly. No coverage is lost; the behavior being tested — that tampering is detected — is preserved. The new form is also safer because it does not suppress panics that would indicate bugs in verify_artifact itself.\n\nbench_full_pipeline sign_artifact SUBSTITUTION: The substitution is semantically correct — sign_artifact performs canonical CBOR + blake3 + COSE_Sign1 in sequence, which is the same pipeline the old full_pipeline measured. However, the refactor inadvertently made bench_cose_sign and bench_full_pipeline redundant with each other because both now call sign_artifact end-to-end. The original benchmarks had a meaningful distinction: bench_cose_sign isolated just the COSE building step by pre-computing CBOR outside the closure. That isolation was lost. This is flagged as a major finding because benchmark redundancy reduces the diagnostic value of the benchmark suite — you cannot tell which stage is the bottleneck if two benchmarks measure the same composite operation."
+}

--- a/work/mnemonic-core/logs/working/task-10/test-reviewer-round2.json
+++ b/work/mnemonic-core/logs/working/task-10/test-reviewer-round2.json
@@ -1,0 +1,52 @@
+{
+  "reviewer": "test-reviewer",
+  "round": 2,
+  "task": 10,
+  "verdict": "approved",
+  "round1_findings_resolution": {
+    "major_bench_redundancy": {
+      "status": "resolved",
+      "notes": "sign_cose was extracted cleanly from sign_artifact. sign_artifact calls sign_cose after computing canonical_cbor and content_hash — no canonicalization occurs inside sign_cose. bench_cose_sign pre-computes CBOR outside b.iter() and calls sign_cose inside, so it now measures only: COSE_Sign1 header construction, Ed25519 sign of tbs_data, COSE serialization. bench_full_pipeline still calls sign_artifact end-to-end. The two benchmark groups now measure distinct stages and their numbers can be subtracted to isolate canonicalization+hash cost from pure COSE cost. Isolation is genuine."
+    },
+    "minor_bench_size_asymmetry": {
+      "status": "resolved",
+      "notes": "Fixer chose to add a comment rather than add 10000-byte cases. Both bench_cose_sign and bench_full_pipeline now carry explicit comments explaining that 10000B is intentionally excluded because COSE serialization overhead dominates at that size and the canonicalization + hash benches already cover 10000B. The rationale is stated, the comment cross-references, the asymmetry is no longer silent. Acceptable resolution."
+    },
+    "minor_cbor_smaller_than_json_tolerance": {
+      "status": "resolved",
+      "notes": "Changed from cbor_bytes.len() <= json_bytes.len() + 50 to strict cbor_bytes.len() < json_bytes.len(). Comment explains the source of savings (delimiter removal + CBOR tag-1 epoch integer for created_at). Now rejects any regression where CBOR equals or exceeds JSON size."
+    },
+    "nit_hash_is_deterministic": {
+      "status": "resolved",
+      "notes": "Replaced with sign_artifact_content_hash_matches_blake3_of_canonical_cbor. The new proptest exercises sign_artifact under random content (regex .{1,500}), then makes three behavioral assertions: (1) content_hash == hash_bytes(signed.canonical_cbor), (2) fresh to_canonical_cbor produces identical bytes to what sign_artifact stored, (3) content_hash == hash_bytes of independently computed CBOR. Wires canonical codec, hash layer, and sign pipeline together. This would catch: a sign_artifact bug that stores wrong canonical_cbor, a hash layer that uses a different algorithm than blake3, or a canonicalization implementation that is not pure. Genuinely adds cross-layer coverage."
+    }
+  },
+  "additional_evaluation": {
+    "q5_proptest_input_variety": {
+      "assessment": "adequate",
+      "notes": "The .{1,500} regex draws from proptest's full Unicode character set (not just ASCII), with lengths from 1 to 500 characters. The artifact_id and producer fields are fixed for this proptest, but the content variation is the primary driver of CBOR byte variation. proptest will run 256 cases by default, providing meaningful coverage. One minor weakness: the fixed artifact_id='art:proptest' and producer='test' mean the proptest never exercises field variation for those keys, but these are constant-length and their CBOR encoding is deterministic, so the omission does not create a realistic failure gap. Adequate for the stated purpose."
+    },
+    "q6_bench_diagnostic_value": {
+      "assessment": "passes",
+      "notes": "Bench groups now give distinct signals: cbor_canonicalize measures pure serialization cost, blake3_hash measures pure hashing cost, cose_sign measures COSE construction + Ed25519 signing cost (all on pre-computed CBOR), full_pipeline measures the composite. A developer can now compare cose_sign vs full_pipeline numbers to determine how much of the pipeline cost is canonicalization+hash vs COSE signing. This is the diagnostic separation the round-1 finding requested."
+    }
+  },
+  "findings": [],
+  "metrics": {
+    "filesReviewed": 4,
+    "litmusTest": {
+      "checked": 11,
+      "passed": 11,
+      "failed": 0
+    },
+    "coverageAssessment": "excellent",
+    "pyramidBalance": {
+      "unit": 9,
+      "integration": 5,
+      "e2e": 0,
+      "proptest": 3,
+      "assessment": "healthy"
+    }
+  },
+  "notes": "All four round-1 findings fully addressed. sign_cose isolation is real and verifiable from the source: sign_cose takes &[u8] payload bytes and runs only COSE header construction, tbs_data computation, Ed25519 sign, and serialization. sign_artifact calls to_canonical_cbor and hash_bytes before delegating to sign_cose — no hidden canonicalization inside sign_cose. The new cross-layer proptest has three meaningful assertions wiring three separate modules together. The strict CBOR < JSON assertion now catches encoding regressions. Bench isolation enables bottleneck analysis. No new issues found."
+}

--- a/work/mnemonic-core/logs/working/task-11/code-reviewer-round1.json
+++ b/work/mnemonic-core/logs/working/task-11/code-reviewer-round1.json
@@ -1,0 +1,33 @@
+{
+  "reviewer": "code-reviewer",
+  "round": 1,
+  "task": 11,
+  "verdict": "approved_with_suggestions",
+  "findings": [
+    {
+      "severity": "major",
+      "location": "mcp/src/main.rs:106-113 (refund path)",
+      "issue": "Refund uses credit_deposit with a synthetic tx_sig ('refund:<error-message>'), but credit_deposit has an idempotency guard that rejects any tx_sig already seen in payment_events. If the same error message recurs on repeated failures for the same API key, the second refund silently fails (result is discarded with `let _ = ...`). Additionally, credit_deposit inserts the synthetic string into the tx_sig column of payment_events, polluting deposit records with refund entries.",
+      "suggestion": "Introduce a dedicated refund_balance helper in payment.rs that performs a direct UPDATE (no idempotency check, no tx_sig column insertion) and emits an event_type='refund' row. The refund path is a charge reversal, not a deposit, and should not share the deposit code path. This is pre-existing behavior from before task 11, not a regression introduced here, but the task-11 consolidation makes it clearly visible and the correct fix is cheap."
+    },
+    {
+      "severity": "minor",
+      "location": "mcp/src/mcp.rs:87 — tool_definitions()",
+      "issue": "The mnemonic_sign_memory tool description still says 'SHA-256 hash' and 'anchors on Solana via SPL Memo'. Since task 2 the implementation uses blake3(canonical_cbor) as the content hash and the Solana memo anchor has been v3 since at least task 8. The stale description propagates to every MCP client that calls tools/list.",
+      "suggestion": "Update to: 'Creates a verifiable memory attestation: embeds content, blake3 hash of CBOR-canonical artifact, stores COSE_Sign1 envelope on Arweave, anchors hash on Solana memo (v3)'. This is client-facing metadata."
+    },
+    {
+      "severity": "nit",
+      "location": "mcp/src/payment.rs:469-491 — random_bytes<N>",
+      "issue": "The SHA-256 fallback in random_bytes (used when /dev/urandom is unavailable) produces only 32 bytes of entropy and repeats them cyclically for N > 32. The constant N=24 in the call site means the cycling never triggers for the current use case, but the pattern is fragile and slightly misleading for future callers who might pass N > 32.",
+      "suggestion": "Add a const assert or comment noting that the fallback is only safe for N <= 32, or better, loop the Sha256 counter increment to generate additional blocks. Alternatively, consider using getrandom crate which is already a transitive dependency via solana-sdk and works on all platforms without the manual /dev/urandom fallback."
+    },
+    {
+      "severity": "nit",
+      "location": "mcp/src/tools.rs:47 — #[allow(clippy::too_many_arguments)]",
+      "issue": "sign_memory has 10 parameters. Suppressing the lint is understandable for this task (import cleanup only, no logic changes), but the underlying design pressure is real: the function signature couples the entire McpState decomposition to the tool implementation.",
+      "suggestion": "Track as follow-up debt: introduce a SignMemoryCtx<'_> reference struct grouping keypair, solana, arweave, store, embedder, compressor, storage_mode. This eliminates the allow and makes the call site in mcp.rs more readable. Not required for this task."
+    }
+  ],
+  "notes": "The db.rs consolidation into payment.rs is architecturally clean and correct. All moved helpers are genuine payment concerns (API key lifecycle, balance, P&L, replay protection, cost accounting). The file is ~490 lines but well-organized in two clearly delineated sections with a section comment. Cohesion is high — every function either gates/checks payment or persists payment state. The four #[allow(dead_code)] suppressions are all justified: http_host/http_port exist for env-level inspection symmetry while CLI flags take precedence at runtime; jsonrpc is deserialized for protocol compliance but never branched on; network is deserialized for spec compliance but verification is network-agnostic. Cargo.toml cleanup is thorough and correct — all 14 removed deps are confirmed absent from mcp sources; the local-embed feature forwarding to mnemonic-core/local-embed is the right pattern. pricing.rs byte-identity confirmed (md5 match against b2e52e6). The TurboQuant 90s cold-init is correctly characterized as a pre-existing trait of turboquant_plus_rs, not a task-11 regression. All acceptance criteria from the task spec are met: mcp/src/ contains exactly {config.rs, main.rs, mcp.rs, payment.rs, pricing.rs, tools.rs}; no domain types flow from crate:: imports (only crate::{payment, pricing, tools}); workspace build, tests, and clippy are all clean per teammate verification."
+}

--- a/work/mnemonic-core/logs/working/task-11/code-reviewer-round2.json
+++ b/work/mnemonic-core/logs/working/task-11/code-reviewer-round2.json
@@ -1,0 +1,62 @@
+{
+  "reviewer": "code-reviewer",
+  "round": 2,
+  "task": 11,
+  "verdict": "approved_with_suggestions",
+  "fixer_claims_verified": {
+    "refund_path_major": "VERIFIED — `refund_balance()` in payment.rs uses `tx_sig = NULL` via a literal NULL in the INSERT, partial UNIQUE index syntax `WHERE tx_sig IS NOT NULL` is correct SQLite, wrapped in BEGIN IMMEDIATE / COMMIT with explicit ROLLBACK on each error path. `main.rs` call site at line 112 uses `payment::refund_balance(&store, key, current_cost, reason)` and logs failures via `tracing::warn!`. The `current_cost` captured at gate-check time (line 69) is the correct amount that was deducted.",
+    "stale_tool_description_minor": "VERIFIED — `mcp.rs:87` now reads: 'canonical CBOR + blake3 hash, signed with COSE_Sign1 (Ed25519), stored on Arweave, hash anchored as SPL Memo on Solana'. Accurate and client-facing.",
+    "random_bytes_nit": "VERIFIED — `random_bytes<N>` now returns `anyhow::Result<[u8; N]>`. The SHA-256 fallback is removed entirely; function fails loudly on missing `/dev/urandom`. `create_api_key` propagates via `?` at line 307.",
+    "ten_arg_sign_memory_nit": "DEFERRED — acceptable per stated follow-up scope. No regression introduced."
+  },
+  "migration_analysis": {
+    "partial_index_existing_dbs": "CLEAN — the partial index is part of the `SCHEMA` const string in `core/src/storage/sqlite.rs`. `SqliteStore::open()` calls `conn.execute_batch(SCHEMA)` on every open, and `CREATE UNIQUE INDEX IF NOT EXISTS` is idempotent. Any existing DB gets the index applied on the next server restart at no cost. No explicit migration script needed.",
+    "pnl_stats_interaction": "CLEAN — `get_pnl_stats` queries `attestation_costs` exclusively (lines 547-566), not `payment_events`. Refund rows land in `payment_events` with `event_type='refund'` and update `api_keys.balance_micro_usdc`, but they have no direct path into the P&L aggregation. This is consistent with the existing cost-accounting model: P&L tracks server-side costs per attestation, not balance movements."
+  },
+  "tests_verified": {
+    "refund_balance_allows_duplicate_reasons": "CORRECT — seeds 1000 via credit_deposit, fires two identical-reason refund_balance(100), asserts after_1=1100 and after_2=1200, then verifies COUNT(*) WHERE event_type='refund' = 2. Tests the previously broken duplicate-refund path.",
+    "credit_deposit_concurrent_same_tx_sig_applies_once": "STRUCTURALLY CORRECT, POTENTIALLY FLAKY — two threads use a Barrier to fire credit_deposit with the same tx_sig concurrently against a shared file-backed DB. The test asserts exactly one succeeds and the failure message contains 'deposit tx already applied'. However: SQLite is opened without WAL mode or a busy_timeout pragma. The loser thread may get SQLITE_BUSY (rusqlite default busy_timeout = 0ms) on `BEGIN IMMEDIATE` rather than a ConstraintViolation. In the Busy case, the error message will NOT contain 'deposit tx already applied', causing the string assertion at line 706 to fail. The 'exactly one succeeds' count assertion remains correct because Busy is still an error. This is a test-correctness issue, not a production correctness issue.",
+    "deduct_balance_concurrent_cannot_overdraw": "CORRECT — balance = 100, two concurrent 75-deducts via Barrier + file-backed DB. The single-UPDATE atomicity (WHERE balance >= amount) prevents both from succeeding. Final balance = 25 asserted. SQLite write serialization is sufficient here because deduct_balance does not use BEGIN IMMEDIATE — the single UPDATE statement is inherently atomic under SQLite's writer lock.",
+    "deduct_balance_insufficient_leaves_balance_unchanged": "CORRECT — straightforward regression guard.",
+    "deduct_balance_unknown_key_reports_not_found": "CORRECT — straightforward regression guard.",
+    "credit_deposit_sequential_duplicate_is_rejected": "CORRECT — baseline idempotency using in-memory store; ConstraintViolation path exercised sequentially."
+  },
+  "criticalIssues": [],
+  "suggestions": [
+    {
+      "file": "mcp/src/payment.rs",
+      "line": 341,
+      "severity": "major",
+      "category": "error-handling",
+      "suggestion": "Wrap `deduct_balance` in a `BEGIN IMMEDIATE` / `COMMIT` transaction the same way `credit_deposit` and `refund_balance` are. Currently the balance UPDATE (line 346) and the `payment_events` INSERT (line 368) are two separate auto-commit statements. If the INSERT fails (disk full, constraint error on event_id collision), the balance is already decremented with no audit trail. The inconsistency is also confusing: all three financial mutations should be atomic.",
+      "benefit": "Audit trail is guaranteed to match balance: no deduction without a charge event row. Consistent transaction discipline across all three financial helpers.",
+      "optional": false
+    },
+    {
+      "file": "mcp/src/payment.rs",
+      "line": 706,
+      "severity": "minor",
+      "category": "testing",
+      "suggestion": "The `credit_deposit_concurrent_same_tx_sig_applies_once` test asserts `err_msg.contains('deposit tx already applied')`. Under SQLite default journal mode with two file-backed connections, the losing `BEGIN IMMEDIATE` may return `SQLITE_BUSY` rather than a ConstraintViolation. Rusqlite's default busy_timeout is 0ms, so the Busy path is realistic. Fix: either (a) add `PRAGMA busy_timeout = 5000` in `SqliteStore::open` and note that the test is exercising the constraint path, or (b) relax the assertion to `err_msg.contains('deposit tx already applied') || err_msg.contains('database is locked')` with a comment explaining both are valid rejection outcomes. The production behavior (one credit applied) is correct regardless — only the test string assertion is fragile.",
+      "benefit": "Eliminates test flake on slow CI runners where thread scheduling makes Busy more likely than constraint violation.",
+      "optional": false
+    },
+    {
+      "file": "core/src/storage/sqlite.rs",
+      "line": 86,
+      "severity": "minor",
+      "category": "performance",
+      "suggestion": "Add `PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;` to `SqliteStore::open` (not `in_memory`, where WAL is irrelevant). WAL allows concurrent readers alongside one writer, which the runtime already exploits (pricing refresh reads while MCP writes). Without WAL, any concurrent read during a write holds the database-level lock and causes reader starvation. This also resolves the busy_timeout concern from the concurrent test note above.",
+      "benefit": "Correct concurrent reader/writer behavior under multi-connection access; also required for the concurrent test to reliably exercise the ConstraintViolation path rather than SQLITE_BUSY.",
+      "optional": false
+    }
+  ],
+  "metrics": {
+    "filesReviewed": 4,
+    "criticalIssuesCount": 0,
+    "majorIssuesCount": 1,
+    "minorIssuesCount": 2,
+    "testCoverageAssessment": "adequate"
+  },
+  "summary": "All four round-1 findings are correctly addressed: `refund_balance` is atomic (BEGIN IMMEDIATE), uses NULL tx_sig exempt from the partial index, is called from the correct main.rs site, and is covered by a test that verifies duplicate refunds both apply. The tool description, random_bytes signature, and migration behavior are all clean. Two related concerns remain: `deduct_balance` is the only financial helper not wrapped in an explicit transaction (UPDATE + INSERT are two separate auto-commits), creating an audit trail gap; and the concurrent credit_deposit test's string assertion may fail under SQLITE_BUSY rather than ConstraintViolation when SQLite runs without WAL or busy_timeout. Neither blocks the merge but both should be addressed in the next touch of payment.rs."
+}

--- a/work/mnemonic-core/logs/working/task-11/code-reviewer-round3.json
+++ b/work/mnemonic-core/logs/working/task-11/code-reviewer-round3.json
@@ -1,0 +1,41 @@
+{
+  "reviewer": "code-reviewer",
+  "round": 3,
+  "task": 11,
+  "status": "approved",
+  "summary": "All three round-2 findings are correctly addressed. `deduct_balance` now wraps UPDATE + INSERT in BEGIN IMMEDIATE / COMMIT with explicit ROLLBACK on every non-success path (UPDATE error, changes==0, INSERT error). The new rollback test uses a BEFORE INSERT trigger to force a genuine INSERT failure and verifies both balance integrity and absence of a stale charge row. The dedup migration helper is logically correct and idempotent. No new critical or major issues introduced.",
+  "fixer_claims_verified": {
+    "deduct_balance_audit_atomicity_major": {
+      "verdict": "VERIFIED",
+      "detail": "Three distinct rollback paths confirmed in payment.rs lines 355-401: (1) UPDATE error -> ROLLBACK + propagate Err (lines 368-371); (2) changed==0 -> ROLLBACK + read-only get_balance for precise message (lines 379-386); (3) INSERT error -> ROLLBACK + propagate Err (lines 392-398). COMMIT only reaches line 401 when both statements succeed. The `get_balance` call after ROLLBACK in path (2) is safe — the transaction is already rolled back, so the subsequent SELECT executes outside any transaction and reads committed state."
+    },
+    "wal_busy_timeout_minor": {
+      "verdict": "VERIFIED",
+      "detail": "SqliteStore::open sets `PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;` (line 125) before SCHEMA and migration. SqliteStore::in_memory sets only `PRAGMA busy_timeout=5000;` (line 137) with a correct comment explaining WAL is inapplicable in memory. Ordering is correct: pragmas before schema creation."
+    },
+    "migration_dedup_minor": {
+      "verdict": "VERIFIED",
+      "detail": "migrate_payment_events_unique_index() at lines 95-111 runs inside a single BEGIN IMMEDIATE / COMMIT. The DELETE keeps MIN(rowid) per tx_sig group among non-NULL tx_sigs only (WHERE tx_sig IS NOT NULL in both outer DELETE and inner subquery). NULL tx_sig rows (refunds/charges) are untouched. CREATE UNIQUE INDEX IF NOT EXISTS is idempotent on clean DBs. The function is called from both open() (line 128) and in_memory() (line 139). The UNIQUE index partial predicate `WHERE tx_sig IS NOT NULL` matches what was in SCHEMA previously, so existing code paths are unaffected."
+    },
+    "new_test_rollback": {
+      "verdict": "VERIFIED — GENUINE FAILURE PATH",
+      "detail": "Test at lines 822-886 installs a BEFORE INSERT trigger with RAISE(ABORT, ...) keyed on description='__FORCE_FAIL__'. SQLite RAISE(ABORT) aborts the current SQL statement and any enclosing transaction, so the trigger is a correct mechanism to simulate INSERT failure. The test seeds 500, attempts a 100-deduct with the sentinel, asserts: (a) error is returned, (b) balance remains 500, (c) no charge row exists. It then drops the trigger and executes a successful deduct to verify the store is not left in a stuck transaction state (400 balance final assertion). The test is not trivially passing — without the ROLLBACK in deduct_balance, the balance would be 400 after the first call even though it errored, failing assertion (b)."
+    }
+  },
+  "dedup_query_correctness": {
+    "preserves_earliest_row": "CORRECT — MIN(rowid) selects the earliest insert per tx_sig group. The NOT IN condition deletes all other rows with the same tx_sig.",
+    "null_tx_sig_safety": "CORRECT — Both the outer DELETE and the inner subquery include `WHERE tx_sig IS NOT NULL`. NULL rows (refunds, charges) are fully excluded from both sides of the NOT IN predicate. No risk of deleting NULL-tx_sig rows.",
+    "idempotency": "CORRECT — On a clean DB the DELETE is a no-op (no duplicates exist), and `CREATE UNIQUE INDEX IF NOT EXISTS` is cheap. On a legacy DB with duplicates, the earliest row per tx_sig survives.",
+    "concurrency": "CORRECT — BEGIN IMMEDIATE acquires the write lock before the DELETE, so two concurrent openers cannot see a half-migrated state."
+  },
+  "new_issues": [],
+  "criticalIssues": [],
+  "suggestions": [],
+  "metrics": {
+    "filesReviewed": 3,
+    "criticalIssuesCount": 0,
+    "majorIssuesCount": 0,
+    "minorIssuesCount": 0,
+    "testCoverageAssessment": "excellent"
+  }
+}

--- a/work/mnemonic-core/logs/working/task-11/security-auditor-round1.json
+++ b/work/mnemonic-core/logs/working/task-11/security-auditor-round1.json
@@ -1,0 +1,51 @@
+{
+  "reviewer": "security-auditor",
+  "round": 1,
+  "task": 11,
+  "verdict": "approved",
+  "findings": [
+    {
+      "severity": "major",
+      "location": "mcp/src/payment.rs:354-380 (credit_deposit)",
+      "issue": "TOCTOU race on deposit idempotency check. The check-then-insert pattern for duplicate tx_sig detection (SELECT COUNT(*) ... then INSERT) is not wrapped in a transaction. Under concurrent deposit requests with the same tx_sig, two threads could both read 0 and both proceed to credit the balance. The UNIQUE constraint on x402_nonces catches replay for x402 payments atomically (INSERT fails on ConstraintViolation), but payment_events for deposits uses a manual SELECT+INSERT pattern which is not atomic.",
+      "suggestion": "Wrap the entire credit_deposit body in an explicit SQLite transaction: `conn.execute(\"BEGIN IMMEDIATE\", [])?;` / `conn.execute(\"COMMIT\", [])?;` with rollback on error. Alternatively, add a UNIQUE constraint on payment_events.tx_sig column and rely on ConstraintViolation (mirroring the mark_x402_nonce pattern) rather than a SELECT COUNT check. The IMMEDIATE begin acquires a write lock at start, preventing the race."
+    },
+    {
+      "severity": "major",
+      "location": "mcp/src/payment.rs:334-351 (deduct_balance)",
+      "issue": "Balance check and deduction are not atomic. get_balance and the subsequent UPDATE execute as two separate statements with no transaction. Under concurrent requests on the same API key, both could pass the balance check then both decrement, resulting in negative balance (double-spend of prepaid credits). This is the same TOCTOU issue as the deposit path but on the charge path.",
+      "suggestion": "Perform the deduction atomically using a conditional UPDATE that incorporates the balance check: `UPDATE api_keys SET balance_micro_usdc = balance_micro_usdc - ? WHERE api_key = ? AND balance_micro_usdc >= ?` and check `conn.changes() == 0` to detect insufficient funds, eliminating the separate SELECT. This is a single statement and SQLite serializes it correctly without an explicit transaction."
+    },
+    {
+      "severity": "minor",
+      "location": "mcp/src/payment.rs:469-491 (random_bytes fallback)",
+      "issue": "The fallback CSPRNG when /dev/urandom is unavailable uses a SHA-256 hash of (timestamp + PID + counter). While the counter prevents duplicate outputs within a process, the timestamp has nanosecond resolution and PID is predictable on many platforms. If /dev/urandom fails (e.g. in a sandboxed environment) and an attacker can observe timing, the API key prefix space is reducible. The output is also truncated to 24 bytes from a 32-byte hash, re-using hash bytes cyclically (though for 24 bytes this is fine since it fits in one hash block).",
+      "suggestion": "Replace the fallback with `getrandom::getrandom()` or use the `rand` crate's `OsRng`, which correctly errors rather than silently degrading to a weak fallback. If the fallback must exist, use `OsRng` from the `rand` crate which already handles platform-specific entropy sources including Windows CNG. Alternatively, treat a /dev/urandom failure as fatal: `panic!(\"entropy source unavailable — cannot create API key\")` since creating a weak key is worse than refusing."
+    },
+    {
+      "severity": "minor",
+      "location": "mcp/src/main.rs:257-263 (deposit authz error message)",
+      "issue": "The deposit-rejected error message leaks a 12-character prefix of the owner pubkey and a 16-character prefix of the tx_sig in the HTTP 403 response body. While partial, these prefixes narrow the key space for an attacker trying to correlate identities across deposit attempts.",
+      "suggestion": "Remove the sensitive identifiers from the client-facing error message. Log them server-side via tracing::warn! with full values for operator debugging, and return a generic message to the client: `\"deposit rejected: API key owner is not a signer of this transaction\"`. The client that submitted the request already knows their own pubkey and tx_sig."
+    },
+    {
+      "severity": "minor",
+      "location": "mcp/src/main.rs:104-113 (refund via credit_deposit)",
+      "issue": "The tool-failure refund path calls credit_deposit with `format!(\"refund:{}\", error_message)` as the tx_sig parameter. The error_message comes from resp.error.message which is an internal Rust error string. credit_deposit then checks for duplicate tx_sig in payment_events — but these refund pseudo-tx_sigs are not unique (two failures of the same type would produce identical refund keys). The idempotency check in credit_deposit would incorrectly reject the second refund, silently swallowing it. In practice this only affects concurrent failures of the same tool for the same key, but it is a latent billing correctness issue.",
+      "suggestion": "Use a unique refund identifier instead of the error message: `format!(\"refund:{}:{}\", uuid::Uuid::new_v4(), resp.error.as_ref().map(|e| e.message.as_str()).unwrap_or(\"error\"))`. This ensures each refund event is unique while still being searchable in payment_events."
+    },
+    {
+      "severity": "nit",
+      "location": "mcp/src/main.rs:472-484 (CORS configuration)",
+      "issue": "CORS is configured with `allow_origin(Any)`, `allow_methods(Any)`, and `allow_headers(Any)`. The payment-sensitive routes (/deposit, /admin/stats, /api-keys) accept CORS requests from any origin. For a self-hosted payment server, this allows malicious websites to trigger cross-origin deposit or balance queries against the server if authentication is missing or bypassable.",
+      "suggestion": "Restrict CORS to known origins (e.g. the MCP client host) or at minimum restrict to the /mcp route only (which Claude Code accesses). Payment API endpoints (/deposit, /api-keys, /admin/stats) should either be excluded from CORS or require a pre-shared secret beyond the api_key query parameter."
+    },
+    {
+      "severity": "nit",
+      "location": "mcp/src/main.rs:282-315 (admin_stats — no authentication)",
+      "issue": "The /admin/stats endpoint returns P&L data (attestation count, earnings, costs, margin percentage, current pricing) without any authentication check. Any client that can reach the HTTP port can query this data.",
+      "suggestion": "Gate /admin/stats behind a pre-shared admin secret checked in a request header (e.g. `X-Admin-Token`), or restrict it to loopback-only using a separate listener or middleware that checks the remote address."
+    }
+  ],
+  "notes": "Security axes covered:\n\n1. SQL INJECTION: All 9 moved DB functions exclusively use rusqlite params![] macro for query parameterization. No string interpolation into SQL was introduced. The get_pnl_stats interval string is formatted as '-{days} days' from a u64 integer (no user-supplied string), passed as a bound parameter via params![interval], not interpolated into the SQL string. CLEAR.\n\n2. NONCE REPLAY / DOUBLE-SPEND: mark_x402_nonce uses INSERT with UNIQUE constraint on tx_sig and correctly catches ConstraintViolation. This is atomic at the SQLite level. The nonce check happens BEFORE PaymentGate::Proceed is returned in check_x402, so replay is blocked before balance is affected. The verify_usdc_transfer -> mark_x402_nonce ordering is correct. However, the deposit credit_deposit path uses a non-atomic SELECT COUNT then INSERT pattern — flagged as major finding.\n\n3. AUTHZ: The deposit flow correctly retrieves owner_pubkey from the DB and then calls get_tx_signers to verify the API key owner signed the tx. The check at main.rs:252 (`!signers.iter().any(|s| s == &owner_pubkey)`) is present and preserved from the original. The deduct_balance flow does not have this concern (it's called from the payment gate which already verified the bearer token).\n\n4. ERROR LEAKAGE: The forbidden message at main.rs:257-263 leaks partial pubkey and tx_sig — flagged as minor. The mark_x402_nonce error at payment.rs:751 leaks the full tx_sig in the error string returned to PaymentGate::Unauthorized — this propagates to the HTTP response body. The tx_sig was supplied by the caller, so this is not a new information leak.\n\n5. DEPENDENCY REDUCTION: Removed deps: axum-extra (typed-header), bincode, blake3, bs58, ciborium, coset, fastembed (from mcp, forwarded to core), futures, ndarray, spl-memo, thiserror, tokio-stream, tokio-test, turboquant-plus-rs, zstd. None of these were providing crypto or TLS functionality — all crypto (blake3, coset, bs58) moved to mnemonic-core where they are still present. TLS is handled by reqwest/rustls in the underlying runtime. The remaining security-relevant deps (solana-sdk, rusqlite, sha2, base64, reqwest) are all retained.\n\n6. DEAD CODE ALLOWANCES: Four #[allow(dead_code)] annotations: Config.http_host, Config.http_port (env parity fields read from env but overridden by CLI), JsonRpcRequest.jsonrpc (protocol field, value not inspected), X402PaymentProof.network (protocol field, not inspected). All are on protocol-parity fields that carry legitimate structural meaning. None are on code paths that skip security checks.\n\n7. OWASP: A01 (Broken Access Control) — admin_stats unauthenticated (nit). A02 (Crypto) — random_bytes fallback weakness (minor). A04 (Insecure Design) — TOCTOU on balance operations (major). A05 (Misconfiguration) — CORS Any (nit). A07 (Auth Failures) — no issues with API key extraction or bearer token handling. A09 (Logging) — partial pubkey in error response (minor). No A03, A06, A08, A10 issues found."
+}

--- a/work/mnemonic-core/logs/working/task-11/security-auditor-round2.json
+++ b/work/mnemonic-core/logs/working/task-11/security-auditor-round2.json
@@ -1,0 +1,113 @@
+{
+  "reviewer": "security-auditor",
+  "round": 2,
+  "task": 11,
+  "verdict": "approved",
+  "round1_fixes_verified": {
+    "credit_deposit_TOCTOU": {
+      "status": "fixed",
+      "notes": [
+        "Partial UNIQUE index `uq_payment_events_tx_sig ON payment_events(tx_sig) WHERE tx_sig IS NOT NULL` is correct. SQLite treats two NULL values as distinct under a partial index, so refund and charge rows (tx_sig=NULL) are exempt from the constraint while real tx sigs collide atomically.",
+        "BEGIN IMMEDIATE acquires the write lock at transaction open. INSERT payment_event is the idempotency gate (first); UPDATE balance is second. If INSERT fails with ConstraintViolation the ROLLBACK fires and balance is never touched. Ordering is correct.",
+        "ConstraintViolation mapping uses `rusqlite::ErrorCode::ConstraintViolation` which is the exact enum variant rusqlite raises for SQLITE_CONSTRAINT. Correct.",
+        "Concurrent test `credit_deposit_concurrent_same_tx_sig_applies_once` opens two independent file-backed SqliteStore connections and synchronizes with a Barrier. The UNIQUE constraint + BEGIN IMMEDIATE together guarantee exactly one success. Test methodology is sound — it does not rely on scheduling luck."
+      ]
+    },
+    "deduct_balance_TOCTOU": {
+      "status": "fixed",
+      "notes": [
+        "Single conditional UPDATE `WHERE api_key = ? AND balance_micro_usdc >= ?` is a single SQLite statement. SQLite serializes all writes, so two concurrent executions cannot both pass the guard. Atomic at the database level without an explicit transaction needed.",
+        "changes()==0 branch uses a follow-up read-only `get_balance` call to produce a precise error message (None => not found, Some(bal) => insufficient). This is semantically correct. The comment correctly notes that the balance read may be slightly stale — acceptable because the code is on a rejection path only; no financial side-effects can occur from stale diagnostics.",
+        "Concurrent test `deduct_balance_concurrent_cannot_overdraw` uses the same Barrier + file-backed dual-connection pattern. Final balance assertion (100 - 75 = 25) definitively proves no overdraft. Sound."
+      ]
+    },
+    "random_bytes_fallback": {
+      "status": "fixed",
+      "notes": [
+        "The SHA-256(timestamp+PID+counter) fallback branch is completely removed. `random_bytes` now returns `anyhow::Result<[u8; N]>` and fails loudly via `?` propagation if /dev/urandom is unavailable or unreadable. `create_api_key` propagates the error upward; the HTTP handler returns 500. No silent fallback path remains."
+      ]
+    },
+    "deposit_403_info_leak": {
+      "status": "fixed",
+      "notes": [
+        "The partial pubkey and tx_sig prefixes are removed from the 403 response body. The client now receives only: `{\"error\": \"deposit rejected: API key owner is not a signer of this transaction\"}`. Full owner_pubkey, tx_sig, and signers list are logged server-side via `tracing::warn!` for operator debugging. No identifier leaks in the 403 body."
+      ]
+    },
+    "refund_tx_sig_collision": {
+      "status": "fixed",
+      "notes": [
+        "Refunds now use the dedicated `refund_balance` function which writes `tx_sig=NULL` to payment_events and `event_type='refund'`. NULL values are exempt from the partial UNIQUE index (`WHERE tx_sig IS NOT NULL`), so repeated refunds with identical reasons all apply correctly.",
+        "Security soundness: NULL exemption is intentional and documented. An attacker cannot exploit this because refund_balance is only called from the authenticated mcp_handler after a deduct_balance has already succeeded. The balance can never increase beyond what was previously deducted (refund amount == deducted cost). No double-refund amplification is possible via NULL.",
+        "Accounting correctness: test `refund_balance_allows_duplicate_reasons` seeds a key, fires two identical-reason refunds, and asserts both increment the balance and both rows exist in payment_events. The accounting is correct."
+      ]
+    }
+  },
+  "deferred_findings_assessment": {
+    "CORS_allow_origin_Any": {
+      "deferred": true,
+      "acceptable": true,
+      "rationale": "Pre-existing, self-hosted server context. The payment routes are not credentialed (no cookies), and the api_key bearer token is the real auth control. A malicious cross-origin page cannot extract the bearer token from the client that submitted the request. Deferral is acceptable as a tracked debt item."
+    },
+    "admin_stats_no_auth": {
+      "deferred": true,
+      "acceptable": true,
+      "rationale": "Pre-existing. The endpoint exposes only aggregate P&L data (no keys, no tx sigs, no user-identifiable information). For a self-hosted single-operator server this is a low-impact exposure. Deferral is acceptable as tracked debt."
+    }
+  },
+  "status": "approved",
+  "summary": {
+    "totalFindings": 2,
+    "critical": 0,
+    "major": 0,
+    "minor": 2
+  },
+  "findings": [
+    {
+      "severity": "minor",
+      "category": "A04: Insecure Design / data integrity",
+      "title": "deduct_balance: payment_events charge INSERT is outside any transaction",
+      "description": "The atomic UPDATE in `deduct_balance` correctly prevents balance overdraft, but the subsequent `INSERT INTO payment_events` that records the charge event is a separate, unguarded statement outside any explicit transaction. If this INSERT fails (e.g. disk full, constraint on uuid collision), the balance has already been decremented but no audit trail exists for the charge. This creates a silent accounting discrepancy: the balance reflects the deduction but the payment_events ledger does not.",
+      "location": "mcp/src/payment.rs:368-371 (deduct_balance, charge INSERT)",
+      "impact": "If the INSERT fails, the operator's payment_events ledger is silently incomplete. The user was charged but there is no charge event. Financial reconciliation would show a balance deficit with no matching charge record. In practice the only failure mode is a SQLite error (disk full, process kill) which is unusual, but it is not protected against.",
+      "recommendation": "Wrap the UPDATE and INSERT in an IMMEDIATE transaction, matching the pattern used in `credit_deposit` and `refund_balance`:\n```rust\nconn.execute(\"BEGIN IMMEDIATE\", [])?;\n// existing UPDATE ...\n// existing INSERT ...\nconn.execute(\"COMMIT\", [])?;\n```\nThis ensures both statements are applied atomically or neither is.",
+      "cwe": "CWE-362"
+    },
+    {
+      "severity": "minor",
+      "category": "A05: Security Misconfiguration / migration safety",
+      "title": "Partial UNIQUE index migration fails on existing databases with duplicate tx_sigs",
+      "description": "`CREATE UNIQUE INDEX IF NOT EXISTS uq_payment_events_tx_sig ON payment_events(tx_sig) WHERE tx_sig IS NOT NULL` is executed via `execute_batch(SCHEMA)` every time `SqliteStore::open` is called. If a database on disk already has two payment_events rows where tx_sig is the same non-NULL value (produced by the old SELECT COUNT + INSERT pattern before this fix was deployed), the `CREATE UNIQUE INDEX` statement will fail with `SQLITE_CONSTRAINT` and the entire schema batch will be rejected — causing the server to fail to start on the first restart after deployment.",
+      "location": "core/src/storage/sqlite.rs:53-55 (uq_payment_events_tx_sig creation)",
+      "impact": "Operators upgrading from the pre-fix codebase on a database that experienced the TOCTOU race (i.e. a duplicate deposit was credited before this fix) will find the server refuses to start after the update. This is a deployment availability issue, not a data breach, but it could cause downtime if the schema migration is not handled before restart.",
+      "recommendation": "Before adding the UNIQUE index, deduplicate any existing offending rows, or use a two-step migration: (1) DELETE duplicate payment_events keeping only the earliest row per tx_sig (`DELETE FROM payment_events WHERE rowid NOT IN (SELECT MIN(rowid) FROM payment_events WHERE tx_sig IS NOT NULL GROUP BY tx_sig)`), then (2) CREATE the UNIQUE INDEX. Alternatively, document this as a breaking migration requirement in the deployment runbook and accept manual intervention on affected databases.",
+      "cwe": "CWE-440"
+    }
+  ],
+  "additional_axes_checked": {
+    "test_helpers_leak_real_keys_or_urls": {
+      "result": "clean",
+      "notes": "Test helper `fresh_store()` uses `SqliteStore::in_memory()`. `fresh_file_store()` uses `tempfile::tempdir()` with a synthetic path. All test api_key owner values are synthetic strings ('owner_a', 'owner_concurrent', 'owner_overdraft', 'owner_b', 'owner_c'). Test tx_sig values are synthetic ('same_tx_abc_123', 'seed_tx', 'unique_sig'). No real keys, pubkeys, or production URLs appear in the test module."
+    },
+    "new_partial_unique_index_migration_safety": {
+      "result": "flagged as minor finding above",
+      "notes": "CREATE UNIQUE INDEX IF NOT EXISTS will fail if pre-existing duplicate tx_sigs exist on disk. Flagged as minor finding."
+    },
+    "hardcoded_secrets_scan": {
+      "result": "clean",
+      "notes": "config.rs uses env_or() for all credentials (OPENAI_API_KEY, TREASURY_PUBKEY, SOLANA_RPC_URL, etc.) with safe defaults (empty strings or localhost URLs). The USDC mint address hardcoded as default ('EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v') is a public mainnet contract address — not a secret. No API keys, private keys, or passwords hardcoded in source."
+    },
+    "owasp_coverage": {
+      "A01_broken_access_control": "No new routes or privilege paths introduced. Existing deposit authz (signer check) unchanged and still correct.",
+      "A02_cryptographic_failures": "random_bytes fallback removed; /dev/urandom is now the only entropy source and failure is fatal. Improvement over round 1.",
+      "A03_injection": "No new SQL string interpolation. All new queries use params![] macro.",
+      "A04_insecure_design": "deduct_balance charge INSERT atomicity gap flagged as minor (new finding).",
+      "A05_misconfiguration": "UNIQUE index migration risk flagged as minor (new finding). CORS Any and admin_stats auth remain deferred pre-existing items.",
+      "A06_vulnerable_components": "No new dependencies added. tempfile added to dev-dependencies only; not in production binary.",
+      "A07_auth_failures": "No changes to auth paths. Bearer token extraction unchanged.",
+      "A08_software_data_integrity": "No deserialization changes. JSON parsing uses serde which is safe.",
+      "A09_logging_monitoring": "Improved: full identifiers now logged server-side via tracing::warn! on deposit rejection. Refund failures now logged via tracing::warn! instead of silently discarded with let _ =.",
+      "A10_SSRF": "No new URL construction from user input."
+    }
+  },
+  "notes": "All five round-1 findings are correctly addressed. Both major TOCTOU races are closed atomically. The random_bytes fallback is completely removed. The 403 info leak is remediated. The refund collision is resolved via a dedicated refund_balance function with NULL tx_sig. Two new minor findings are raised: (1) deduct_balance charge INSERT lacks transaction protection (accounting integrity gap, not a security vector), and (2) the UNIQUE index migration can fail on databases with pre-existing duplicate tx_sigs from the old code path. Neither is critical. The round-2 verdict is APPROVED."
+}

--- a/work/mnemonic-core/logs/working/task-11/security-auditor-round3.json
+++ b/work/mnemonic-core/logs/working/task-11/security-auditor-round3.json
@@ -1,0 +1,118 @@
+{
+  "reviewer": "security-auditor",
+  "round": 3,
+  "task": 11,
+  "verdict": "approved",
+  "round2_findings_resolved": {
+    "deduct_balance_audit_trail_not_in_txn": {
+      "status": "fixed",
+      "severity_was": "minor",
+      "analysis": [
+        "BEGIN IMMEDIATE is issued before the UPDATE, acquiring the SQLite write lock at transaction open. This is semantically correct for rusqlite: rusqlite's Connection does not auto-begin, so the explicit BEGIN IMMEDIATE is the only way to open a named transaction from Rust. Verified against rusqlite docs — execute(\"BEGIN IMMEDIATE\", []) works identically to conn.execute_batch(\"BEGIN IMMEDIATE;\").",
+        "The error-handling paths are exhaustive: (1) UPDATE fails -> ROLLBACK + return Err; (2) changed==0 (key not found or insufficient balance) -> ROLLBACK + produce diagnostic via read-only get_balance; (3) INSERT fails -> ROLLBACK + return Err; (4) all success -> COMMIT. No path exits without either committing or rolling back.",
+        "The ROLLBACK on the changed==0 path correctly releases the write lock before calling get_balance. get_balance issues a read-only SELECT that does not require the write lock. Under WAL mode (now enabled) readers never block on writers, so this is safe even if another connection is mid-write.",
+        "One subtle point: after ROLLBACK the in-flight get_balance call reads a committed view. Since the UPDATE was rolled back, the balance read is consistent. The comment notes it 'may be slightly stale' — this is acceptable because the path is diagnostic-only; no financial mutation follows.",
+        "The test deduct_balance_audit_insert_failure_rolls_back_balance installs a BEFORE INSERT trigger that raises ABORT, then asserts (1) the call errors, (2) balance is unchanged at 500, (3) no charge row was written, and (4) the store is not stuck after the rolled-back transaction. SQLITE_ABORT from a trigger causes rusqlite to return Err, which the Rust code maps correctly to the insert_res Err branch, issuing ROLLBACK. Test methodology is sound.",
+        "No concern: the manual ROLLBACK via conn.execute(\"ROLLBACK\", []) uses let _ = to suppress its own error. This is the correct pattern — if ROLLBACK itself errors (which can only happen if there is no active transaction, i.e. the BEGIN IMMEDIATE already errored), we are already in an error path and the suppression avoids a confusing double-error. The outer return Err(e.into()) is what the caller sees."
+      ]
+    },
+    "migration_fails_on_existing_dbs_with_duplicate_tx_sig": {
+      "status": "fixed",
+      "severity_was": "minor",
+      "analysis": [
+        "The migrate_payment_events_unique_index helper runs inside a single BEGIN IMMEDIATE / COMMIT block, so the DELETE and CREATE UNIQUE INDEX are atomic. A concurrent opener that loses the lock race will wait (up to busy_timeout=5000ms) and then observe the fully migrated state.",
+        "The dedup logic keeps MIN(rowid) per tx_sig, which is the earliest-inserted row. This is the correct forensic choice: the first row was the legitimate credit_deposit; duplicates were spurious second writes from the pre-fix TOCTOU race. No legitimate row is deleted.",
+        "The auto-dedup is a no-op on fresh or already-clean databases because the DELETE WHERE rowid NOT IN (...) sub-query returns an empty set when there are no duplicates. CREATE UNIQUE INDEX IF NOT EXISTS is idempotent and cheap once the index exists.",
+        "The migration runs on both open() (file-backed) and in_memory() (test). Running it on in-memory stores is harmless and ensures test stores behave identically to production stores with respect to schema constraints.",
+        "Forensic risk assessment: the deleted rows are duplicates produced by a TOCTOU race; they represent erroneous double-credits that should not have existed. Operators who suspect fraud (unusual duplicate deposits before upgrade) are advised in the decisions.md to audit payment_events before upgrading — but the code does not enforce this. This is an acceptable risk for a self-hosted operator-grade tool. The surviving row (MIN(rowid)) preserves the full audit record for the legitimate credit."
+      ]
+    }
+  },
+  "targeted_review": {
+    "transaction_pattern_correctness": {
+      "verdict": "correct",
+      "details": "BEGIN IMMEDIATE acquires an IMMEDIATE write lock in rusqlite, preventing any other connection from opening a RESERVED or EXCLUSIVE lock. The UPDATE executes within this lock. changes() is called (implicitly via the return value of execute()) before any other statement, which is the correct rusqlite API for reading the per-connection row-change counter. INSERT executes within the same transaction. COMMIT releases the lock. The sequence UPDATE-check-INSERT-COMMIT is logically sound. No re-entrant connection issue exists because SqliteStore is !Send and each store owns exactly one Connection."
+    },
+    "auto_dedup_migration_security_risks": {
+      "verdict": "acceptable — no new security risk introduced",
+      "details": [
+        "Silent deletion of duplicates: the deleted rows are TOCTOU artifacts (spurious second credits). Deleting them does not create a security hole because: (a) the balance was double-credited at the time of the race, and (b) the operator would need to reconcile balance against payment_events anyway. The surviving MIN(rowid) row is the complete audit record.",
+        "Wrong-row selection risk: MIN(rowid) reliably selects the row that SQLite assigned the lowest internal rowid, which is guaranteed to be the one inserted first in a single-connection sequential scenario. In the concurrent race scenario, rowid assignment is serialized by SQLite's write lock, so MIN(rowid) is still deterministic. There is no ambiguity about which row is 'correct'.",
+        "Forensic information loss: the deleted duplicate rows contained the same tx_sig, api_key, amount, and created_at as the surviving row (same function call, same inputs). The only information lost is proof that two rows existed, which is itself evidence of the old bug. Operators who want to preserve this evidence for audit should take a DB snapshot before the first post-upgrade restart. This is not documented in-code but is noted in decisions.md.",
+        "Recommendation (minor, informational): Consider logging a warning via tracing::warn! if the DELETE removes any rows, e.g. 'migrated N duplicate tx_sig rows from payment_events'. This would surface the event in operator logs without blocking startup or requiring manual intervention. Currently the dedup is completely silent."
+      ]
+    },
+    "wal_mode_security_implications": {
+      "verdict": "acceptable with operator awareness note",
+      "details": [
+        "WAL mode creates two additional files alongside the main DB: <name>-wal (write-ahead log) and <name>-shm (shared memory index). These files contain recent uncommitted and committed transactions and must be protected with the same filesystem permissions as the main DB file. If the main DB file is chmod 600 (owner-only) but the WAL/SHM files inherit a more permissive umask, an unprivileged user could read the WAL to reconstruct recent transactions including api_keys, balance changes, and payment_events.",
+        "The code does not set the WAL/SHM file permissions explicitly. std::fs::create_dir_all creates the parent directory but does not set a restrictive umask on the files SQLite creates. File permissions depend on the process umask at startup.",
+        "This is not a new vulnerability introduced by round 3 — the main DB file already had the same permission-dependency. WAL mode increases the attack surface slightly by adding two more files that must be protected.",
+        "The busy_timeout=5000 setting is not a security concern. It affects how long a loser of a lock race waits before returning SQLITE_BUSY. 5 seconds is reasonable for a payment workload and does not create a DoS amplification risk beyond what SQLite already allows.",
+        "WAL mode checkpoint behavior: WAL frames are merged back to the main DB on connection close or explicit PRAGMA wal_checkpoint. This is handled automatically by SQLite. No security implication beyond the file-permission note above.",
+        "Operator documentation recommendation (minor, informational): the deployment runbook should note that the DB directory (and all files within it, including -wal and -shm) must be restricted to the service account. This is not a code change but a documentation gap."
+      ]
+    },
+    "new_issues_in_round3": {
+      "verdict": "no new security issues found",
+      "details": [
+        "No new SQL queries or parameterization changes. All inserts/selects in the migration helper use literal SQL with no user-supplied values.",
+        "No new routes, auth paths, or input-handling code.",
+        "No new dependencies in Cargo.toml.",
+        "ROLLBACK-on-error pattern is consistent across the new deduct_balance code and the existing credit_deposit / refund_balance functions.",
+        "The test trigger (CREATE TRIGGER force_fail_charge) is installed only in a test-module function and is dropped at the end of the test. No production code path creates or depends on this trigger.",
+        "No hardcoded secrets, keys, or credentials introduced."
+      ]
+    }
+  },
+  "owasp_final_sweep": {
+    "A01_broken_access_control": "No new routes or privilege paths. Unchanged from round 2.",
+    "A02_cryptographic_failures": "No changes. random_bytes fallback was removed in round 2.",
+    "A03_injection": "No new SQL string interpolation. Migration SQL in migrate_payment_events_unique_index uses no user-supplied values — all literals.",
+    "A04_insecure_design": "deduct_balance atomicity gap is now closed. UPDATE + INSERT are in one BEGIN IMMEDIATE transaction.",
+    "A05_misconfiguration": "WAL/SHM file permissions are an operator-configuration concern, not a code defect. Noted as informational. UNIQUE index migration is now safe on legacy DBs.",
+    "A06_vulnerable_components": "No new production dependencies.",
+    "A07_auth_failures": "No changes to auth paths.",
+    "A08_software_data_integrity": "No deserialization changes.",
+    "A09_logging_monitoring": "Silent dedup during migration is a minor informational gap (no tracing::warn! if rows deleted). Not a security finding but noted.",
+    "A10_SSRF": "No new URL construction from user input."
+  },
+  "status": "approved",
+  "summary": {
+    "totalFindings": 2,
+    "critical": 0,
+    "major": 0,
+    "minor": 2
+  },
+  "findings": [
+    {
+      "severity": "minor",
+      "category": "A05: Security Misconfiguration",
+      "title": "WAL mode adds -wal and -shm files that must be protected with same permissions as main DB",
+      "description": "Enabling WAL mode (PRAGMA journal_mode=WAL) causes SQLite to create two companion files: <dbname>-wal and <dbname>-shm. These files contain recent committed and uncommitted transaction data, including payment_events and api_keys. The code does not explicitly set filesystem permissions on these files; their permissions depend on the process umask. If the umask is too permissive, an unprivileged local user could read the WAL file and reconstruct recent payment and key data.",
+      "location": "core/src/storage/sqlite.rs:125 (PRAGMA journal_mode=WAL)",
+      "impact": "Local privilege escalation to read payment data, api_keys, and balance information from WAL/SHM files if the operator runs the service with a permissive umask. This is a deployment configuration risk, not a remote exploitation vector.",
+      "recommendation": "Document in the deployment runbook that the DB directory (and all files, including -wal and -shm) must be chmod 700 / owned by the service account. Optionally, set a restrictive umask (0o077) in main() before SqliteStore::open is called, or set permissions on the DB directory explicitly in SqliteStore::open after create_dir_all.",
+      "cwe": "CWE-732"
+    },
+    {
+      "severity": "minor",
+      "category": "A09: Security Logging and Monitoring",
+      "title": "Auto-dedup migration silently removes rows — no operator-visible log entry",
+      "description": "migrate_payment_events_unique_index silently deletes duplicate tx_sig rows (TOCTOU artifacts from the old code path) and creates the UNIQUE index. If the DELETE removes any rows, the operator has no record of the cleanup in the application logs. A suspicious operator (or auditor) reviewing logs after an upgrade would see no indication that rows were removed, making forensic reconstruction harder.",
+      "location": "core/src/storage/sqlite.rs:96-110 (migrate_payment_events_unique_index)",
+      "impact": "Reduced auditability of the migration step. If duplicate rows existed due to an actual double-credit exploit rather than the TOCTOU race, the cleanup would be silent and the operator would be unaware.",
+      "recommendation": "After the DELETE, query the number of affected rows (or check sqlite3_changes()) and emit a tracing::warn! if count > 0. Example: 'Removed N duplicate tx_sig rows from payment_events during migration — these were TOCTOU artifacts from the pre-fix code path.' This makes the migration auditable without blocking startup.",
+      "cwe": "CWE-778"
+    }
+  ],
+  "round2_findings_closure": {
+    "minor_deduct_balance_audit_trail": "RESOLVED — BEGIN IMMEDIATE wraps UPDATE + INSERT; all error paths issue ROLLBACK; test confirms balance is untouched when INSERT fails.",
+    "minor_unique_index_migration_safety": "RESOLVED — migrate_payment_events_unique_index deletes duplicates (keeping MIN(rowid)) inside BEGIN IMMEDIATE before creating the UNIQUE index; idempotent and safe on fresh DBs."
+  },
+  "deferred_carried_items": {
+    "CORS_allow_origin_Any": "Still deferred, still acceptable. No change in round 3.",
+    "admin_stats_no_auth": "Still deferred, still acceptable. No change in round 3."
+  },
+  "notes": "Both round-2 minor findings are correctly resolved. The transaction pattern in deduct_balance is semantically correct under rusqlite semantics. The auto-dedup migration is safe, idempotent, and preserves the forensically relevant row (MIN(rowid) = earliest insert). WAL mode is operationally sound; the -wal/-shm file-permission concern is a pre-existing deployment configuration risk elevated slightly by WAL, not a new code defect. No new critical or major issues were found. The round-3 verdict is APPROVED."
+}

--- a/work/mnemonic-core/logs/working/task-11/test-reviewer-round1.json
+++ b/work/mnemonic-core/logs/working/task-11/test-reviewer-round1.json
@@ -1,0 +1,63 @@
+{
+  "reviewer": "test-reviewer",
+  "round": 1,
+  "task": "11",
+  "verdict": "needs_improvement",
+  "status": "needs_improvement",
+  "summary": "Test count parity is acceptable: db.rs had zero tests before deletion, so no coverage was lost in the move. The 83 tests remain intact. However, payment.rs now contains 9 DB functions operating on real money (create_api_key, deduct_balance, credit_deposit, mark_x402_nonce, get_pnl_stats, etc.) with zero automated tests. The MCP round-trip smoke test and the cold-init regression concern are captured only by manual one-shot verification — neither is automated. These gaps are non-blocking for a pure rewiring task but represent accumulating debt on financial-critical code.",
+  "findings": [
+    {
+      "severity": "major",
+      "category": "missing_coverage",
+      "location": "mcp/src/payment.rs (entire file, 491 lines)",
+      "issue": "payment.rs contains 9 DB functions handling real money (create_api_key, get_owner_pubkey, get_balance, deduct_balance, credit_deposit, mark_x402_nonce, record_attestation_cost, get_pnl_stats, random_bytes) plus check_payment/check_balance/check_x402 payment-gating logic. No test module exists — not before deletion of db.rs and not after the merge. These functions contain non-trivial business logic: deduct_balance enforces an insufficient-funds guard, credit_deposit enforces idempotency via tx_sig deduplication, mark_x402_nonce enforces replay protection via UNIQUE constraint, get_pnl_stats performs a multi-column aggregation with margin-pct arithmetic. None of these code paths is covered by any automated test.",
+      "recommendation": "Add a #[cfg(test)] module to mcp/src/payment.rs using tempfile::NamedTempFile + SqliteStore::open_path to create an in-memory/temp SQLite database. Required test cases: (1) create_api_key returns a key with mnm_ prefix and persists a row; (2) deduct_balance succeeds when balance is sufficient and records a charge event; (3) deduct_balance returns Err when balance is insufficient — balance must be unchanged after the error; (4) credit_deposit increments balance and returns new balance; (5) credit_deposit returns Err on duplicate tx_sig (idempotency guard); (6) mark_x402_nonce returns Ok on first use and Err on second use with same sig; (7) get_pnl_stats returns margin_pct = 0.0 for empty attestation_costs, and correct arithmetic for a seeded row. These do not require network or async — all are synchronous SQLite operations on a temp DB.",
+      "litmusTestFailed": true,
+      "litmusNote": "Currently there are zero test assertions for this code — removing any of the 9 DB functions would not cause any test to fail."
+    },
+    {
+      "severity": "major",
+      "category": "missing_coverage",
+      "location": "MCP round-trip — no automated test, decisions.md task-11 verification section",
+      "issue": "The MCP stdio round-trip (echo tools/list JSON-RPC call, assert 5 tools returned with correct names) was verified once manually during task completion. It is not an automated test. Any future refactor of tools.rs, mcp.rs, or main.rs that drops or renames a tool will not be caught by cargo test. The decisions.md records 'MCP stdio round-trip -> 5 entries' as one-shot evidence — this does not protect against regression.",
+      "recommendation": "Add an integration test that spawns `cargo run -p mnemonic-mcp -- --transport stdio` as a child process (std::process::Command), writes the tools/list JSON-RPC request to stdin, reads stdout, and asserts: (a) response contains 'result', (b) the tools array has exactly 5 elements, (c) each of the 5 expected names is present (mnemonic_whoami, mnemonic_sign_memory, mnemonic_verify, mnemonic_prove_identity, mnemonic_recall). Place this in mcp/tests/smoke_rpc.rs. Gate it with a CI feature flag or #[ignore] to avoid blocking fast unit runs, and use a timeout of at least 120s to account for cold-init."
+    },
+    {
+      "severity": "minor",
+      "category": "missing_coverage",
+      "location": "Cold-init ~90s — noted in decisions.md task-11 deviations, no automated check",
+      "issue": "The teammate noted that TurboQuant cold-init for 1536-dim embeddings takes ~90s, and that a CI script with a 10s default timeout would fail. There is no automated performance guard. A future change (e.g., swapping the embedding backend, changing dim count, altering feature flags) could silently regress cold-init to 900s or fail it entirely. The 90s observation exists only as a prose note in decisions.md.",
+      "recommendation": "Add a timed smoke test (e.g., mcp/tests/cold_init_timing.rs, #[ignore] by default, run explicitly in CI nightly) that measures wall-clock time from process spawn to first valid JSON-RPC response and asserts it is under a configurable threshold (e.g., 180s). This provides a regression baseline without blocking PRs. Alternatively, document the expected range in a CI environment variable COLD_INIT_TIMEOUT_SECS and assert against it in the stdio smoke test."
+    },
+    {
+      "severity": "minor",
+      "category": "missing_coverage",
+      "location": "mcp/src/payment.rs:check_balance, check_x402, check_payment",
+      "issue": "The payment-gating logic (check_balance, check_x402, check_payment with modes 'balance', 'x402', 'both', 'none') has no unit tests. The 'both' mode has a fall-through logic (try balance, fall through to x402 on failure) that was refactored in this task (match -> if-let). The refactored path is untested — a bug in the fall-through would silently allow or block payments.",
+      "recommendation": "Unit-test check_balance with a mocked/temp SqliteStore: (1) Proceed when balance >= cost; (2) Unauthorized when balance < cost; (3) Unauthorized when key not found. For check_payment with mode 'none', assert PaymentGate::Proceed(None) is returned without any DB interaction. The x402 path requires a mock Solana RPC and is appropriately skipped in unit tests, but the balance portion of 'both' mode is testable synchronously."
+    }
+  ],
+  "notes": [
+    "Test count parity analysis: db.rs (deleted) contained 208 lines but zero tests — confirmed by reading the full deleted file in the diff. No coverage was lost by the deletion. The 83 passing tests (75 core unit + 5 integration + 3 proptest) all live in mnemonic-core, not mnemonic-mcp. This parity is expected and acceptable per the task spec's TDD anchor ('compile + test chain itself').",
+    "The task spec explicitly defines the TDD anchor as the compile+clippy+test chain, not new unit tests. The test gaps flagged here are pre-existing debt that this task's scope did not require addressing. The major findings are flagged to surface accumulating risk on financial logic, not to block the current rewiring.",
+    "db.rs did not have a #[cfg(test)] block before deletion — verified by reading the full 208-line deleted file in the diff. The move to payment.rs preserves the zero-test state of this code.",
+    "random_bytes has a fallback path (SHA256 from system time when /dev/urandom is unavailable) that is never tested. On production Linux this path is unreachable, but it is dead untested code that could produce weak entropy silently."
+  ],
+  "metrics": {
+    "filesReviewed": 6,
+    "litmusTest": {
+      "checked": 9,
+      "passed": 0,
+      "failed": 9,
+      "note": "All 9 DB helper functions in payment.rs fail the litmus test — removing any of them would not cause any automated test to fail, because no tests exist for them."
+    },
+    "coverageAssessment": "insufficient",
+    "pyramidBalance": {
+      "unit": 75,
+      "integration": 8,
+      "e2e": 0,
+      "assessment": "unbalanced",
+      "note": "All 83 tests cover mnemonic-core only. mnemonic-mcp has zero automated tests despite containing financial logic (payment gating, balance management, replay protection)."
+    }
+  }
+}

--- a/work/mnemonic-core/logs/working/task-11/test-reviewer-round2.json
+++ b/work/mnemonic-core/logs/working/task-11/test-reviewer-round2.json
@@ -1,0 +1,96 @@
+{
+  "reviewer": "test-reviewer",
+  "round": 2,
+  "task": "11",
+  "verdict": "passed",
+  "status": "passed",
+  "summary": "The 6 new tests are well-designed and directly address the two round-1 major findings on financial logic. The concurrent tests use the correct ingredients (file-backed DB, separate connections, Barrier synchronization) and carry assertions strong enough to catch regressions. The three-function set (deduct, credit, refund) now has deterministic coverage of all safety-critical paths. The deferred items (remaining helpers, MCP stdio smoke, cold-init timing) are reasonable scoping decisions for a rewiring task: the financial-safety-critical paths are now covered and the deferred debt is tracked explicitly in decisions.md.",
+  "findings": [
+    {
+      "severity": "minor",
+      "category": "missing_coverage",
+      "location": "mcp/src/payment.rs — deduct_balance_concurrent_cannot_overdraw",
+      "issue": "The concurrent overdraft test uses `ok_count == 1` to assert exactly one deduct succeeds and `final_bal == 25` to verify no double-deduct. However, both threads open independent SqliteStore handles to the same file. SQLite WAL-mode or journal-mode differences could cause one thread to receive `SQLITE_BUSY` (returned as a rusqlite Err) rather than the 'insufficient balance' error. In that scenario ok_count == 0 and the assertion fails spuriously on a slow CI runner. The test is mostly deterministic because SQLite serializes writers, but busy-timeout behaviour (default 0ms) can cause false failures under I/O contention. This is a minor flakiness risk, not a logic gap — the core assertion (final_bal == 25, never negative) is sound.",
+      "recommendation": "Add `PRAGMA busy_timeout = 5000;` immediately after each `SqliteStore::open` call inside the thread closures, or configure it via `SqliteStore::open` if the API supports it. This eliminates SQLITE_BUSY false failures without changing the race semantics. Alternatively, accept-and-document: if either thread returns an Err, assert that the error message is either 'insufficient balance' OR contains 'database is locked', then re-check the balance."
+    },
+    {
+      "severity": "minor",
+      "category": "missing_coverage",
+      "location": "mcp/src/payment.rs — entire #[cfg(test)] module",
+      "issue": "The test module has no coverage for create_api_key (key format/prefix), mark_x402_nonce (replay protection), get_pnl_stats (arithmetic), record_attestation_cost, or the check_balance/check_payment payment-gating logic. These were flagged as round-1 minor items and are explicitly deferred in decisions.md with team-lead approval. Calling them out for completeness — they remain open debt.",
+      "recommendation": "Track as follow-up: add tests for mark_x402_nonce (first call Ok, second Err), get_pnl_stats (zero-row returns margin 0.0, seeded row returns correct arithmetic), and create_api_key (result starts with 'mnm_', length correct, row persisted). These are all synchronous SQLite operations on a fresh_store() — no network or async required."
+    },
+    {
+      "severity": "minor",
+      "category": "missing_coverage",
+      "location": "MCP stdio round-trip — still no automated test",
+      "issue": "The round-1 major finding on MCP stdio round-trip automation remains deferred. This is explicitly approved in decisions.md. Not escalated to major because the financial-safety code (the higher-priority gap) is now covered.",
+      "recommendation": "Follow-up task: add mcp/tests/smoke_rpc.rs that spawns the binary via std::process::Command, sends tools/list JSON-RPC to stdin, and asserts exactly 5 tool names in the response. Gate with #[ignore] for CI speed."
+    }
+  ],
+  "roundOneResolution": {
+    "major_payment_tests": {
+      "status": "resolved",
+      "detail": "Round-1 major finding (zero tests for payment.rs DB functions) is substantially resolved. The three financial-safety-critical functions — deduct_balance, credit_deposit, refund_balance — now have 6 tests covering: normal success paths, insufficient-funds path, unknown-key path, sequential idempotency, concurrent double-credit prevention (UNIQUE constraint + BEGIN IMMEDIATE), concurrent overdraft prevention (atomic conditional UPDATE), and duplicate-refund allowance (tx_sig=NULL partial index exemption). Litmus test now passes for all 3 functions."
+    },
+    "major_mcp_smoke": {
+      "status": "deferred",
+      "detail": "MCP stdio round-trip smoke test was not added. Deferred with explicit team-lead approval in decisions.md. Downgraded from major to minor given that the higher-priority financial code is now covered."
+    },
+    "minor_cold_init": {
+      "status": "deferred",
+      "detail": "Cold-init timing regression guard deferred. No change from round 1. Remains minor."
+    },
+    "minor_check_balance_logic": {
+      "status": "deferred",
+      "detail": "check_balance/check_x402/check_payment gating logic still has no unit tests. Deferred. Remains minor."
+    }
+  },
+  "concurrentTestAnalysis": {
+    "credit_deposit_concurrent_same_tx_sig_applies_once": {
+      "raceIngredients": "correct — file-backed DB (not in-memory), two separate SqliteStore::open calls creating independent connections, Barrier::wait() synchronizes thread entry, BEGIN IMMEDIATE in credit_deposit serializes at DB level",
+      "determinism": "high — UNIQUE index violation is deterministic regardless of thread ordering; one thread wins the IMMEDIATE lock and commits, the other receives ConstraintViolation on rollback",
+      "assertionStrength": "strong — asserts exactly 1 success AND exactly 1 failure AND error message contains 'deposit tx already applied' AND balance equals exactly one amount (not two) AND payment_events has exactly 1 deposit row for the tx_sig",
+      "flakiness": "low — the only non-determinism is which thread wins the lock (r1 or r2), but the outcome counts are invariant regardless"
+    },
+    "deduct_balance_concurrent_cannot_overdraw": {
+      "raceIngredients": "correct — file-backed DB, two independent connections, Barrier synchronizes entry; deduct_balance uses single conditional UPDATE (no BEGIN IMMEDIATE needed for atomic read+write since SQLite serializes writers at statement level)",
+      "determinism": "high — the conditional UPDATE WHERE balance >= amount atomically checks and deducts; second thread sees updated balance and fails the WHERE clause",
+      "assertionStrength": "good — asserts ok_count == 1 (exactly one deduct succeeds) AND final_bal == 25 (balance is 100 - 75, never negative). The exact-balance assertion is the critical regression guard",
+      "flakiness": "low-to-medium — slight risk if SqliteStore busy_timeout is 0ms and one thread gets SQLITE_BUSY before executing the UPDATE, producing ok_count == 0 and a spurious failure. In practice SQLite WAL serializes write-lock acquisition, but CI I/O pressure could trigger this"
+    }
+  },
+  "newFunctionCoverage": {
+    "refund_balance": "covered by refund_balance_allows_duplicate_reasons (success + duplicate-reason both apply + event rows counted)",
+    "credit_deposit": "covered by credit_deposit_concurrent_same_tx_sig_applies_once (concurrent idempotency) + credit_deposit_sequential_duplicate_is_rejected (sequential idempotency) + balance-verification in both",
+    "deduct_balance": "covered by deduct_balance_concurrent_cannot_overdraw (overdraft prevention) + deduct_balance_insufficient_leaves_balance_unchanged (error path + balance unchanged) + deduct_balance_unknown_key_reports_not_found (missing key path)",
+    "get_balance": "indirectly exercised as setup/verification in every test but has no dedicated test",
+    "create_api_key": "indirectly exercised as setup in every test but key format/persistence not directly asserted",
+    "mark_x402_nonce": "not covered — deferred",
+    "get_pnl_stats": "not covered — deferred",
+    "record_attestation_cost": "not covered — deferred",
+    "check_balance_check_x402_check_payment": "not covered — deferred"
+  },
+  "deferralReasonableness": {
+    "assessment": "reasonable",
+    "detail": "Task 11 scope is 'db.rs -> payment.rs rewiring + verification'. The three functions with live-money safety properties (deduct, credit, refund) are now tested. The remaining helpers (mark_x402_nonce, get_pnl_stats, record_attestation_cost) have simpler logic and lower real-money-at-risk severity. The MCP smoke test and cold-init guard are infrastructure concerns that belong in a dedicated test-coverage task. The deferral is explicitly documented in decisions.md with specific follow-up items listed — this is the correct practice.",
+    "escalate": "None — no deferred item is severe enough to re-block the task. The most important follow-up (mark_x402_nonce replay protection) should be prioritized in the next test-coverage task since it guards against x402 payment replay."
+  },
+  "metrics": {
+    "filesReviewed": 3,
+    "litmusTest": {
+      "checked": 6,
+      "passed": 6,
+      "failed": 0,
+      "note": "All 6 new tests fail the litmus test in the intended direction: removing deduct_balance causes 3 tests to fail, removing credit_deposit causes 2 tests to fail, removing refund_balance causes 1 test to fail. Each test is tied to specific behavior that would regress without the implementation."
+    },
+    "coverageAssessment": "adequate",
+    "pyramidBalance": {
+      "unit": 81,
+      "integration": 8,
+      "e2e": 0,
+      "assessment": "healthy",
+      "note": "89 total tests (83 mnemonic-core + 6 new mnemonic-mcp). The 6 new tests are unit/integration hybrids (real SQLite, no network) — appropriate for DB logic. The pyramid remains unit-heavy, which is correct for this codebase type. E2E gap is acceptable given no user-facing UI."
+    }
+  }
+}

--- a/work/mnemonic-core/logs/working/task-12/code-reviewer-round1.json
+++ b/work/mnemonic-core/logs/working/task-12/code-reviewer-round1.json
@@ -1,0 +1,48 @@
+{
+  "status": "changes_required",
+  "summary": "Task 12 correctly removes attest/, wasm/ module entries, HashEmbedder, and hash fallback from the module list and external integrations section. However, one dead reference was not cleaned up: patterns.md line 28 still references `core/src/wasm/` in the error handling section, a path that does not exist post-refactor. Additionally, the fallback chain description in architecture.md is slightly misleading about provider priority order. Both are accuracy issues with the stated goal of the task.",
+  "criticalIssues": [],
+  "suggestions": [
+    {
+      "file": "/home/claude/.openclaw/workspace/mnemonic-refactored/.claude/worktrees/agent-ae0729cb/.claude/skills/project-knowledge/references/patterns.md",
+      "line": 28,
+      "severity": "major",
+      "category": "accuracy",
+      "suggestion": "Surviving dead reference: the Error handling section reads 'Convert to `JsValue` only at the WASM boundary in `core/src/wasm/`.' The directory `core/src/wasm/` does not exist — it was removed as part of the post-task-10 refactor. The task spec required removing the `wasm/mod.rs` path reference from the Dual-target compilation section (done) but missed this second occurrence in the Error handling section. The sentence should be updated to remove the path reference, e.g., 'Convert to `JsValue` only at the WASM boundary.' or removed entirely if WASM boundary error conversion is no longer applicable.",
+      "benefit": "Eliminates the only remaining dead path reference in patterns.md, completing the stale-reference cleanup this task was scoped to do. An agent reading this line would attempt to navigate to a non-existent module.",
+      "optional": false
+    },
+    {
+      "file": "/home/claude/.openclaw/workspace/mnemonic-refactored/.claude/worktrees/agent-ae0729cb/.claude/skills/project-knowledge/references/architecture.md",
+      "line": 83,
+      "severity": "minor",
+      "category": "accuracy",
+      "suggestion": "The fallback chain 'openai → fastembed → Err' implies OpenAI is the primary provider and fastembed is the fallback, but `core/src/embed/mod.rs` build_embedder() comments and logic establish the opposite priority: 'Priority: fastembed (open, verifiable) > openai (proprietary but semantic)'. The chain description is written from the OpenAI integration entry, so framing it as an OpenAI-centric fallback is plausible, but it may mislead agents about which provider is preferred. Consider revising to 'Fallback (when EMBED_PROVIDER=openai or fastembed fails): openai → fastembed → Err' or moving the priority note to the embed/ description in Project Structure.",
+      "benefit": "Accurately reflects the provider selection logic, preventing agents from misunderstanding which embedder is preferred for verifiable attestations.",
+      "optional": true
+    },
+    {
+      "file": "/home/claude/.openclaw/workspace/mnemonic-refactored/.claude/worktrees/agent-ae0729cb/.claude/skills/project-knowledge/references/architecture.md",
+      "line": 37,
+      "severity": "minor",
+      "category": "completeness",
+      "suggestion": "The lineage/ description covers the DAG of parent-child relationships but omits the `Direction` enum (Ancestors/Descendants/Both) which is the primary public API surface for graph traversal. This is a real exported type that agents working on lineage queries will need to know about. Consider adding: 'exposes a `Direction` enum (Ancestors/Descendants/Both) for BFS traversal.'",
+      "benefit": "Agents implementing or extending lineage queries will find the key traversal API documented without needing to read source.",
+      "optional": true
+    }
+  ],
+  "metrics": {
+    "filesReviewed": 2,
+    "criticalIssuesCount": 0,
+    "majorIssuesCount": 1,
+    "minorIssuesCount": 2,
+    "testCoverageAssessment": "adequate"
+  },
+  "reviewAxesVerdict": {
+    "accuracy": "PARTIAL — core module list, embed provider list, storage trait names, fallback chain all match lib.rs and source. One inaccuracy: patterns.md line 28 references core/src/wasm/ which does not exist.",
+    "completeness": "ACCEPTABLE — Direction enum and sign_cose are not mentioned but are within scope of optional depth. sign_cose is #[doc(hidden)] by design so omitting it is correct. Direction enum is a minor gap.",
+    "styleConsistency": "PASS — edits match the existing prose style of each file. No code blocks introduced. Inline backtick refs used consistently.",
+    "noSpeculation": "PASS — no forward-looking statements about task 11+ detected.",
+    "deadRefs": "FAIL — one surviving dead ref: patterns.md line 28 still contains 'core/src/wasm/' path. All other target refs (attest/, HashEmbedder, hash fallback, wasm/mod.rs in dual-target section) are confirmed removed."
+  }
+}

--- a/work/mnemonic-core/logs/working/task-12/code-reviewer-round2.json
+++ b/work/mnemonic-core/logs/working/task-12/code-reviewer-round2.json
@@ -1,0 +1,20 @@
+{
+  "status": "approved",
+  "summary": "All three round-1 findings are correctly addressed. The dead `core/src/wasm/` reference is gone from every file in `.claude/skills/project-knowledge/references/` — grep confirms zero matches across all five reference files. The fallback-chain reframing now leads with fastembed as the default and accurately captures the provider-selection logic from `build_embedder`. The `Direction` enum addition to the lineage/ description is accurate and readable. No new issues introduced.",
+  "criticalIssues": [],
+  "suggestions": [],
+  "metrics": {
+    "filesReviewed": 2,
+    "criticalIssuesCount": 0,
+    "majorIssuesCount": 0,
+    "minorIssuesCount": 0,
+    "testCoverageAssessment": "adequate"
+  },
+  "reviewAxesVerdict": {
+    "deadRefs": "PASS — grep for 'core/src/wasm' across all references/ files returns zero matches. The only surviving wasm references are legitimate: wasm-bindgen in the tech stack, webapp/src/wasm/ in project structure, WASM target cfg in patterns.md dual-target section, and wasm-pack test in the testing section.",
+    "accuracy": "PASS — patterns.md error handling line now correctly names `webapp/src/wasm/` as the wasm-bindgen bridge location. architecture.md provider priority line now correctly reflects that fastembed is the open/default provider and openai is opt-in with its own fallback chain. lineage/ description now mentions the Direction enum with its three variants.",
+    "styleConsistency": "PASS — all three edits match the existing inline-backtick and prose style of their respective files. No code blocks introduced.",
+    "noSpeculation": "PASS — no forward-looking statements detected in any edited section.",
+    "completeness": "PASS — decisions.md round-2 entry accurately documents all three changes plus grep-based verification evidence."
+  }
+}

--- a/work/mnemonic-core/tasks/13.md
+++ b/work/mnemonic-core/tasks/13.md
@@ -1,5 +1,5 @@
 ---
-status: planned
+status: done
 depends_on: [11, 12]
 wave: 12
 skills: [code-reviewing]

--- a/work/mnemonic-core/tasks/14.md
+++ b/work/mnemonic-core/tasks/14.md
@@ -1,5 +1,5 @@
 ---
-status: planned
+status: done
 depends_on: [11, 12]
 wave: 12
 skills: [security-auditor]

--- a/work/mnemonic-core/tasks/15.md
+++ b/work/mnemonic-core/tasks/15.md
@@ -1,5 +1,5 @@
 ---
-status: planned
+status: done
 depends_on: [11, 12]
 wave: 12
 skills: [test-master]


### PR DESCRIPTION
## Summary

Wave 12 audit-only wave: code, security, and test audits over the post-refactor `mnemonic-core` state. No source changes from the audits themselves.

Two commits, easy to review independently:
1. **`style: cargo fmt --all`** — mechanical formatting, 21 files / ~1000 LOC. Build + tests (75/75) verified post-fmt. Prior PRs landed unformatted code; this baselines fmt going forward.
2. **`feat: wave 12 audit results`** — three audit reports + decisions.md summaries + task status flips + `.gitignore` change to track `work/*/logs/`.

## Audit verdicts

| Task | Verdict | Severity |
|------|---------|----------|
| 13 — Code audit | issues-found | **1 critical**, 4 major, 7 minor, 1 nit |
| 14 — Security audit | issues-found | 0 critical/major, 4 minor, 3 nit |
| 15 — Test audit | issues-found | 0 critical, 3 major, 4 minor, 1 nit |

## Top findings (likely fix wave needed before pre-deploy QA)

- **CRITICAL — task 13:** `cargo build --features local-embed` fails — `fastembed` 5.x API break in `FastEmbedder` (`InitOptions` non-exhaustive, `embed` takes `&mut self`). Default features green.
- **MAJOR — task 13:** Payment schema + migration in `core/` despite Decision 2 saying payment stays in `mcp/`.
- **MAJOR — task 13:** Vestigial task-6 `LineageStore` trait + parallel lineage table never unified with task-9 `core/src/lineage/`.
- **MAJOR — task 13:** `AttestationStore::search` still uses error-swallowing `filter_map(|r| r.ok())`.
- **MAJOR — task 15:** Storage tests use concrete `SqliteStore` rather than `&dyn AttestationStore` / `&dyn LineageStore` — trait abstraction has zero contract guarantee.
- **MAJOR — task 15:** `test_compress_empty_embedding` and `test_compress_single_element` use `catch_unwind` + `let _ = result;` (pass regardless).
- **MAJOR — task 15:** `test_compress_roundtrip_mse` hardcodes `0.05` instead of a named threshold const.

Task 14 found nothing critical/major. Payment-layer atomicity is correct end-to-end.

## Why track logs/

`work/*/logs/` previously gitignored. Tracking gives all agents shared, persistent audit/review history across PRs. Cost is minimal — 464 KB uncompressed, ~105 KB compressed in git, ~10 KB per task going forward. Rule scoped to `/logs/` (top-level only).

## Verification

- `cargo build --workspace` → pass (post-fmt)
- `cargo test --workspace --lib` → 75/0 (post-fmt)
- `cargo test -p mnemonic-core -- --list` → 83 tests registered
- Audit JSONs under `work/mnemonic-core/logs/working/audit/`

## Test plan

- [ ] CI passes
- [ ] Reviewer skims `decisions.md` Task 13/14/15 summaries
- [ ] Reviewer confirms the `.gitignore` scope change is intentional
- [ ] Triage: fix wave for the 1 critical + 4 majors before task 16, or accept as known issues?

🤖 Generated with [Claude Code](https://claude.com/claude-code)