### PR TITLE
ci: add release pipeline and Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+target/
+.git/
+.github/
+work/
+docs/
+webapp/
+.claude/
+.env
+.env.*
+!.env.example
+*.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,86 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            archive: tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            archive: tar.gz
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+
+      - name: Build
+        run: cargo build --release --target ${{ matrix.target }} -p mnemonic-mcp
+
+      - name: Package
+        shell: bash
+        run: |
+          tag="${GITHUB_REF#refs/tags/}"
+          name="mnemonic-mcp-${tag}-${{ matrix.target }}"
+          mkdir -p "$name"
+          cp "target/${{ matrix.target }}/release/mnemonic-mcp" "$name/"
+          cp README.md "$name/" 2>/dev/null || true
+          tar czf "${name}.tar.gz" "$name"
+          echo "ASSET=${name}.tar.gz" >> $GITHUB_ENV
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target }}
+          path: ${{ env.ASSET }}
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/**/*.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM rust:1.83-slim AS builder
+
+WORKDIR /build
+
+RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
+
+COPY Cargo.toml Cargo.lock* ./
+COPY core/ core/
+COPY mcp/ mcp/
+
+RUN cargo build --release -p mnemonic-mcp
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/release/mnemonic-mcp /usr/local/bin/mnemonic-mcp
+
+ENV MCP_TRANSPORT=http
+ENV MCP_HTTP_PORT=3000
+ENV STORAGE_MODE=local
+ENV RUST_LOG=info
+
+EXPOSE 3000
+
+ENTRYPOINT ["mnemonic-mcp"]
+CMD ["--transport", "http", "--port", "3000"]


### PR DESCRIPTION
## Summary
- Add `release.yml` workflow: cross-compiles `mnemonic-mcp` for 4 targets (x86_64/aarch64 linux/macos) on `v*` tag push, creates GitHub Release with binary tarballs
- Add `Dockerfile`: multi-stage build for containerized deployment of mnemonic-mcp
- Add `.dockerignore` to keep Docker context clean

## Context
First deploy of the working prototype. Tasks 17-23 (audit refactoring) deferred -- shipping functional prototype first. Pre-deploy QA passed: 83 tests green, 17/17 acceptance criteria met.

## Test plan
- [ ] CI passes on this PR (fmt, clippy, test, gitleaks)
- [ ] After merge, tag `v0.1.0` to trigger release workflow
- [ ] Verify GitHub Release is created with 4 binary tarballs

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>