### PR TITLE
docs: wave 13 fix tasks (17-23) for deferred audit majors

### DIFF
--- a/work/mnemonic-core/tasks/16.md
+++ b/work/mnemonic-core/tasks/16.md
@@ -1,7 +1,7 @@
 ---
 status: planned
-depends_on: [13, 14, 15]
-wave: 13
+depends_on: [13, 14, 15, 17, 18, 19, 20, 21, 22, 23]
+wave: 14
 skills: [pre-deploy-qa]
 verify: []
 reviewers: []

--- a/work/mnemonic-core/tasks/17.md
+++ b/work/mnemonic-core/tasks/17.md
@@ -1,0 +1,124 @@
+---
+status: planned
+depends_on: [13]
+wave: 13
+skills: [code-writing]
+verify: [smoke]
+reviewers: [code-reviewer, security-auditor, test-reviewer]
+teammate_name:
+---
+
+# Task 17: Move payment schema out of core + delete vestigial LineageStore trait
+
+## Required Skills
+
+Before starting, load: `/skill:code-writing` — [SKILL.md](/home/claude/.claude/skills/code-writing/SKILL.md)
+
+## Description
+
+Two related cleanups flagged by Task 13 code audit (CODE-AUDIT-002, single major finding with two sub-issues):
+
+1. **Payment schema leaks into core.** `core/src/storage/sqlite.rs` defines the full payment schema (`api_keys`, `payment_events`, `x402_nonces`, `attestation_costs`) and owns the `migrate_payment_events_unique_index` helper, despite Tech Spec Decision 2 stating "payment methods stay in mcp/". A downstream consumer pulling `mnemonic-core` from crates.io receives four payment-specific tables they don't need and can't opt out of.
+
+2. **Vestigial `LineageStore` trait + parallel lineage table.** `core/src/storage/traits.rs` defines a `LineageStore` trait (`save_edge` / `get_edges` / `clear_edges`) over a `lineage_edges` table. This was introduced in Task 6 with a `TODO(task-9)` comment, but Task 9's `core/src/lineage/` module replaced it with a different schema (`artifact_lineage`). The Task 6 trait + table are dead code — never consumed by mcp, never unified in Task 11. Two parallel lineage schemas coexist in core for the same conceptual DAG.
+
+This is the highest-priority architectural cleanup because it directly affects the public crate surface published to crates.io.
+
+## What to do
+
+1. **Move payment schema to mcp.** Extract from `core/src/storage/sqlite.rs`:
+   - The DDL for `api_keys`, `payment_events`, `x402_nonces`, `attestation_costs` (currently in the constructor / `init_schema` helper around lines 31-68).
+   - The `migrate_payment_events_unique_index` migration helper (currently around lines 95-111).
+   Move both into a new function `init_payment_schema(conn: &Connection)` in `mcp/src/payment.rs` (or a sibling `mcp/src/payment_schema.rs` if it grows). Run it once at startup from `McpState::new` (or wherever the SqliteStore is opened in mcp).
+
+2. **Verify core only knows about non-payment tables.** After the move, `core/src/storage/sqlite.rs` should create only the attestations table and any lineage table actually used by `core/src/lineage/`. Grep `core/src/storage/sqlite.rs` for `api_keys`, `payment_events`, `x402_nonces`, `attestation_costs` — must be empty.
+
+3. **Delete the `LineageStore` trait.** Remove from `core/src/storage/traits.rs`:
+   - The `LineageStore` trait definition.
+   - Any `impl LineageStore for SqliteStore` block in `core/src/storage/sqlite.rs`.
+   - The `lineage_edges` table DDL and any related INSERT/SELECT/DELETE in sqlite.rs.
+   - Any contract tests in `core/src/storage/sqlite.rs` that reference `LineageStore` methods (`save_edge`, `get_edges`, `clear_edges`) — these were testing dead code.
+
+4. **Verify `core/src/lineage/` is the sole lineage surface.** Grep `core/src/` for `lineage_edges` (the dead table name) — must be empty. Grep for `save_edge`, `get_edges`, `clear_edges` — must be empty in core/.
+
+5. **Re-export updates.** `core/src/storage/mod.rs` may currently re-export `LineageStore`. Remove that re-export. Verify `mcp/src/` does not import `LineageStore` from `mnemonic_core::` anywhere.
+
+6. **Run full verification:**
+   - `cargo build --workspace` — pass.
+   - `cargo test --workspace` — pass.
+   - `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
+   - MCP startup smoke test: confirm payment-related tables are created (sqlite3 `.tables` against the dev DB shows api_keys, payment_events, x402_nonces, attestation_costs after first mcp run).
+
+7. **decisions.md entry** documenting the move, before/after table ownership, and migration strategy for any existing dev DBs (the migration helper still runs idempotently from mcp).
+
+## Acceptance Criteria
+
+- [ ] `grep -nE 'api_keys|payment_events|x402_nonces|attestation_costs' core/src/` — empty
+- [ ] `grep -nE 'lineage_edges' core/src/` — empty
+- [ ] `grep -nE 'LineageStore|save_edge|get_edges|clear_edges' core/src/` — empty
+- [ ] `mcp/src/payment.rs` (or `payment_schema.rs`) contains a single `init_payment_schema` function with all four payment tables + migration logic
+- [ ] `init_payment_schema` is invoked exactly once on mcp startup (e.g. from `McpState::new`)
+- [ ] `cargo build --workspace` passes
+- [ ] `cargo test --workspace` passes (any test that referenced the dead `LineageStore` trait is removed, not stubbed)
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
+- [ ] MCP server starts and creates all four payment tables on a fresh DB
+- [ ] decisions.md entry written for Task 17
+
+## Context Files
+
+**Feature context:**
+- [user-spec.md](../user-spec.md)
+- [tech-spec.md](../tech-spec.md) (Decision 2: payment stays in mcp)
+- [decisions.md](../decisions.md)
+
+**Audit source:**
+- [logs/working/audit/code-auditor.json](../logs/working/audit/code-auditor.json) — search for `code-audit-002` (or the major finding on storage/sqlite.rs:31-68)
+
+**Code to modify:**
+- `core/src/storage/sqlite.rs` — remove payment DDL + migration; remove `lineage_edges` DDL/queries
+- `core/src/storage/traits.rs` — delete `LineageStore` trait
+- `core/src/storage/mod.rs` — remove `LineageStore` re-export
+- `mcp/src/payment.rs` — add `init_payment_schema`
+- `mcp/src/mcp.rs` — invoke `init_payment_schema` from `McpState::new` (or wherever the store opens)
+
+## Verification Steps
+
+### Automated
+
+```
+cargo build --workspace
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+grep -rn 'api_keys\|payment_events\|x402_nonces\|attestation_costs' core/src/
+grep -rn 'lineage_edges\|LineageStore\|save_edge\|get_edges\|clear_edges' core/src/
+```
+
+All four greps must return zero matches.
+
+### Smoke
+
+Start the mcp binary against a fresh `:memory:` SQLite store; verify schema introspection returns exactly:
+- core tables: `attestations`, `artifact_lineage` (the live one)
+- mcp-added tables: `api_keys`, `payment_events`, `x402_nonces`, `attestation_costs`
+
+## Details
+
+**Why this matters:** crates.io publication is the V1 distribution channel. A downstream consumer building an agent on top of `mnemonic-core` should not have payment tables forced into their database schema. The trait abstraction in `core/src/storage/` is meant to be portable; payment is a billing concern of the hosted service.
+
+**Migration strategy for existing dev DBs:** the `migrate_payment_events_unique_index` helper is idempotent (it does `DROP INDEX IF EXISTS` + `CREATE UNIQUE INDEX`). Moving it to mcp doesn't break existing dev DBs as long as mcp continues to invoke it on startup.
+
+**Ordering:** payment schema move before LineageStore deletion — the `LineageStore` removal is purely subtractive and has no migration concern, so it goes second. If the changes are split into two PRs, this is the natural order.
+
+**No new abstractions.** Do not introduce a `core::storage::Migrator` trait or similar to "make this more general." The audit recommends a direct, surgical move; no over-engineering.
+
+## Reviewers
+
+- code-reviewer — verify the trait abstraction in core is now domain-pure (no payment concerns leaked through traits.rs); verify lineage cleanup is fully subtractive (no resurrection in disguise).
+- security-auditor — verify payment tables remain access-controlled in mcp (no public exposure introduced); verify no SQL injection regression.
+- test-reviewer — verify the deleted `LineageStore` contract tests (if any) were testing dead code, not real behavior.
+
+## Post-completion
+
+- [ ] decisions.md entry: Task 17 status / summary / verification with file paths
+- [ ] If any test was deleted, note exact file:line removed and why
+- [ ] Update Task 16 if any acceptance criteria need adjustment after the schema move

--- a/work/mnemonic-core/tasks/18.md
+++ b/work/mnemonic-core/tasks/18.md
@@ -1,0 +1,109 @@
+---
+status: planned
+depends_on: [13]
+wave: 13
+skills: [code-writing]
+verify: [smoke]
+reviewers: [code-reviewer, test-reviewer]
+teammate_name:
+---
+
+# Task 18: Replace error-swallowing `filter_map(|r| r.ok())` with proper error propagation in storage
+
+## Required Skills
+
+Before starting, load: `/skill:code-writing` — [SKILL.md](/home/claude/.claude/skills/code-writing/SKILL.md)
+
+## Description
+
+Task 13 code audit (CODE-AUDIT-003 major) flagged that `core/src/storage/sqlite.rs:246` (`AttestationStore::search`) and the `LineageStore::get_edges` site at line 271 still use the `filter_map(|r| r.ok())` pattern on `query_map` iterators. This silently drops row-level DB errors — a corrupted blob or schema-drift produces "zero results" instead of an error, masking real failures from the caller.
+
+Task 9 already established the convention fix in `core/src/lineage/`: collect rows into `rusqlite::Result<Vec<_>>` and propagate via `?`. This task brings the storage module to the same convention. (Note: if Task 17 deletes the `LineageStore` trait + `get_edges`, that site becomes moot; this task focuses on `AttestationStore::search` regardless.)
+
+## What to do
+
+1. **Locate every `filter_map(|r| r.ok())` (and equivalents like `.flatten()` on a `Result` iterator) in `core/src/storage/`.** Grep: `grep -rn 'filter_map.*\.ok()' core/src/storage/`. Document each call site.
+
+2. **Replace with the Task 9 pattern** at each site:
+   ```rust
+   let collected: rusqlite::Result<Vec<_>> = rows.collect();
+   let rows = collected?;
+   ```
+   Then iterate `rows` for the rest of the function.
+
+3. **Update the function's return signature** if needed. `AttestationStore::search` already returns `Result<Vec<SearchResult>, _>` (or similar); the change should be transparent at the call boundary. If the trait method was returning a non-Result type, audit whether the trait + impl need a Result return — but the audit suggests this is internal to functions that already return Result.
+
+4. **Add a regression test** in `core/src/storage/sqlite.rs` `#[cfg(test)] mod tests`:
+   - Insert an attestation with valid bytes.
+   - Then directly UPDATE the row in the underlying SQLite to a malformed blob (e.g. embed bytes of wrong length or invalid CBOR).
+   - Call `search` with a query that would otherwise hit that row.
+   - Assert: returns `Err(_)`, not `Ok(vec![])`. This proves error propagation works.
+
+5. **Run full verification:**
+   - `cargo build --workspace` pass
+   - `cargo test --workspace` pass (including new regression test)
+   - `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
+
+6. **decisions.md entry** noting the convention is now uniform across `core/src/lineage/` and `core/src/storage/`. Add a follow-up note: consider a `cargo clippy` lint or `xtask` check that flags `filter_map(|r| r.ok())` on iterators of `Result`.
+
+## Acceptance Criteria
+
+- [ ] `grep -rn 'filter_map.*\.ok()' core/src/storage/` — zero matches (or all matches are explicitly NOT on Result iterators, with a comment justifying why)
+- [ ] Every previously-affected function returns `Err(_)` on row-level DB errors instead of silently producing fewer results
+- [ ] At least one regression test in `core/src/storage/sqlite.rs` proves `search` propagates a forced row-level error as `Err(_)`
+- [ ] `cargo build --workspace` passes
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
+- [ ] decisions.md entry written for Task 18
+
+## Context Files
+
+**Feature context:**
+- [user-spec.md](../user-spec.md)
+- [tech-spec.md](../tech-spec.md)
+- [decisions.md](../decisions.md) (Task 9 entry — same convention applied to lineage)
+
+**Audit source:**
+- [logs/working/audit/code-auditor.json](../logs/working/audit/code-auditor.json) — major finding at sqlite.rs:246, 271
+
+**Reference (good pattern):**
+- `core/src/lineage/mod.rs` — see `get_parents` / `get_children` for the established Task 9 pattern
+
+**Code to modify:**
+- `core/src/storage/sqlite.rs` — both call sites
+- (test add) `core/src/storage/sqlite.rs` `#[cfg(test)] mod tests`
+
+## Verification Steps
+
+### Automated
+
+```
+cargo build --workspace
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+grep -rn 'filter_map.*\.ok()' core/src/storage/
+```
+
+The grep must return zero matches in `core/src/storage/`. (If a legitimate `filter_map(|x| x.ok())` exists on a non-Result, comment-justify it.)
+
+### Smoke
+
+The new regression test is the smoke gate; failure to propagate `Err` is a hard-fail.
+
+## Details
+
+**Why this matters:** silent error swallowing in a storage layer is one of the most common ways production systems develop ghosts — operators see "search returned 0 results" when the truth is "search hit a corrupted row and aborted that iteration." For a verifiable-memory system, this is doubly bad: a tampered or corrupted attestation row should surface, not vanish.
+
+**No new error types.** Don't introduce a `StorageError` enum to "make errors more typed" — `rusqlite::Error` (or `anyhow::Error` if the function already wraps) is sufficient and matches the existing convention. Surgical change only.
+
+**Test technique:** to corrupt a stored row deterministically, use `rusqlite` directly on the same connection: `conn.execute("UPDATE attestations SET emb = ? WHERE id = ?", params![&bad_bytes, &id])` where `bad_bytes` is a length-mismatched or otherwise invalid blob. Avoid touching disk / external tools.
+
+## Reviewers
+
+- code-reviewer — verify error propagation matches Task 9 convention exactly; flag any `unwrap()`/`expect()` introduced in the rewrite.
+- test-reviewer — verify the regression test actually hits a row-level error path (not just a query parsing error or schema error). The test must demonstrate the difference between "0 rows" and "Err on iteration".
+
+## Post-completion
+
+- [ ] decisions.md entry: Task 18 status / before-after diff summary / regression test description
+- [ ] Note any further `filter_map(|r| r.ok())` sites discovered outside `core/src/storage/` (record as follow-up if found)

