### PR TITLE
docs: add §5.3 Pipeline Walkthrough + docs/how-it-works.md

### DIFF
--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -115,6 +115,18 @@ Storage is selected by mode:
 - **Local mode:** SQLite only, synthetic local transaction IDs, no payment gate.
 - **Full mode:** signed artifact bytes can be persisted to Arweave, anchored on Solana, and indexed locally in SQLite.
 
+### 5.3 Pipeline Walkthrough (sign / recall / verify)
+
+The MCP server exposes three primary operational flows. Each is a thin orchestration layer over `mnemonic-core` primitives.
+
+**`mnemonic_sign_memory`.** A request carrying content text and tags traverses a fixed pipeline. The active embedder (FastEmbed local, OpenAI remote, or `MockEmbedder` in tests) produces a full-precision f32 vector. The vector is run through the TurboQuant scalar quantizer at the configured bit width (2, 3, or 4 bits per dimension; default 4) so the compressed form can be carried inside artifact metadata. The artifact — content, producer DID, timestamp, tags, embedding metadata — is encoded to canonical CBOR with stable field ordering, hashed with blake3, and signed as a COSE_Sign1 envelope using the server's Ed25519 identity. In `local` mode the COSE bytes plus the uncompressed embedding are written to SQLite and the operation returns synthetic `local:` transaction IDs at zero cost. In `full` mode the COSE bytes are uploaded to Arweave (via Irys) and the blake3 hash plus Arweave tx ID are anchored on Solana via an SPL Memo instruction; both real tx IDs are then committed alongside the row in the SQLite `AttestationStore`.
+
+**`mnemonic_recall`.** Recall is local-only by design. The query string is embedded with the same provider used at sign time, then scored against every stored uncompressed f32 embedding in SQLite via cosine similarity, and the top-k rows are returned ordered by score. The compressed bytes that traveled to Arweave are not consulted here: they are proof-of-existence artifacts for third-party verification, not a retrieval index. Recall therefore costs one embed call and one full table scan, with no chain reads.
+
+**`mnemonic_verify`.** Verification reads the stored artifact (locally, or by fetching the COSE bytes from Arweave in full mode), recomputes the blake3 hash over the canonical CBOR payload, and validates the COSE_Sign1 signature against the claimed Ed25519 producer identity. In full mode the verifier additionally confirms that the on-chain SPL Memo on Solana exists and references the same blake3 hash and Arweave tx ID. The result is one of `verified`, `tampered`, or `not_found`.
+
+For a deeper walkthrough including module boundaries and lock discipline, see [docs/how-it-works.md](./how-it-works.md).
+
 ## 6. Artifact Model
 
 Mnemonic artifacts are typed, versioned, and canonical.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,73 @@
