### PR TITLE
feat(webapp): add WindSurf as a fourth MCP install target

### DIFF
--- a/mcp/src/cors_policy.rs
+++ b/mcp/src/cors_policy.rs
@@ -25,6 +25,9 @@
 ///     `*.cursor.com`
 ///   - OpenAI: `https://chatgpt.com` + `*.chatgpt.com`,
 ///     `https://chat.openai.com`, `https://openai.com` + `*.openai.com`
+///   - WindSurf / Codeium: `https://windsurf.com` + `*.windsurf.com`,
+///     `https://codeium.com` + `*.codeium.com` (the Cascade web preview and
+///     Codeium dashboard share the OAuth surface)
 ///
 /// All entries are HTTPS-only — `http://` origins return `false` to keep
 /// production traffic on TLS. Subdomain suffix-matching preserves a leading
@@ -69,6 +72,8 @@ pub fn is_allowed_cors_origin(origin: &[u8]) -> bool {
         "chatgpt.com",
         "chat.openai.com",
         "openai.com",
+        "windsurf.com",
+        "codeium.com",
     ];
     if exact_allow.contains(&host) {
         return true;
@@ -82,6 +87,8 @@ pub fn is_allowed_cors_origin(origin: &[u8]) -> bool {
         ".cursor.com",
         ".chatgpt.com",
         ".openai.com",
+        ".windsurf.com",
+        ".codeium.com",
     ];
     suffix_allow.iter().any(|suf| host.ends_with(suf))
 }
@@ -110,6 +117,14 @@ mod tests {
         assert!(is_allowed_cors_origin(b"https://chatgpt.com"));
         assert!(is_allowed_cors_origin(b"https://chat.openai.com"));
         assert!(is_allowed_cors_origin(b"https://platform.openai.com"));
+    }
+
+    #[test]
+    fn allows_windsurf_and_codeium() {
+        assert!(is_allowed_cors_origin(b"https://windsurf.com"));
+        assert!(is_allowed_cors_origin(b"https://app.windsurf.com"));
+        assert!(is_allowed_cors_origin(b"https://codeium.com"));
+        assert!(is_allowed_cors_origin(b"https://www.codeium.com"));
     }
 
     #[test]

--- a/webapp/e2e/install.spec.ts
+++ b/webapp/e2e/install.spec.ts
@@ -7,8 +7,9 @@ import { mcpBase } from "./_helpers";
  *   - Clicking "Generate keypair" runs the WASM `generate_keypair`,
  *     persists `mnemonic.identity` to localStorage, and renders the
  *     base58 pubkey
- *   - The Cursor / VS Code / Claude.ai install buttons emit deeplinks
- *     in the formats the respective clients accept (per
+ *   - The Cursor / VS Code / Claude.ai / WindSurf install buttons emit
+ *     deeplinks (or, for Claude.ai + WindSurf, modal copy-paste flows) in
+ *     the formats the respective clients accept (per
  *     `InstallButtons.tsx::cursorDeeplink/vscodeDeeplink`)
  */
 
@@ -91,6 +92,30 @@ test.describe("/install page", () => {
     // Must include scheme — Claude.ai rejects bare hostnames in
     // "Add custom connector" with "Invalid connector URL".
     expect(pasteUrl?.trim()).toMatch(/^https:\/\/mcp\.[\w.-]+\/mcp$/);
+
+    // WindSurf — no deeplink for custom remote MCPs (the
+    // `windsurf://windsurf-mcp-registry?serverName=` scheme is registry-only).
+    // The control is a <button> (not an anchor) and clicking it opens a modal
+    // with the JSON snippet for `~/.codeium/windsurf/mcp_config.json`. The
+    // browser must NOT navigate away when clicked.
+    const windsurfBtn = page.getByTestId("install-windsurf");
+    await expect(windsurfBtn).toHaveJSProperty("tagName", "BUTTON");
+    await expect(windsurfBtn).not.toHaveAttribute("href", /.+/);
+    const urlBeforeClick = page.url();
+    await windsurfBtn.click();
+    expect(page.url()).toBe(urlBeforeClick);
+
+    const snippet = await page
+      .getByTestId("windsurf-config-snippet")
+      .textContent();
+    const parsedWindsurf = JSON.parse(snippet ?? "{}");
+    expect(parsedWindsurf).toEqual({
+      mcpServers: {
+        mnemonic: {
+          serverUrl: expect.stringMatching(/^https:\/\/mcp\.[\w.-]+\/mcp$/),
+        },
+      },
+    });
   });
 });
 