--- a/work/mnemonic-core/tasks/19.md
+++ b/work/mnemonic-core/tasks/19.md
@@ -1,0 +1,129 @@
+---
+status: planned
+depends_on: [13]
+wave: 13
+skills: [code-writing]
+verify: [smoke]
+reviewers: [code-reviewer, security-auditor]
+teammate_name:
+---
+
+# Task 19: Replace `unsafe impl Send/Sync for McpState` with a safe alternative
+
+## Required Skills
+
+Before starting, load: `/skill:code-writing` — [SKILL.md](/home/claude/.claude/skills/code-writing/SKILL.md)
+
+## Description
+
+Task 13 code audit (CODE-AUDIT-004 major) flagged `mcp/src/mcp.rs:75-76`:
+
+```rust
+unsafe impl Send for McpState {}
+unsafe impl Sync for McpState {}
+```
+
+`SqliteStore` contains `rusqlite::Connection` which is `!Send`. The surrounding `Mutex<SqliteStore>` does **not** create `Send` from nothing — `Mutex<T>: Sync` requires `T: Send`. The `unsafe impl` is a workaround for axum's `State<Arc<McpState>>` requiring `Send + Sync`. It is load-bearing without a SAFETY comment explaining what invariants the workaround relies on.
+
+This is unlikely to be the source of an actual bug today (the connection is held only inside short critical sections, and tokio handlers don't `.await` while holding the lock), but the unsafe impl is fragile: a future contributor adding `.await` inside the `lock()` guard would not be flagged at compile time. The audit recommends one of three remediations.
+
+## What to do
+
+Pick **one** of the three remediations below, document the choice in decisions.md, and apply it.
+
+**Option A (preferred — safe and idiomatic):** Replace `Mutex<SqliteStore>` with a `StoreHandle` actor pattern. Move the `Connection` into a dedicated worker thread (or `tokio::task::spawn_blocking` per-call wrapper). The handle exposes async methods that send commands over a `tokio::sync::mpsc` channel and await responses on a `oneshot`. The `StoreHandle` itself is `Send + Sync` because it only holds a channel sender. The `unsafe impl` blocks are deleted entirely.
+
+**Option B (simpler but coarser):** Replace `std::sync::Mutex<SqliteStore>` with `tokio::sync::Mutex<SqliteStore>`. This still requires the inner type to be `Send`, so wrap connection access through `tokio::task::spawn_blocking` at every callsite, OR use `connection-pool` style: open a fresh connection per call (`rusqlite::Connection` itself is `Send`; only borrowed `&Connection` is `!Sync`). The `unsafe impl` blocks are deleted.
+
+**Option C (minimum remediation — only if A and B are too invasive):** Keep `unsafe impl Send + Sync for McpState` but add a `// SAFETY:` comment on each line that states the exact invariant: "The contained `Mutex<SqliteStore>` is only locked inside synchronous critical sections; no `.await` is held across the `MutexGuard`. All public methods that lock the mutex are non-async or release the guard before any `.await`. This is verified by `cargo test` in `mcp/src/payment.rs::tests::concurrent_*` (3 tests)." Add a CI lint or doc-comment on every `lock()` call reminding contributors of the invariant.
+
+**Recommended path:** Option A. Option B is acceptable if the actor pattern is judged out of scope. Option C is a band-aid — only acceptable if a follow-up task is filed to do A or B post-deploy.
+
+Whichever option is chosen:
+
+1. **Verify async/await safety** — write or extend a test in `mcp/src/mcp.rs::tests` that demonstrates concurrent `tools/call` requests do not deadlock or starve. With Option A this is a property test; with B/C it's an integration test that hits the axum router with multiple in-flight requests.
+
+2. **Run full verification:**
+   - `cargo build --workspace` pass
+   - `cargo test --workspace` pass (including the new concurrency test)
+   - `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
+   - End-to-end smoke: existing MCP tools/list and tools/call still work
+
+3. **decisions.md entry** documenting:
+   - Which option was chosen and why (trade-off analysis)
+   - The new architecture diagram for the store layer (1-2 sentences)
+   - Whether any deferred follow-up is needed
+
+## Acceptance Criteria
+
+- [ ] `grep -nE '^[[:space:]]*unsafe[[:space:]]+impl' mcp/src/` — empty (Options A and B); OR every match has an immediately preceding `// SAFETY:` comment articulating the specific invariants (Option C only)
+- [ ] If Option A or B chosen: `cargo build --workspace` succeeds without any `unsafe impl` for store types
+- [ ] At least one test exercises concurrent access to the store (multiple in-flight requests)
+- [ ] No `.await` is held across a synchronous mutex `lock()` guard anywhere in `mcp/src/`
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
+- [ ] `cargo run -p mnemonic-mcp -- --transport stdio` startup smoke still works
+- [ ] decisions.md entry written for Task 19
+
+## Context Files
+
+**Feature context:**
+- [user-spec.md](../user-spec.md)
+- [tech-spec.md](../tech-spec.md)
+- [decisions.md](../decisions.md)
+
+**Audit source:**
+- [logs/working/audit/code-auditor.json](../logs/working/audit/code-auditor.json) — major finding at mcp.rs:75-76
+
+**Code to modify (depending on option):**
+- `mcp/src/mcp.rs` — `McpState` definition and the unsafe impl block
+- `mcp/src/tools.rs` — call sites that lock the store
+- `mcp/src/payment.rs` — call sites that lock the store
+- (Option A) new file `mcp/src/store_handle.rs` for the actor pattern
+- (Option B) callsite changes to `tokio::task::spawn_blocking`
+
+## Verification Steps
+
+### Automated
+
+```
+cargo build --workspace
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+grep -nE '^\s*unsafe\s+impl' mcp/src/
+```
+
+The grep must return zero matches (Options A/B) or annotated matches with SAFETY comments (Option C).
+
+### Smoke
+
+```
+echo '{"jsonrpc":"2.0","method":"tools/list","id":1}' | cargo run -p mnemonic-mcp -- --transport stdio
+```
+
+Must return the 5-tool list. Then run a representative `tools/call` (e.g. `sign_memory`) and confirm it succeeds.
+
+### Concurrency
+
+Spawn 8 concurrent `tools/call` requests against the running mcp; verify no panic, no deadlock, no incorrect serialization (each call returns its own response).
+
+## Details
+
+**Why this matters:** `unsafe impl Send/Sync` is a load-bearing safety claim. Without a SAFETY comment, future contributors cannot tell what invariants the unsafe relies on, and a refactor that introduces `.await` across the lock would silently introduce a tokio runtime panic potential (or worse, depending on what reentrancy looks like inside rusqlite). For a security-sensitive product (verifiable memory, payment handling), this is the kind of latent fragility audits flag preemptively.
+
+**Why not just leave it alone:** payment-layer concurrent tests already exist (`mcp/src/payment.rs` has 3 concurrent tests proving balance atomicity). The audit's claim is that those tests pass *currently* but provide no guarantee against a future contributor regression. Adding a SAFETY comment is the minimum cost; refactoring to Option A is the principled fix.
+
+**Picking option A:** the actor pattern has the additional benefit that the `StoreHandle` becomes mockable for the mcp-side tests. Trait-driven testability is a side benefit.
+
+**Connection-per-call cost (Option B):** rusqlite connection-open is ~1ms on a hot disk cache. For mcp's request rate this is negligible. The bigger question is consistency: each call gets its own transaction — fine for the current API surface but a constraint for future multi-statement operations.
+
+## Reviewers
+
+- code-reviewer — verify the chosen option is implemented end-to-end without leftover unsafe; verify no `.await` across guards (especially in the chosen approach's call sites).
+- security-auditor — verify the change does not introduce a new attack surface (e.g. Option A: ensure the channel sender is not exposed as a public API; Option C: verify the SAFETY comment's invariants are actually testable).
+
+## Post-completion
+
+- [ ] decisions.md entry: Task 19 status, option chosen, rationale, key code locations
+- [ ] If Option C chosen: file a follow-up task for post-deploy A or B refactor
+- [ ] Update architecture.md if the store layout changed materially (Option A)

--- a/work/mnemonic-core/tasks/20.md
+++ b/work/mnemonic-core/tasks/20.md
@@ -1,0 +1,113 @@
+---
+status: planned
+depends_on: [13]
+wave: 13
+skills: [code-writing]
+verify: [smoke]
+reviewers: [code-reviewer, security-auditor]
+teammate_name:
+---
+
+# Task 20: Demote `SolanaClient::rpc` and add a typed high-level method
+
+## Required Skills
+
+Before starting, load: `/skill:code-writing` — [SKILL.md](/home/claude/.claude/skills/code-writing/SKILL.md)
+
+## Description
+
+Task 13 code audit (CODE-AUDIT-005 major) flagged `core/src/solana/mod.rs:29`:
+
+```rust
+pub fn rpc(&self, method: &str, params: Value) -> Result<...> { ... }
+```
+
+`SolanaClient::rpc` is fully public — a general-purpose JSON-RPC escape hatch on the stable API surface. The only reason it's `pub` is Task 8's cross-crate call from `mcp/src/payment.rs:241-244`, where `verify_usdc_transfer` reaches in and issues `client.rpc("getTransaction", ...)` directly. This leaks the JSON-RPC shape into the public crates.io API.
+
+Decisions.md Task 8 entry already noted this deviation: "Made `rpc` `pub` (task said 'no need to make rpc public'...)". For a library targeting crates.io publication, this is a permanent stain on the public surface unless fixed now.
+
+## What to do
+
+1. **Identify all cross-crate consumers of `SolanaClient::rpc`.** Grep `mcp/src/` and any other workspace crate for calls to `.rpc(`. Document each call site, the JSON-RPC method invoked, and the parsing logic that follows.
+
+2. **For each consumer, design a typed high-level method on `SolanaClient`.** The audit-recommended specific case is `verify_usdc_transfer`'s `getTransaction` lookup: add `pub fn get_transaction_token_balances(&self, tx_sig: &str) -> Result<Vec<TokenBalance>>` (or similar) that returns a typed struct rather than raw JSON. Move the JSON-shape parsing out of `mcp/src/payment.rs` and into `core/src/solana/mod.rs`.
+
+3. **Demote `SolanaClient::rpc`.** After all consumers use typed methods, change visibility to `pub(crate)` (or `#[doc(hidden)] pub` if there's a justified reason it must remain externally callable — match the convention used for `codec::sign::sign_cose` which is `#[doc(hidden)] pub` for benchmark access only). The audit prefers `pub(crate)`.
+
+4. **Update tests.** The httpmock tests in `core/src/solana/` that exercise `rpc` directly should be repointed to exercise the new typed methods. If a test asserts on raw JSON-RPC return shape, restructure to assert on the typed struct.
+
+5. **Run full verification:**
+   - `cargo build --workspace` — pass
+   - `cargo test --workspace` — pass (all 8 solana httpmock tests still cover the same scenarios)
+   - `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
+   - `mcp` still verifies USDC transfers correctly (smoke against arlocal or httpmock-backed integration test)
+
+6. **decisions.md entry** describing:
+   - The new typed methods added (signature + purpose)
+   - Why `rpc` is now `pub(crate)` (or `#[doc(hidden)] pub`)
+   - Reverses the deviation noted in Task 8 decisions entry — close that loop
+
+## Acceptance Criteria
+
+- [ ] `grep -nE 'SolanaClient::rpc|client\.rpc\(' mcp/src/` — empty
+- [ ] `pub fn rpc` does not appear in `core/src/solana/mod.rs` — only `pub(crate) fn rpc` (or `#[doc(hidden)] pub fn rpc`, if justified)
+- [ ] At least one new typed method on `SolanaClient` exists (e.g. `get_transaction_token_balances`) and is exercised by `mcp/src/payment.rs::verify_usdc_transfer`
+- [ ] All 8 solana httpmock tests still pass — same scenarios covered, possibly via the typed method instead of `rpc`
+- [ ] `verify_usdc_transfer` no longer parses raw JSON-RPC responses; only consumes typed structs from core
+- [ ] `cargo build --workspace` passes
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
+- [ ] decisions.md entry written for Task 20 (and ideally references Task 8 to close the deviation loop)
+
+## Context Files
+
+**Feature context:**
+- [user-spec.md](../user-spec.md)
+- [tech-spec.md](../tech-spec.md)
+- [decisions.md](../decisions.md) (Task 8 entry — original deviation)
+
+**Audit source:**
+- [logs/working/audit/code-auditor.json](../logs/working/audit/code-auditor.json) — major finding at solana/mod.rs:29
+
+**Code to modify:**
+- `core/src/solana/mod.rs` — visibility of `rpc`, addition of typed methods
+- `mcp/src/payment.rs:241-244` — `verify_usdc_transfer` rewrite to use the new typed method
+- `core/src/solana/` test module — possibly repoint tests to typed methods
+
+## Verification Steps
+
+### Automated
+
+```
+cargo build --workspace
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+grep -rn 'SolanaClient::rpc\|client\.rpc(' mcp/src/
+grep -nE 'pub\s+fn\s+rpc' core/src/solana/mod.rs
+```
+
+The first grep must be empty. The second must return zero matches for `pub fn rpc` (only `pub(crate)` or `#[doc(hidden)] pub` are acceptable).
+
+### Smoke
+
+`mcp/src/payment.rs::verify_usdc_transfer` integration path: spin up an httpmock server returning a known `getTransaction` response, call `verify_usdc_transfer`, assert the parsed token balance matches expectations. This already exists in some form — verify it still passes after the refactor.
+
+## Details
+
+**Why this matters:** for a crates.io-published library, the public API is a *permanent contract*. Once `pub fn rpc(method: &str, params: Value)` is on a 1.0 release, downstream consumers may use it, and removing it later is a breaking change. The audit's framing — "permanent stain on the public surface" — is precisely correct for this kind of issue.
+
+**Naming the typed method:** `get_transaction_token_balances` is one option. If `verify_usdc_transfer` only needs specific fields (sender, receiver, amount, token mint), name the method that way: `get_usdc_transfer_details(tx_sig) -> Result<UsdcTransferDetails>`. Match the call site's actual needs, not the abstract Solana JSON-RPC method.
+
+**Visibility choice — `pub(crate)` vs `#[doc(hidden)] pub`:** prefer `pub(crate)` if no other workspace crate needs `rpc`. Use `#[doc(hidden)] pub` only if benchmarks or test-only crates outside `core` need it (similar to `sign_cose`).
+
+**No new traits.** Don't introduce a `SolanaRpcClient` trait or "make this swappable for testing." The httpmock pattern already provides test-time substitution by URL override. Surgical only.
+
+## Reviewers
+
+- code-reviewer — verify the typed methods have idiomatic names and return appropriate types (avoid leaking `serde_json::Value` in return types). Verify visibility change is mechanically correct.
+- security-auditor — verify the new typed methods do not silently weaken any safety property (e.g. parsing strictness around USDC mint address, decimal precision).
+
+## Post-completion
+
+- [ ] decisions.md entry: Task 20 status, new methods, visibility changes, reference to Task 8 deviation closure
+- [ ] Note in `core/src/solana/mod.rs` doc comment: "Public API surface is the typed methods; `rpc` is internal."

--- a/work/mnemonic-core/tasks/21.md
+++ b/work/mnemonic-core/tasks/21.md
@@ -1,0 +1,124 @@
+---
+status: planned
+depends_on: [15]
+wave: 13
+skills: [code-writing]
+verify: [smoke]
+reviewers: [code-reviewer, test-reviewer]
+teammate_name:
+---
+
+# Task 21: Storage tests — exercise traits via `&dyn AttestationStore` references
+
+## Required Skills
+
+Before starting, load: `/skill:code-writing` — [SKILL.md](/home/claude/.claude/skills/code-writing/SKILL.md)
+
+## Description
+
+Task 15 test audit (TEST-STORAGE-CONTRACT-1 major) flagged that all 7 storage tests in `core/src/storage/sqlite.rs:301-401` call methods directly on the concrete `SqliteStore` value rather than through `&dyn AttestationStore` (and `&dyn LineageStore` if the trait survives Task 17). The tech spec explicitly required trait-reference contract testing — currently the trait abstraction provides zero compile-time or behavioral guarantee that the trait is faithful to its only implementation. A second backend (e.g. wasm32 IndexedDB store, planned per ADR-014) would not be caught by these tests if the trait shape diverged.
+
+This is test-only work. No production code changes.
+
+**Coordination note:** if Task 17 deletes the `LineageStore` trait, this task only retargets attestation tests. If Task 17 lands first, update the criteria below mentally to drop the `LineageStore` reference.
+
+## What to do
+
+1. **Identify all 7 storage tests** in `core/src/storage/sqlite.rs` `#[cfg(test)] mod tests`. List names: from the audit, they include `test_save_and_find_by_tx`, `test_search_ranking`, `test_count_by_signer`, `test_find_by_tx_not_found`, `test_duplicate_attestation_id`, `test_lineage_save_and_get`, `test_lineage_clear`.
+
+2. **Refactor each test to access the store through a trait reference:**
+   ```rust
+   let store = SqliteStore::new(":memory:").unwrap();
+   let store_ref: &dyn AttestationStore = &store;
+   store_ref.save(&attestation).unwrap();
+   let found = store_ref.find_by_tx("abc123").unwrap();
+   ```
+   This forces every method called in the test to be present on the trait, with the correct signature. A method that's on `SqliteStore` but missing from the trait will fail to compile under this pattern.
+
+3. **For setup that genuinely requires concrete-impl operations** (e.g., direct DB introspection, schema migration testing): keep the concrete `&store` reference for those calls, but use `&dyn AttestationStore` for the methods being contract-tested. Add a comment explaining the split.
+
+4. **Detect missing trait methods:** if any test currently calls a method that isn't on the trait, decide whether to (a) add it to the trait (legitimate trait gap), (b) remove the test (testing concrete-impl-only behavior that doesn't belong in a contract test), or (c) split the test into a trait-contract part and an impl-internal part. Document each decision.
+
+5. **Add at least one new contract test** that demonstrates trait-object usability across multiple call sites — e.g., a function `fn run_contract_test(store: &dyn AttestationStore)` invoked from one or more test functions. This proves the trait-object pattern compiles and works at function boundaries, not just inline expressions.
+
+6. **Run full verification:**
+   - `cargo build --workspace` — pass
+   - `cargo test --workspace` — pass (all 7 storage tests + any new contract test)
+   - `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
+
+7. **decisions.md entry** with: number of tests refactored, any trait method added/removed, the new helper function (if any), and a one-line note on why this prevents trait/impl drift.
+
+## Acceptance Criteria
+
+- [ ] All storage tests in `core/src/storage/sqlite.rs` use `&dyn AttestationStore` (and `&dyn LineageStore` if Task 17 left the trait alive) for the methods being contract-tested
+- [ ] At least one helper or test function takes `&dyn AttestationStore` as a parameter (proves trait-object usability across function boundaries)
+- [ ] No method is called inside a contract-test code path that isn't on the trait — every contract-tested method is reachable via the trait reference
+- [ ] If trait methods were added during this task, they have a one-line doc comment explaining the contract
+- [ ] `cargo build --workspace` passes
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
+- [ ] decisions.md entry written for Task 21
+
+## Context Files
+
+**Feature context:**
+- [user-spec.md](../user-spec.md)
+- [tech-spec.md](../tech-spec.md) (look for trait-reference test requirement language)
+- [decisions.md](../decisions.md)
+
+**Audit source:**
+- [logs/working/audit/test-auditor.json](../logs/working/audit/test-auditor.json) — TEST-STORAGE-CONTRACT-1 major finding at sqlite.rs:301-401
+
+**Code to modify:**
+- `core/src/storage/sqlite.rs` `#[cfg(test)] mod tests` — refactor 7 tests
+- `core/src/storage/traits.rs` — possibly add 1-2 missing trait methods (optional)
+
+## Verification Steps
+
+### Automated
+
+```
+cargo build --workspace
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+```
+
+All must succeed. Optionally:
+
+```
+grep -nE '&dyn AttestationStore|&dyn LineageStore' core/src/storage/sqlite.rs
+```
+
+Expect at least 7 matches (one per refactored test plus helpers).
+
+### Smoke
+
+The change is test-only — production behavior is unchanged. The smoke gate is "test count and pass rate stay the same or grow."
+
+Before:
+```
+cargo test -p mnemonic-core -- --list | grep -c '^storage::sqlite::tests'
+```
+Should be ≥ 7.
+
+After: the same count or higher.
+
+## Details
+
+**Why this matters:** the trait abstraction in `core/src/storage/` is meant to enable a second backend (e.g. wasm32 IndexedDB store for the WebStorage variant in ADR-014). Without trait-reference contract tests, a future second-backend implementer cannot verify their impl is structurally compatible with what existing tests prove. The trait becomes documentation rather than enforcement.
+
+**Test-pattern reference:** see Rust idiomatic pattern in std collections testing — `BTreeMap` / `HashMap` tests often use `&dyn Map`-style helpers. Search for "trait object contract test" patterns; or model after `proptest` strategies that take a generic `T: Trait`.
+
+**No new abstractions.** Don't introduce a generic `<T: AttestationStore>` test fixture if a `&dyn` reference is sufficient. Object-safe traits accept `&dyn`; use that.
+
+**Scope discipline:** this task does not change any production code, does not change trait shape unless trait gaps are discovered. If trait gaps are found, prefer `(b)` (remove or split the test) before adding methods — many concrete-impl-only tests are testing setup, not contract.
+
+## Reviewers
+
+- code-reviewer — verify the refactor pattern is consistent across all 7 tests; flag any test that silently lost a method call by going through the trait reference (could mask a regression).
+- test-reviewer — verify the new helper function (if added) has a meaningful contract; verify each refactored test's assertions still test the same behavior as before, just through a trait reference.
+
+## Post-completion
+
+- [ ] decisions.md entry: Task 21 status, count of tests refactored, helper added (if any), trait methods added (if any)
+- [ ] If trait gaps were discovered (methods on impl but not on trait), document in decisions.md as a separate note: "Trait shape inventory after Task 21" with the deltas

--- a/work/mnemonic-core/tasks/22.md
+++ b/work/mnemonic-core/tasks/22.md
@@ -1,0 +1,131 @@
+---
+status: planned
+depends_on: [15]
+wave: 13
+skills: [code-writing]
+verify: [smoke]
+reviewers: [test-reviewer]
+teammate_name:
+---
+
+# Task 22: Replace `catch_unwind` + `let _ = result;` with real assertions in compress edge tests
+
+## Required Skills
+
+Before starting, load: `/skill:code-writing` — [SKILL.md](/home/claude/.claude/skills/code-writing/SKILL.md)
+
+## Description
+
+Task 15 test audit (TEST-COMPRESS-EDGE-1 major) flagged `core/src/compress/mod.rs:209-225`:
+
+```rust
+#[test]
+fn test_compress_empty_embedding() {
+    let result = std::panic::catch_unwind(|| compress(&[]));
+    let _ = result;
+}
+
+#[test]
+fn test_compress_single_element() {
+    let result = std::panic::catch_unwind(|| compress(&[1.0]));
+    let _ = result;
+}
+```
+
+These are Category 1 empty tests — they pass regardless of whether `compress` panics, returns garbage, or returns a meaningful error. They satisfy the count-based "edge case present" gate without proving any actual behavior. The litmus test: rewrite `compress` to `panic!("not yet implemented")` for empty input, and these tests still pass.
+
+This is test-only work. No production code changes (the compress function may be invoked with edge inputs already, and the actual behavior is what we'll discover and assert).
+
+## What to do
+
+1. **Read `compress` in `core/src/compress/mod.rs`.** Determine the actual behavior on `&[]` (empty embedding) and `&[1.0]` (single-element embedding). Three possibilities:
+   - Returns `Err(...)` — test should `assert!(matches!(result, Err(_)))` and ideally match a specific error variant.
+   - Returns `Ok(...)` with a sensible empty/short compressed output — test should assert on the contents.
+   - Panics — this is a behavioral choice that should be made explicit. Either change `compress` to return `Err(...)` (preferable; turboquant_plus_rs likely has a typed error), or use `#[should_panic(expected = "...")]` with the exact panic message to lock the contract in.
+
+2. **Rewrite each test with concrete assertions:**
+   ```rust
+   #[test]
+   fn test_compress_empty_embedding() {
+       let result = compress(&[]);
+       // Whatever the actual behavior is — assert on it.
+       // Example: assert!(matches!(result, Err(CompressError::EmptyInput)));
+       // Or:      let compressed = result.unwrap();
+       //          assert_eq!(compressed.bytes.len(), 0);
+       //          assert_eq!(compressed.dim, 0);
+   }
+   ```
+
+3. **No `catch_unwind` unless the test is explicitly asserting the function panics** — and in that case, prefer `#[should_panic]` with `expected =` for the message.
+
+4. **No `let _ = result;`.** Every test must consume `result` with at least one assertion that would fail if the implementation regressed.
+
+5. **Decompression roundtrip on edge inputs (bonus, low cost):** if `compress(&[1.0])` returns `Ok(...)`, the matching `decompress` should round-trip. Add the roundtrip assertion. Empty input may not roundtrip meaningfully — assert on the error case instead.
+
+6. **Run full verification:**
+   - `cargo build --workspace` — pass
+   - `cargo test --workspace` — pass (the rewritten tests now actually fail if behavior regresses)
+   - `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
+
+7. **decisions.md entry** noting: actual edge behavior of `compress` (Err / Ok / panic), the new assertions, and any documentation comment added to `compress` documenting the edge contract.
+
+## Acceptance Criteria
+
+- [ ] `grep -nE 'catch_unwind' core/src/compress/` — empty (or all matches are inside `#[should_panic]` tests with explicit expected message)
+- [ ] `grep -nE 'let _ = result' core/src/compress/` — empty
+- [ ] Both `test_compress_empty_embedding` and `test_compress_single_element` (or their renamed equivalents) contain assertions that exercise the actual behavior of `compress`
+- [ ] If `compress` panics on edge input: that panic is locked in via `#[should_panic(expected = "...")]`, OR `compress` was changed to return `Err(...)` and a doc comment added explaining the edge contract
+- [ ] If `compress(&[1.0])` returns `Ok`, a matching `decompress` roundtrip assertion is present
+- [ ] `cargo build --workspace` passes
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
+- [ ] decisions.md entry written for Task 22
+
+## Context Files
+
+**Feature context:**
+- [user-spec.md](../user-spec.md)
+- [tech-spec.md](../tech-spec.md)
+- [decisions.md](../decisions.md)
+
+**Audit source:**
+- [logs/working/audit/test-auditor.json](../logs/working/audit/test-auditor.json) — TEST-COMPRESS-EDGE-1 major finding at compress/mod.rs:209-225
+
+**Code to modify:**
+- `core/src/compress/mod.rs` `#[cfg(test)] mod tests` — rewrite 2 tests
+- `core/src/compress/mod.rs` `compress` doc comment (possibly add edge-case section)
+
+## Verification Steps
+
+### Automated
+
+```
+cargo build --workspace
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+grep -rn 'catch_unwind' core/src/compress/
+grep -rn 'let _ = result' core/src/compress/
+```
+
+Both greps must return zero matches (or with explicit justification per acceptance criteria).
+
+### Smoke
+
+The litmus test: temporarily change the `compress` function body to `panic!("placeholder")` for empty input. The rewritten test should now FAIL. Revert the experiment. This proves the test catches what it claims to catch. (Note: this is a manual discipline check, not an automated gate — but useful during code review.)
+
+## Details
+
+**Why this matters:** the audit's litmus test is the canonical way to spot empty-test patterns: "does the test still pass if I break the implementation?" If yes, the test is decorative. The fix isn't subtle — replace the discard with an assertion. The harder question is what assertion to write, which requires reading the actual function behavior first.
+
+**Decision: Err vs panic for empty input.** Public library functions should generally return `Err` rather than panic, especially for foreseeable inputs. The audit notes that `MockEmbedder::new(0)` returns an empty vec rather than panicking; `compress` should match that convention. If `turboquant_plus_rs` panics internally on empty input, wrap it: `if input.is_empty() { return Err(CompressError::EmptyInput); }` before delegating.
+
+**Don't add edge protection to production code unnecessarily.** If `compress` already returns `Err` on empty input (because turboquant_plus_rs handles it), this task is purely test-side. Don't introduce defensive guards in production for cases the underlying lib already handles.
+
+## Reviewers
+
+- test-reviewer — verify each rewritten test has a concrete assertion; verify the litmus-test-fail scenario above is met (test would fail if implementation regresses); verify no `let _` discards remain.
+
+## Post-completion
+
+- [ ] decisions.md entry: Task 22 status, edge behavior documented (Err vs Ok vs panic), test-by-test rewrite summary
+- [ ] If `compress` doc comment was updated to document edge behavior, note the file:line of the new doc lines

--- a/work/mnemonic-core/tasks/23.md
+++ b/work/mnemonic-core/tasks/23.md
@@ -1,0 +1,116 @@
+---
+status: planned
+depends_on: [15]
+wave: 13
+skills: [code-writing]
+verify: [smoke]
+reviewers: [test-reviewer]
+teammate_name:
+---
+
+# Task 23: Replace magic-number `0.05` in MSE roundtrip test with named threshold constant
+
+## Required Skills
+
+Before starting, load: `/skill:code-writing` — [SKILL.md](/home/claude/.claude/skills/code-writing/SKILL.md)
+
+## Description
+
+Task 15 test audit (TEST-COMPRESS-MSE-CONST-1 major) flagged `core/src/compress/mod.rs::test_compress_roundtrip_mse`: the assertion uses the magic number `0.05` directly in both the `assert!` and the format string, with no named threshold constant. Acceptance criterion #7 of Task 15 explicitly required a named threshold constant (e.g. `const MAX_ROUNDTRIP_MSE: f32 = 0.01`).
+
+The cost of the fix is trivial; the value is two-fold: (a) the threshold becomes documentation about the expected fidelity of the compression scheme, (b) future contributors who see a regression to MSE = 0.04 know whether that's the expected ceiling or a 4x degradation from the actual target.
+
+This is test-only work. No production code changes.
+
+## What to do
+
+1. **Define a named constant** at the top of `core/src/compress/mod.rs` `#[cfg(test)] mod tests` (or as a `pub(crate) const` if it's referenced from a sibling test file or doc-test):
+
+   ```rust
+   /// Maximum acceptable mean-squared error after a turboquant 4-bit roundtrip
+   /// for a 384-dim normalized embedding. Empirically established at <0.05;
+   /// regressions above this likely indicate a quantization codec change.
+   const MAX_ROUNDTRIP_MSE_4BIT_384: f32 = 0.05;
+   ```
+
+   Naming guidance: include the bit-depth and dimension if the test is parameterized by them, so the constant is self-describing. If multiple roundtrip tests exist with different threshold expectations, define one constant per test target.
+
+2. **Replace the magic number** in the assertion and format string:
+
+   ```rust
+   // Before
+   assert!(mse < 0.05, "mse {mse} exceeded 0.05");
+
+   // After
+   assert!(
+       mse < MAX_ROUNDTRIP_MSE_4BIT_384,
+       "mse {mse} exceeded threshold {MAX_ROUNDTRIP_MSE_4BIT_384}"
+   );
+   ```
+
+3. **Audit for other magic-number thresholds** in `core/src/compress/`. Grep for `assert.*\b[0-9]+\.[0-9]+` or `< 0\.\d+` patterns. If any other test uses bare floats as comparison thresholds, apply the same naming convention. Keep this scope-controlled: only float thresholds in test-code assertions, not hyperparameters in production code.
+
+4. **Run full verification:**
+   - `cargo build --workspace` — pass
+   - `cargo test --workspace` — pass (the test still passes; it's the same threshold, just named)
+   - `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean
+
+5. **decisions.md entry** noting the named constant(s) introduced and their numerical values, plus the empirical context (e.g. "established by 1K-memory recall@10 test, ADR-016").
+
+## Acceptance Criteria
+
+- [ ] `core/src/compress/mod.rs` defines at least one named threshold constant (e.g. `MAX_ROUNDTRIP_MSE_4BIT_384`) for the MSE roundtrip test
+- [ ] The constant has a doc comment explaining what it represents and where the value came from (empirical bound, target spec, etc.)
+- [ ] No bare float magic number appears in `test_compress_roundtrip_mse` assertion or format string
+- [ ] If other compress tests use float thresholds, they too use named constants (uniform convention)
+- [ ] `cargo build --workspace` passes
+- [ ] `cargo test --workspace` passes
+- [ ] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
+- [ ] decisions.md entry written for Task 23
+
+## Context Files
+
+**Feature context:**
+- [user-spec.md](../user-spec.md)
+- [tech-spec.md](../tech-spec.md)
+- [decisions.md](../decisions.md) (search for ADR-016 — empirical recall data that motivates the threshold)
+
+**Audit source:**
+- [logs/working/audit/test-auditor.json](../logs/working/audit/test-auditor.json) — TEST-COMPRESS-MSE-CONST-1 major finding
+
+**Code to modify:**
+- `core/src/compress/mod.rs` — add named constant, update `test_compress_roundtrip_mse`
+
+## Verification Steps
+
+### Automated
+
+```
+cargo build --workspace
+cargo test --workspace
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+grep -nE 'assert!.*\b0\.[0-9]+|< 0\.[0-9]+' core/src/compress/
+```
+
+The grep should return zero matches in test code (or only in lines that explicitly reference a named constant on the right side).
+
+### Smoke
+
+Trivially small change. Confirm `cargo test test_compress_roundtrip_mse` passes with the same numeric threshold as before.
+
+## Details
+
+**Why this matters:** the project's V1 retrieval gates are tied to specific empirical thresholds (94.2% final recall@10 at 10K, 99.4% at 1K — see ADR-016). The MSE bound is a proxy for those guarantees. A bare `0.05` in test code disconnects the assertion from its provenance; a named constant with a doc comment recovers it. This is a low-cost, high-leverage discipline win that future contributors benefit from every time they read the test.
+
+**Don't over-name.** A single threshold for a single test deserves a single constant. Don't introduce a `ThresholdConfig` struct or a builder pattern. The audit explicitly recommends `const NAME: f32 = value;` — match that.
+
+**ADR linkage in the doc comment** is high-value: if the constant ever needs revisiting (e.g. moving from 4-bit to 2-bit quantization), the doc comment tells the future contributor where the empirical justification lives. Without that, the constant becomes its own magic number again.
+
+## Reviewers
+
+- test-reviewer — verify the named constant has a meaningful doc comment that explains the empirical origin; verify the value is unchanged from `0.05` (this is a renaming, not a tightening); verify the constant is reachable only from test code (not leaked into production API).
+
+## Post-completion
+
+- [ ] decisions.md entry: Task 23 status, named constant(s) introduced, ADR/empirical reference
+- [ ] If other test files (proptests, integration_cbor) had similar magic numbers, document any spillover work and whether it was addressed in this task


### PR DESCRIPTION
## Summary

Documents-only PR adding 7 task files for the major findings deferred from the wave 12 audits (PR #7). Each task is ready for parallel execution before pre-deploy QA.

The 1 **critical** finding (fastembed 5.x compat) is handled separately in #9.

## Tasks added

| Task | Title | Source finding |
|---|---|---|
| 17 | Move payment schema out of core + delete vestigial `LineageStore` trait | CODE-AUDIT-002 (compound; two sub-issues combined per audit recommendation) |
| 18 | Replace error-swallowing `filter_map(\|r\| r.ok())` in storage | CODE-AUDIT-003 |
| 19 | Replace `unsafe impl Send/Sync for McpState` with safe alternative | CODE-AUDIT-004 |
| 20 | Demote `SolanaClient::rpc` + add typed high-level method | CODE-AUDIT-005 |
| 21 | Storage tests: exercise traits via `&dyn` references | TEST-STORAGE-CONTRACT-1 |
| 22 | Replace `catch_unwind` + `let _ = result;` with real assertions in compress edge tests | TEST-COMPRESS-EDGE-1 |
| 23 | Replace magic-number `0.05` in MSE test with named threshold const | TEST-COMPRESS-MSE-CONST-1 |

## Wave structure

- **Wave 13** (new): tasks 17–23, parallelizable, depend on wave 12 audits (13 and/or 15).
- **Wave 14** (was 13): task 16 — pre-deploy QA — bumped, with `depends_on` extended to `[13, 14, 15, 17, 18, 19, 20, 21, 22, 23]`. QA only runs once the fix wave lands.

## Reviewer assignments per task

Reviewers chosen to match the nature of each fix:

- 17, 19, 20 → `code-reviewer + security-auditor` (architectural / safety boundaries)
- 18, 21 → `code-reviewer + test-reviewer` (correctness + contract coverage)
- 22, 23 → `test-reviewer` only (test-only changes)

## Verification commands per task

Each task file lists the exact `cargo` and `grep` commands the agent must run to verify completion. All include the `--all-features` clippy gate so this category of feature-flagged regression cannot recur.

## Source of findings

- `work/mnemonic-core/logs/working/audit/code-auditor.json`
- `work/mnemonic-core/logs/working/audit/test-auditor.json`

## Test plan

- [ ] Reviewer skims each task file for clarity / scope discipline (no over-engineering, no premature abstractions)
- [ ] Reviewer confirms task 16's bumped `depends_on` matches the new wave structure
- [ ] CI passes (no code changes; markdown only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)