+# How Mnemonic Works
+
+Companion to [WHITEPAPER §5.3 Pipeline Walkthrough](./WHITEPAPER.md#53-pipeline-walkthrough-sign--recall--verify). Where the whitepaper sketches the sign / recall / verify flows at protocol granularity, this document maps each step onto the actual `mnemonic-core` and `mnemonic-mcp` modules so contributors can navigate the codebase, understand the dependency direction, and reason about operational concerns such as lock discipline, storage modes, and payment gating.
+
+## Module map
+
+The repository is a Cargo workspace (`resolver = "2"`) with two members. The dependency graph is strictly one-way: `mcp/` depends on `core/`; `core/` never references `mcp/`.
+
+| Module | Responsibility |
+|---|---|
+| `mnemonic-core::codec` | Canonical CBOR encoding, blake3 hashing, COSE_Sign1 sign/verify, schema registry (`memory`, `rag.context`, `rag.result`, `agent.state`, `receipt`). |
+| `mnemonic-core::embed` | `Embedder` trait plus providers: `OpenAIEmbedder`, `FastEmbedder` (behind `local-embed`, ships an ONNX model on first run), `MockEmbedder` (`#[cfg(test)]` only). |
+| `mnemonic-core::compress` | TurboQuant scalar quantization at 2/3/4 bits per dimension; default 4. |
+| `mnemonic-core::identity` | Ed25519 keypair load/generate, base58 encoding, `did:sol` and `did:key` derivation. |
+| `mnemonic-core::storage` | `AttestationStore` trait and `SqliteStore` implementation; `LineageStore` trait; SQL lives in `core/src/storage/sqlite.rs`. |
+| `mnemonic-core::arweave` | Full-mode persistence: ANS-104 bundle builder, Irys upload, deep hash + Avro encoding. |
+| `mnemonic-core::solana` | Full-mode anchoring: `SolanaClient` for SPL Memo writes/reads. |
+| `mnemonic-core::lineage` | Parent-child artifact DAG with cycle detection and BFS traversal (`Direction::{Ancestors, Descendants, Both}`). |
+| `mnemonic-mcp` | JSON-RPC 2.0 dispatcher (`mcp.rs`), five MCP tools (`tools.rs`), Axum bootstrap (`main.rs`), payment gating (`payment.rs`), pricing engine (`pricing.rs`), env-driven config (`config.rs`). |
+
+## End-to-end walkthrough — sign_memory
+
+Implemented in `mcp/src/tools.rs::sign_memory`.
+
+1. **Embed.** Call the active `Embedder` to produce a full-precision f32 vector. Provider is selected at startup from `EMBED_PROVIDER`; the server aborts if no embedder is available. Embed quality dictates recall quality, so it must match between sign time and query time.
+2. **Compress.** Run the embedding through `compress::EmbeddingCompressor` (TurboQuant, default 4 bits/dim). The compressed bytes ride along inside artifact metadata as portable proof-of-existence; they are not used for local recall.
+3. **Build artifact.** Assemble the canonical JSON shape: `artifact_id`, `type`, `schema_version`, `content`, `producer` (DID-sol), `created_at`, `tags`, embedding metadata.
+4. **Canonicalize.** `codec::canonical::to_canonical_cbor` produces a deterministic byte sequence with stable field ordering. Determinism is required so the hash is reproducible across runtimes.
+5. **Hash.** `codec::hash::hash_bytes` computes blake3 over the canonical CBOR. This is the artifact's identity.
+6. **Sign.** `codec::sign::sign_artifact` wraps the CBOR payload in a COSE_Sign1 envelope under the server's Ed25519 identity.
+7. **Persist.**
+   - **Local mode:** write COSE bytes plus the uncompressed embedding to `SqliteStore`; return synthetic `local:` tx IDs.
+   - **Full mode:** upload COSE bytes to Arweave via the Irys client; submit an SPL Memo on Solana carrying `{"h": blake3, "a": arweave_tx, "v": 2}`; record both tx IDs alongside the row in SQLite. Cost is captured in `attestation_costs` for P&L tracking.
+
+## End-to-end walkthrough — recall
+
+Implemented in `mcp/src/tools.rs::recall` over `core/src/storage/sqlite.rs`.
+
+1. Embed the query with the same provider used at sign time.
+2. Cosine-score the query vector against every uncompressed f32 embedding in the local `memory_embeddings` table.
+3. Return the top-k rows ordered by score, joined to their `attestations` row metadata.
+
+Recall is intentionally local: SQLite read plus an in-process scan, no chain calls. Uncompressed f32 wins here because cosine similarity is sensitive to small magnitude shifts and TurboQuant compressed bytes are optimized for portability and inner-product approximation, not for being the canonical retrieval index. The compressed form on Arweave is proof-of-existence; the uncompressed form in SQLite is the search index.
+
+## End-to-end walkthrough — verify
+
+Implemented in `mcp/src/tools.rs::verify`.
+
+- **Artifact-only path.** Read the COSE_Sign1 envelope (locally, or by fetching the Arweave object in full mode), decode to canonical CBOR, recompute blake3 over the bytes, and check the recomputed hash matches the stored value. Then validate the COSE_Sign1 signature against the producer's claimed Ed25519 public key. Result is `verified`, `tampered`, or `not_found`.
+- **Chain-anchored path (full mode).** In addition to the above, fetch the SPL Memo on Solana referenced by `solana_tx`, parse its `{h, a, v}` payload, and confirm that the on-chain hash and Arweave tx ID match the local row. This adds independent timestamped existence to the integrity and authorship checks.
+
+## Operational notes
+
+- **Storage modes** (`STORAGE_MODE`). `local` is the default: SQLite only, synthetic `local:` tx IDs, free, offline; suitable for development and single-node use. `full` writes COSE bytes to Arweave and an SPL Memo to Solana on every sign and requires a funded Ed25519 keypair on a live RPC. The mode is set at startup, not per call; never mix modes in one DB.
+- **Payment modes** (`PAYMENT_MODE`, HTTP transport in `full` mode only). `none` | `balance` (Bearer-token API key checked against the live pricing engine) | `x402` (HTTP 402 challenge, retry with `X-Payment` header) | `both`. Only `mnemonic_sign_memory` is paid; `whoami`, `recall`, `verify`, and `prove_identity` are free.
+- **Lock discipline.** `rusqlite::Connection` is `!Send`. Always wrap `SqliteStore` in `std::sync::Mutex` in async contexts and never hold the lock across an `.await`. Tool handlers explicitly take `&std::sync::Mutex<SqliteStore>` and scope their guards before any IO.
+- **TurboQuant bit width.** Default 4 bits per dimension. Never change for an existing database — old and new compressed embeddings become incomparable, breaking any cross-node comparison and the artifact metadata commitment.
+
+## Architectural rules (audit-enforced)
+
+- Payment methods (`create_api_key`, `deduct_balance`, `credit_deposit`, `mark_x402_nonce`, `record_attestation_cost`, `get_pnl_stats`, `get_owner_pubkey`, `verify_usdc_transfer`) live only in `mcp/src/payment.rs`. None in `core/`.
+- `verify_usdc_transfer` is a standalone function taking `&SolanaClient`, not a method on it.
+- `pricing.rs` lives in `mcp/`, never in `core/`.
+- No `HashEmbedder` anywhere; `MockEmbedder` is allowed only inside `#[cfg(test)]` blocks.
+- `core/` has zero references to anything in `mcp/`. The dependency graph is one-way.
+
+## Pointers
+
+- [WHITEPAPER.md](./WHITEPAPER.md) — §4 Core Insight, §5 Architecture Overview (including §5.3 Pipeline Walkthrough), §6 Artifact Model, §7 Trust Model, §11 Current Implementation Status.
+- [research/condensed-principles.md](./research/condensed-principles.md) — TurboQuant design principles distilled.
+- [usecases/](./usecases/) — concrete agent-memory use-case roles for the protocol.
+- [competitive-landscape/](./competitive-landscape/) — positioning vs decentralized RAG, zkTAM, V3DB, and adjacent directions.
+- [problems/](./problems/) — open issues and unresolved questions.


### PR DESCRIPTION
## Summary

Restores commit `5310d58` from `feat/docs-actualization` that PR #19's squash merge missed. Adds the "How It Works" content the docs tree should have shipped with PR #19.

- **`docs/WHITEPAPER.md` §5.3 Pipeline Walkthrough** — ~340 words inside existing §5 Architecture Overview; walks `sign_memory` (embed → TurboQuant compress → canonical CBOR → blake3 → COSE_Sign1 → SQLite or Arweave+Solana), `recall` (cosine search over uncompressed f32 in SQLite), and `verify` (recompute hash, validate signature, optional on-chain anchor check). Closes with a pointer to the companion doc.
- **`docs/how-it-works.md`** (new, ~880 words) — module map covering `mnemonic-core::{codec, embed, compress, identity, storage, arweave, solana, lineage}` and `mnemonic-mcp`; end-to-end walkthroughs for the three flows; operational notes (storage modes, payment modes, lock discipline, TurboQuant bit-width caveat); audit-enforced architectural rules verbatim from `CLAUDE.md`; pointers to whitepaper sections, condensed-principles, use cases, competitive landscape, and problems.

## Why this is a separate PR

PR #19 was squash-merged at `a67b8ca`; the §5.3 + `how-it-works.md` commit (`5310d58`) was pushed to the feature branch after that point and never made it to `main`. Easier to re-land via a clean PR than to re-open #19.

§9 numbering is preserved (no shift).

## Test plan

- [x] Cherry-picked clean from `5310d58` (no merge conflicts).
- [ ] `docs-link-check` workflow runs and exits 0 on this PR.
- [ ] Reviewer skim §5.3 and `how-it-works.md` for accuracy against `CLAUDE.md` data flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)