--- a/webapp/src/components/InstallButtons.test.tsx
+++ b/webapp/src/components/InstallButtons.test.tsx
@@ -40,5 +40,21 @@ describe("InstallButtons", () => {
     fireEvent.click(claude);
     const pasteUrl = screen.getByTestId("claude-paste-url");
     expect(pasteUrl.textContent).toBe("https://mcp.mnemonik.xyz/mcp");
+
+    // WindSurf has no deeplink for arbitrary remote MCP URLs — its
+    // `windsurf://windsurf-mcp-registry?serverName=` scheme only resolves
+    // first-party registry entries (per docs.windsurf.com/windsurf/cascade/mcp).
+    // We mirror the Claude.ai flow instead: a button opens a modal with the
+    // JSON snippet that goes into `~/.codeium/windsurf/mcp_config.json`.
+    const windsurf = screen.getByTestId("install-windsurf");
+    expect(windsurf.tagName).toBe("BUTTON"); // not an anchor — no deeplink.
+    fireEvent.click(windsurf);
+    const snippetEl = screen.getByTestId("windsurf-config-snippet");
+    const parsedWindsurf = JSON.parse(snippetEl.textContent ?? "{}");
+    expect(parsedWindsurf).toEqual({
+      mcpServers: {
+        mnemonic: { serverUrl: "https://mcp.mnemonik.xyz/mcp" },
+      },
+    });
   });
 });

--- a/webapp/src/components/InstallButtons.tsx
+++ b/webapp/src/components/InstallButtons.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
 /**
- * Three deeplink buttons for the supported AI tools.
+ * Four install entry points for the supported AI tools.
  *
  * Cursor + VS Code use their respective custom URI schemes — both encode the
  * MCP server config in the URL so the user lands directly in the
@@ -11,8 +11,16 @@ import { useState } from "react";
  * with copy-to-clipboard instructions for `Settings → Connectors → Add custom
  * connector`.
  *
+ * WindSurf's `windsurf://windsurf-mcp-registry?serverName=` deeplink only
+ * accepts entries from WindSurf's first-party MCP registry — it cannot encode
+ * an arbitrary remote HTTP MCP URL. Until Mnemonic is published to that
+ * registry, we mirror the Claude.ai modal: a copy-the-URL prompt that
+ * instructs the user to paste the JSON snippet into
+ * `~/.codeium/windsurf/mcp_config.json`.
+ * Reference: https://docs.windsurf.com/windsurf/cascade/mcp
+ *
  * The MCP HTTP endpoint is `https://mcp.mnemonik.xyz/mcp` (per smithery.yaml +
- * Decision 5). All three integrations point to the same endpoint and reuse the
+ * Decision 5). All four integrations point to the same endpoint and reuse the
  * same OAuth flow established in Task 4.
  */
 
@@ -57,19 +65,45 @@ function vscodeDeeplink(): string {
   return `vscode:mcp/install?${encodeURIComponent(JSON.stringify(config))}`;
 }
 
