### PR TITLE
fix: fastembed 5.x API incompatibility (rebased onto post-fmt main)

### DIFF
--- a/core/src/embed/mod.rs
+++ b/core/src/embed/mod.rs
@@ -22,7 +22,10 @@ pub trait Embedder: Send + Sync {
 /// Enable with: cargo build --features local-embed
 #[cfg(feature = "local-embed")]
 pub struct FastEmbedder {
-    model: fastembed::TextEmbedding,
+    // fastembed 5.x requires `&mut self` on `embed`; wrap in Mutex so the
+    // `Embedder` trait can keep its `&self` signature. Inference holds the
+    // lock briefly per call — no `.await` is held across the guard.
+    model: std::sync::Mutex<fastembed::TextEmbedding>,
     dim: usize,
 }
 
@@ -30,26 +33,32 @@ pub struct FastEmbedder {
 impl FastEmbedder {
     pub fn try_new() -> Result<Self, String> {
         use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
-        let model = TextEmbedding::try_new(InitOptions {
-            model_name: EmbeddingModel::AllMiniLML6V2,
-            ..Default::default()
-        })
-        .map_err(|e| format!("fastembed init failed: {e}"))?;
+        let mut model = TextEmbedding::try_new(InitOptions::new(EmbeddingModel::AllMiniLML6V2))
+            .map_err(|e| format!("fastembed init failed: {e}"))?;
 
-        // Probe dimension
         let sample = model
             .embed(vec!["test"], None)
             .map_err(|e| format!("fastembed probe failed: {e}"))?;
         let dim = sample.first().map(|v| v.len()).unwrap_or(384);
 
-        Ok(Self { model, dim })
+        Ok(Self {
+            model: std::sync::Mutex::new(model),
+            dim,
+        })
     }
 }
 
 #[cfg(feature = "local-embed")]
 impl Embedder for FastEmbedder {
     fn embed(&self, text: &str) -> Vec<f32> {
-        match self.model.embed(vec![text.to_string()], None) {
+        let mut guard = match self.model.lock() {
+            Ok(g) => g,
+            Err(poisoned) => {
+                tracing::error!("fastembed mutex poisoned, recovering");
+                poisoned.into_inner()
+            }
+        };
+        match guard.embed(vec![text.to_string()], None) {
             Ok(embeddings) => embeddings
                 .into_iter()
                 .next()


### PR DESCRIPTION
## Summary

Replaces #8 (which had unresolvable conflicts after #7 merged with cargo fmt). Same fix, rebased onto current main.

## What was broken

`cargo build --features local-embed` failed with:

```
error[E0639]: cannot create non-exhaustive struct using struct expression
error[E0596]: cannot borrow `self.model` as mutable, as it is behind a `&` reference
```

- `InitOptions` is `#[non_exhaustive]` in fastembed 5.x — must be built via the `InitOptions::new(model)` builder.
- `TextEmbedding::embed` now takes `&mut self`, but the `Embedder` trait method is `&self`.

## Fix

1. Use the `InitOptions::new(EmbeddingModel::AllMiniLML6V2)` builder.
2. Wrap `TextEmbedding` in `std::sync::Mutex` so the `Embedder` trait keeps its `&self` signature. Inference holds the lock briefly per call; no `.await` is held across the guard. Mutex poisoning is recovered + logged at error level.

The trait keeps `&self` because changing it would propagate through all consumers (`Box<dyn Embedder>` storage, `Arc<dyn Embedder>` sharing, `OpenAIEmbedder` / `MockEmbedder` impls). Mutex is the lower-impact change.

## Verification

- `cargo build -p mnemonic-core --features local-embed` → pass
- `cargo test -p mnemonic-core --lib` → 75/0
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` → clean

## Diff size

18 +/9 - in a single file (`core/src/embed/mod.rs`). Tighter than #8 because the fmt-baseline is already in main from #7.

## Follow-up

The `cargo clippy --workspace --all-features` gate that would have caught this earlier should be added to CI in a separate small PR.

## Relation to other open work

- #7 (wave 12 audits) — merged. Produced the audit that caught this.
- 7 task files for the deferred majors from the same audits will land in a separate docs-only PR (wave 13 fix wave).

## Test plan

- [ ] CI passes (build, fmt, clippy default + all-features, test)
- [ ] `cargo build --features local-embed` no longer errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)