+// JSON snippet that goes into `~/.codeium/windsurf/mcp_config.json`. WindSurf
+// accepts either `serverUrl` or `url` for remote HTTP MCP entries; we use
+// `serverUrl` to match the WindSurf docs' canonical example. Pretty-printed
+// (2-space indent) so a paste into the user's config file produces a
+// readable diff.
+const WINDSURF_CONFIG_SNIPPET = JSON.stringify(
+  {
+    mcpServers: {
+      mnemonic: {
+        serverUrl: MCP_URL,
+      },
+    },
+  },
+  null,
+  2
+);
+
 interface InstallButtonsProps {
   onClaudeAiClick?: () => void;
+  onWindsurfClick?: () => void;
 }
 
 export default function InstallButtons({
   onClaudeAiClick,
+  onWindsurfClick,
 }: InstallButtonsProps) {
   const [showClaudeModal, setShowClaudeModal] = useState(false);
+  const [showWindsurfModal, setShowWindsurfModal] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [windsurfCopied, setWindsurfCopied] = useState(false);
 
   const handleClaudeAi = () => {
     setShowClaudeModal(true);
     onClaudeAiClick?.();
+  };
+
+  const handleWindsurf = () => {
+    setShowWindsurfModal(true);
+    onWindsurfClick?.();
   };
 
   const handleCopy = async () => {
@@ -77,6 +111,16 @@ export default function InstallButtons({
       await navigator.clipboard.writeText(MCP_HOST);
       setCopied(true);
       setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // clipboard may be unavailable (HTTP, no user gesture) — ignore.
+    }
+  };
+
+  const handleCopyWindsurf = async () => {
+    try {
+      await navigator.clipboard.writeText(WINDSURF_CONFIG_SNIPPET);
+      setWindsurfCopied(true);
+      setTimeout(() => setWindsurfCopied(false), 2000);
     } catch {
       // clipboard may be unavailable (HTTP, no user gesture) — ignore.
     }
@@ -110,6 +154,14 @@ export default function InstallButtons({
           data-testid="install-claude-ai"
         >
           Add to Claude.ai
+        </button>
+        <button
+          type="button"
+          onClick={handleWindsurf}
+          className="rounded-md border border-text-muted/30 bg-white/5 px-4 py-3 text-left text-sm font-medium text-text-primary transition-colors hover:border-accent-primary hover:text-accent-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-primary"
+          data-testid="install-windsurf"
+        >
+          Install in WindSurf
         </button>
       </div>
 
@@ -160,6 +212,63 @@ export default function InstallButtons({
               <button
                 type="button"
                 onClick={() => setShowClaudeModal(false)}
+                className="rounded-md border border-text-muted/30 px-4 py-2 text-sm text-text-primary transition-colors hover:border-accent-primary"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {showWindsurfModal && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="windsurf-modal-title"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-background/80 px-4"
+        >
+          <div className="w-full max-w-md rounded-lg border border-text-muted/30 bg-background p-6 shadow-lg">
+            <h3
+              id="windsurf-modal-title"
+              className="text-base font-semibold text-text-primary"
+            >
+              Install in WindSurf
+            </h3>
+            <p className="mt-3 text-sm text-text-muted">
+              WindSurf&rsquo;s deeplink registry only accepts first-party
+              entries, so add Mnemonic by editing{" "}
+              <span className="font-mono text-text-primary">
+                ~/.codeium/windsurf/mcp_config.json
+              </span>{" "}
+              and pasting:
+            </p>
+            <div className="mt-4 rounded-md border border-text-muted/20 bg-white/5 px-3 py-2">
+              <pre
+                className="overflow-x-auto font-mono text-xs text-accent-primary"
+                data-testid="windsurf-config-snippet"
+              >
+                {WINDSURF_CONFIG_SNIPPET}
+              </pre>
+              <div className="mt-2 flex justify-end">
+                <button
+                  type="button"
+                  onClick={handleCopyWindsurf}
+                  className="shrink-0 rounded bg-accent-primary px-3 py-1 text-xs font-medium text-background transition-opacity hover:opacity-90"
+                  aria-label="Copy WindSurf config snippet"
+                >
+                  {windsurfCopied ? "Copied" : "Copy"}
+                </button>
+              </div>
+            </div>
+            <p className="mt-3 text-xs text-text-muted">
+              Reload WindSurf, then run any tool — Cascade prompts the OAuth
+              flow on the first call.
+            </p>
+            <div className="mt-5 flex justify-end">
+              <button
+                type="button"
+                onClick={() => setShowWindsurfModal(false)}
                 className="rounded-md border border-text-muted/30 px-4 py-2 text-sm text-text-primary transition-colors hover:border-accent-primary"
               >
                 Close

--- a/webapp/src/pages/Install.tsx
+++ b/webapp/src/pages/Install.tsx
@@ -4,7 +4,7 @@ import InstallButtons from "../components/InstallButtons";
 
 /**
  * Install hub (`/install`). Two columns on desktop, stacked on mobile:
- *   - Install buttons (Cursor / VS Code / Claude.ai).
+ *   - Install buttons (Cursor / VS Code / Claude.ai / WindSurf).
  *   - Identity panel (Generate / Import / Export keypair).
  */
 export default function Install() {
@@ -48,7 +48,7 @@ export default function Install() {
             OAuth, which signs the request with the local Ed25519 secret.
           </p>
 
-          <div className="grid gap-4 md:grid-cols-3">
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
             <article className="rounded-md border border-text-muted/20 bg-white/5 p-4">
               <h3 className="text-sm font-semibold text-accent-primary">
                 Cursor
@@ -112,6 +112,32 @@ export default function Install() {
                 </li>
                 <li>3. Paste the URL and submit.</li>
                 <li>4. Complete OAuth and approve the connector.</li>
+              </ol>
+            </article>
+
+            <article className="rounded-md border border-text-muted/20 bg-white/5 p-4">
+              <h3 className="text-sm font-semibold text-accent-primary">
+                WindSurf
+              </h3>
+              <ol className="mt-2 space-y-1 text-sm text-text-muted">
+                <li>
+                  1. Click{" "}
+                  <span className="text-text-primary">Install in WindSurf</span>{" "}
+                  above and copy the JSON snippet.
+                </li>
+                <li>
+                  2. Open{" "}
+                  <span className="font-mono text-text-primary">
+                    ~/.codeium/windsurf/mcp_config.json
+                  </span>{" "}
+                  and merge it into{" "}
+                  <span className="font-mono text-text-primary">
+                    mcpServers
+                  </span>
+                  .
+                </li>
+                <li>3. Reload WindSurf so Cascade picks up the new server.</li>
+                <li>4. Complete OAuth on the first tool call.</li>
               </ol>
             </article>
           </div>

--- a/webapp/src/pages/Landing.tsx
+++ b/webapp/src/pages/Landing.tsx
@@ -79,9 +79,10 @@ export default function Landing() {
                 2 · Install the MCP connector in your AI tool
               </p>
               <p className="mt-1 text-sm text-text-muted">
-                Cursor and VS Code accept a deeplink; Claude.ai accepts a custom
-                connector URL. All three negotiate OAuth 2.1 + PKCE against{" "}
-                <code>mcp.mnemonik.xyz</code>.
+                Cursor and VS Code accept a deeplink; Claude.ai takes a custom
+                connector URL; WindSurf takes a JSON snippet for
+                <code>mcp_config.json</code>. All four negotiate OAuth 2.1 +
+                PKCE against <code>mcp.mnemonik.xyz</code>.
               </p>
             </li>
             <li className="rounded-md border border-text-muted/20 bg-white/5 p-4">


### PR DESCRIPTION
## Summary

- Adds a fourth install target on `/install` for WindSurf (Codeium's VS Code fork).
- WindSurf's `windsurf://windsurf-mcp-registry?serverName=` deeplink is registry-only — it cannot encode arbitrary remote HTTP MCP URLs. Until Mnemonic is published to that registry, we mirror the Claude.ai pattern: a button opens a modal with the JSON snippet for `~/.codeium/windsurf/mcp_config.json` and a copy-to-clipboard.
- CORS: `windsurf.com` + `codeium.com` (apex + subdomains) added to the trust list, matching the existing pattern for client-vendor origins.

## Reference

[WindSurf Cascade MCP docs](https://docs.windsurf.com/windsurf/cascade/mcp) — confirms the deeplink scheme and the `mcp_config.json` schema (`mcpServers.<name>.serverUrl`).

## Files changed

- `webapp/src/components/InstallButtons.tsx` — new `install-windsurf` button + modal
- `webapp/src/components/InstallButtons.test.tsx` — assert the snippet shape
- `webapp/src/pages/Install.tsx` — fourth step-by-step card; grid 2-up md / 4-up lg
- `webapp/src/pages/Landing.tsx` — "How it works" copy mentions WindSurf
- `webapp/e2e/install.spec.ts` — Playwright coverage: button is not an anchor, click does not navigate the page, snippet JSON is well-formed
- `mcp/src/cors_policy.rs` — allow `windsurf.com` + `codeium.com`; new unit test

## Test plan

- [x] `cd webapp && npx tsc -b --noEmit` clean
- [x] `cd webapp && npx vitest run src/components/InstallButtons.test.tsx` passes
- [x] `cd webapp && npm run build` produces clean dist
- [x] `cargo test -p mnemonic-mcp --lib cors_policy` — 8/8 pass (incl. new `allows_windsurf_and_codeium`)
- [ ] Manual: hit `/install`, click "Install in WindSurf", verify modal + Copy button
- [ ] Once Mnemonic is in WindSurf's MCP registry, swap the modal for a real `windsurf://windsurf-mcp-registry?serverName=mnemonic` deeplink

> Note: Pre-existing `Sign.test.tsx` failure and `oauth.rs` clippy warnings exist on `main` and are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)