### PR TITLE
docs(a2a-bridge): add A2A bridge feature folder + protocol-integratio…

### DIFF
--- a/.claude/skills/project-knowledge/SKILL.md
+++ b/.claude/skills/project-knowledge/SKILL.md
@@ -32,6 +32,9 @@ All documentation is in the `references/` folder:
 ## Optional references
 
 - **[ux-guidelines.md](references/ux-guidelines.md)** - Interface language, tone of voice, domain glossary, text patterns, design system (only for projects with significant UI)
+- **[crypto-design.md](references/crypto-design.md)** - Cryptographic primitives, COSE_Sign1 envelope, deterministic CBOR canonicalization, Ed25519 identity, blake3 hashing
+- **[economics.md](references/economics.md)** - Pricing engine, payment modes, attestation cost accounting, x402 + balance flows
+- **[protocol-integrations.md](references/protocol-integrations.md)** - Status of bindings to external multi-agent protocols (A2A, MCP-to-MCP delegation, ACP, AGNTCY, frameworks); index over `work/a2a-bridge/` and the protocol-integrations backlog
 - **{custom}.md** - Domain-specific files added per project (e.g., vault.md, bot.md, mcp.md)
 
 ## How to use

--- a/.claude/skills/project-knowledge/references/project.md
+++ b/.claude/skills/project-knowledge/references/project.md
@@ -9,7 +9,9 @@ This file provides high-level project overview for AI agents. Helps agents under
 
 **Name:** mnemonic-protocol (monorepo)
 
-**Description:** Monorepo for the Mnemonic Protocol — verifiable, persistent memory for AI agents with cryptographic attestation on Arweave and Solana.
+**Positioning (locked-in 2026-05-01):** Mnemonic is **verifiable memory for trustless agents**. Cryptographic provenance over content the agent itself claims to remember, composed underneath the trustless-agent stack (A2A + ERC-8004) rather than competing with general-purpose AI memory products on retrieval quality. Strategic rationale, gap analysis, and what this positioning explicitly forecloses: see [`work/a2a-bridge/research/positioning-trustless-agents.md`](../../../../work/a2a-bridge/research/positioning-trustless-agents.md).
+
+**Description:** Monorepo for the Mnemonic Protocol — verifiable, persistent memory for AI agents with cryptographic attestation. Today anchors on Arweave (durable storage) + Solana (SPL Memo timestamp); the anchor layer is being decoupled to support Ethereum (via ERC-8004 Validation Registry) as part of the Phase 5 trustless-agent stack integration.
 
 Contains four components: protocol documentation, a Rust core library, an MCP server for Cursor/Claude Desktop, and a demo web app. The core library compiles to both native Rust and WASM, so all components share one implementation. See architecture.md for the full directory structure.
 

--- a/.claude/skills/project-knowledge/references/protocol-integrations.md
+++ b/.claude/skills/project-knowledge/references/protocol-integrations.md
@@ -4,9 +4,19 @@ Status of Mnemonic's integration with external multi-agent protocols. Source of 
 
 ---
 
+## Positioning
+
+The protocol-integration roadmap exists to deliver one positioning, locked in 2026-05-01:
+
+> **Mnemonic is verifiable memory for trustless agents.**
+
+The trustless-agent stack as it exists in May 2026 (A2A v1.0.0-rc + ERC-8004 mainnet + TEE / crypto-economic validators) is missing the layer that proves what an agent claims to remember. Mnemonic fills that gap. Full rationale, gap analysis, three-regime decision matrix, and what the positioning forecloses live in [`work/a2a-bridge/research/positioning-trustless-agents.md`](../../../../work/a2a-bridge/research/positioning-trustless-agents.md). That document is the strategic charter for everything in the table below.
+
+---
+
 ## TL;DR
 
-Mnemonic's whitepaper positions the protocol underneath multi-agent coordination layers as durable, signed memory. Today the only wire surface is Mnemonic's own MCP tools (5 of them). No protocol bindings ship yet. The active backlog item is the **A2A bridge** — see `work/a2a-bridge/`.
+Today the only wire surface is Mnemonic's own MCP tools (5 of them). No protocol bindings ship yet. The active backlog item is the **A2A bridge** (`work/a2a-bridge/`); the next is the **ERC-8004 follow-on** detailed in `work/a2a-bridge/backlog.md`. Both are required to land the positioning above; they are sequenced together because they share substrate.
 
 ---
 
@@ -15,10 +25,10 @@ Mnemonic's whitepaper positions the protocol underneath multi-agent coordination
 | Protocol | Status | Folder | Schema family |
 |---|---|---|---|
 | **A2A (Agent2Agent)** | Backlog → V1 in flight | `work/a2a-bridge/` | `A2A_TASK_V1`, `A2A_MESSAGE_V1`, `A2A_ARTIFACT_V1` |
+| **ERC-8004 (Trustless Agents, Ethereum mainnet 2026-01-29)** | Backlog — V1 plan locked, anchor pluggability co-required | `work/a2a-bridge/backlog.md` (Phase 2 of the bridge stack) | reuses A2A schemas + new `MNEMONIC_FEEDBACK_V1` for Reputation Registry payloads |
 | **MCP-to-MCP delegation** | Backlog | `work/a2a-bridge/backlog.md` | `MCP_DELEGATION_V1` (planned) |
 | **ACP (IBM/BeeAI)** | Backlog | `work/a2a-bridge/backlog.md` | `ACP_RUN_V1`, `ACP_MESSAGE_V1`, `ACP_AWAIT_V1` (planned) |
 | **AGNTCY (Cisco)** | Watch & wait | `work/a2a-bridge/backlog.md` | TBD post-AGNTCY-v1 |
-| **ERC-8004 / on-chain identity** | Foreclosed pre-Phase-3 | `work/mnemonic-cli/backlog.md` | n/a (anchor-layer) |
 | **LangGraph / AutoGen / CrewAI** | Frameworks, not protocols | `work/a2a-bridge/backlog.md` | reuse A2A / ACP / MCP-delegation envelopes |
 
 ---
@@ -62,6 +72,29 @@ IBM / Linux Foundation / BeeAI's protocol — REST-based (not JSON-RPC), message
 
 ---
 
+## ERC-8004 — Trustless Agents (Ethereum mainnet, live since 2026-01-29)
+
+ERC-8004 is the on-chain trust layer designed to extend A2A. Three registries on Ethereum mainnet:
+
+- **Identity Registry** — ERC-721 NFT per agent. `agentId = tokenId`. `tokenURI` resolves to off-chain JSON registration file with `services[]`, `supportedTrust[]`, cross-chain `registrations[]`.
+- **Reputation Registry** — `giveFeedback` / `appendResponse` / `revokeFeedback` / `readAllFeedback` / `getSummary`; on-chain commits a hash, off-chain JSON carries the rich payload.
+- **Validation Registry** — `validationRequest` / `validationResponse` with `responseURI` + `responseHash` for off-chain attestations. Spec note: still under active update with the TEE community.
+
+**Why Mnemonic plugs in cleanly.** The Validation Registry is *literally designed* for off-chain signed attestations like Mnemonic's COSE_Sign1-over-deterministic-CBOR. Two existing validator categories are filling fast (TEE — Phala / Marlin; crypto-economic — staking-based). Mnemonic occupies a third, distinct trust category — **signed-memory** — that no current ERC-8004 participant holds. First-mover window is months, not years.
+
+**Four integration paths** (full detail in `work/a2a-bridge/backlog.md` § "ERC-8004 — Phase 2 of the bridge stack"):
+
+1. Mnemonic as a registered validator on the Validation Registry (validator-as-a-service).
+2. Mnemonic declared in agents' own registration files (minimal binding).
+3. Mnemonic-attested entries in the Reputation Registry (long-lived signing identity behind every feedback).
+4. Three-way identity reconciliation via `did:mnemonic:` — closes the chain `tokenId → registration file → AgentCard URL → x-mnemonic.ed25519_pubkey`.
+
+**Hard prerequisite — Solana decoupling.** Path-b ("ship ERC-8004 while keeping Solana SPL Memo as the only anchor") is rejected because it deepens the SVM dependency the protocol is trying to escape (`work/mnemonic-cli/backlog.md` Phase 3). The chain-pluggable anchor work — narrowed to "Phase 3α", anchor-only, off-chain envelope alg unchanged — must land *during or before* erc8004-1. This is treated as a sequencing constraint, not a "maybe", and is recorded in `work/a2a-bridge/decisions.md`.
+
+**Scope.** ~20 dev-days across six tasks (`erc8004-0` anchor pluggability through `erc8004-5` Ethereum anchor end-to-end), riding entirely on the A2A bridge substrate.
+
+---
+
 ## AGNTCY (watch & wait)
 
 Cisco / Outshift's Agent Connect initiative — broader than a single wire protocol; standardizes agent identity, discovery, and message-passing with their own AgentCard-like spec (`agp`). Less mature than A2A or ACP. Their identity layer is closer to DIDs than A2A's JWS model — the integration that would force `did:mnemonic:` design is this one.
@@ -84,8 +117,8 @@ These do not change the off-chain envelope and so do not belong in this doc beyo
 
 - **Solana** — current default anchor (SPL Memo). See `core/src/solana/`.
 - **Arweave** — current default durable storage. See `core/src/arweave/`.
-- **Chain-pluggable anchor** (Ethereum / Bitcoin / ICP / Arweave-only / none) — Phase 3 of `mnemonic-cli`. See `work/mnemonic-cli/backlog.md`.
-- **ERC-8004 on-chain agent identity** — foreclosed until chain-pluggable anchor lands. Re-evaluate post-Phase-3.
+- **Chain-pluggable anchor** (Ethereum / Bitcoin / ICP / Arweave-only / none) — Phase 3 of `mnemonic-cli`. The narrowed subset "Phase 3α" (anchor-only, off-chain envelope alg unchanged) is upgraded to **prerequisite or co-requisite of ERC-8004 V1** — see `work/a2a-bridge/backlog.md` and the cross-link in `work/mnemonic-cli/backlog.md` "TOP PRIORITY 2".
+- **ERC-8004 on-chain agent identity** — see the dedicated section above. No longer foreclosed.
 
 ---
 

--- a/.claude/skills/project-knowledge/references/protocol-integrations.md
+++ b/.claude/skills/project-knowledge/references/protocol-integrations.md
@@ -1,0 +1,100 @@
+# Protocol Integrations
+
+Status of Mnemonic's integration with external multi-agent protocols. Source of truth for which bindings exist, which are planned, and which are deliberately deferred.
+
+---
+
+## TL;DR
+
+Mnemonic's whitepaper positions the protocol underneath multi-agent coordination layers as durable, signed memory. Today the only wire surface is Mnemonic's own MCP tools (5 of them). No protocol bindings ship yet. The active backlog item is the **A2A bridge** — see `work/a2a-bridge/`.
+
+---
+
+## Snapshot
+
+| Protocol | Status | Folder | Schema family |
+|---|---|---|---|
+| **A2A (Agent2Agent)** | Backlog → V1 in flight | `work/a2a-bridge/` | `A2A_TASK_V1`, `A2A_MESSAGE_V1`, `A2A_ARTIFACT_V1` |
+| **MCP-to-MCP delegation** | Backlog | `work/a2a-bridge/backlog.md` | `MCP_DELEGATION_V1` (planned) |
+| **ACP (IBM/BeeAI)** | Backlog | `work/a2a-bridge/backlog.md` | `ACP_RUN_V1`, `ACP_MESSAGE_V1`, `ACP_AWAIT_V1` (planned) |
+| **AGNTCY (Cisco)** | Watch & wait | `work/a2a-bridge/backlog.md` | TBD post-AGNTCY-v1 |
+| **ERC-8004 / on-chain identity** | Foreclosed pre-Phase-3 | `work/mnemonic-cli/backlog.md` | n/a (anchor-layer) |
+| **LangGraph / AutoGen / CrewAI** | Frameworks, not protocols | `work/a2a-bridge/backlog.md` | reuse A2A / ACP / MCP-delegation envelopes |
+
+---
+
+## A2A bridge (active)
+
+A2A is Google's Agent2Agent protocol — JSON-RPC + SSE over HTTP, currently v1.0.0-rc, with `Task` / `Message` / `Part` / `Artifact` / `AgentCard` as core types and AgentCard JWS signing for producer identity. The protocol explicitly defers memory ("agents collaborate without needing access to each other's internal state, memory, or tools"), which is exactly the gap Mnemonic fills.
+
+**Why it matters for Mnemonic.** Six of eleven `docs/usecases/*.md` are A2A-shaped (`task-memory-ledger`, `shared-memory-layer`, `shared-project-memory-namespace`, `artifact-attestation-service`, `provenance-attestation-layer`, `reliability-oracle-for-orchestration`). Without a bridge, each integrator hand-rolls the mapping from A2A wire types to `MEMORY_V1` and maintains it across A2A versions. A first-class bridge converts the whitepaper's positioning sentence ("A2A makes agents interoperable in motion; Mnemonic makes them coherent over time") from prose into a working integration surface, and creates a defensible double moat — signed memory + native multi-agent protocol binding — that no current memory competitor (letta / zep / mem0 / cognee) holds.
+
+**Surface (planned).** Three layers:
+- Schemas in `mnemonic-core` (`core/src/codec/a2a/`).
+- Adapter crate `mnemonic-a2a/` (pure-Rust functions over `mnemonic-core`).
+- Three deployment shapes: MCP tools (`mnemonic_attest_a2a`, `mnemonic_recall_a2a`), reference sidecar (`bridge-a2a/`), SDK helpers in `@mnemonik-xyz/sdk`.
+
+**Identity binding.** AgentCard `x-mnemonic` extension publishes the agent's Ed25519 pubkey; A2A's existing JWS over the AgentCard authenticates the binding. No DID, no new identity crypto.
+
+**Conformance.** Golden vectors published as `@mnemonik-xyz/conformance` so any third-party implementation can prove byte-for-byte parity. Ties into the missing `references/conformance.md` doc that this work also creates.
+
+See `work/a2a-bridge/{user-spec.md, tech-spec.md, tasks/, decisions.md, backlog.md}` for the full plan and 8-task wave breakdown.
+
+---
+
+## MCP-to-MCP delegation (planned)
+
+When MCP server A delegates a tool call to MCP server B on the user's behalf, today there is no signed record of the chain. This is structurally identical to A2A task delegation but on the MCP transport.
+
+**Schema sketch.** `MCP_DELEGATION_V1 = {caller_pubkey, callee_pubkey, tool_name, request_hash, response_hash, started_at, completed_at, status}`. Adapter pattern reuses `mnemonic-a2a` 70/30 (most of the lineage / canonicalization plumbing transfers).
+
+**Why it matters.** Closes the audit gap for "agent toolchains where one MCP server forwards calls to another" — currently only the outermost server's logs exist. Mnemonic itself becomes a first-class delegation target ("agent X called `mnemonic_sign_memory` Y times this session"). Differentiates against generic MCP registries (smithery etc.): they list servers, we attest interactions between them.
+
+---
+
+## ACP — Agent Communication Protocol (planned)
+
+IBM / Linux Foundation / BeeAI's protocol — REST-based (not JSON-RPC), messages-as-first-class-objects, async-by-default with explicit `Run.await` semantics for human-in-the-loop. Different surface from A2A, same underlying memory gap.
+
+**Schema sketch.** `ACP_RUN_V1` (matches ACP's `Run` lifecycle: `created → in-progress → awaiting → completed/failed/cancelled`), `ACP_MESSAGE_V1`, `ACP_AWAIT_V1`. The await semantics are particularly attestable — these are the long-running runs where signed audit trail matters most for compliance.
+
+**Why two protocol bindings.** A2A + ACP together makes "vendor-neutral attestation layer" a real claim instead of an aspirational one. They cover the two leading open multi-agent ecosystems (Google-led and IBM-led). Subsequent bindings cost less because the adapter pattern is established.
+
+---
+
+## AGNTCY (watch & wait)
+
+Cisco / Outshift's Agent Connect initiative — broader than a single wire protocol; standardizes agent identity, discovery, and message-passing with their own AgentCard-like spec (`agp`). Less mature than A2A or ACP. Their identity layer is closer to DIDs than A2A's JWS model — the integration that would force `did:mnemonic:` design is this one.
+
+Re-evaluate when AGNTCY tags v1. Premature today: schema would churn.
+
+---
+
+## Frameworks vs. protocols
+
+LangGraph, AutoGen, CrewAI, Agno, etc. are **frameworks**, not protocols. Do **not** define new core schemas per framework. Instead provide framework-specific adapters in `@mnemonik-xyz/sdk` that translate framework events into one of the protocol envelopes (A2A / ACP / MCP-delegation) and route through the appropriate bridge.
+
+This preserves the one-way dependency graph in `core/`, keeps the schema count bounded, and lets each framework pick whichever protocol binding most naturally fits its call shape.
+
+---
+
+## Anchor-layer integrations
+
+These do not change the off-chain envelope and so do not belong in this doc beyond pointer:
+
+- **Solana** — current default anchor (SPL Memo). See `core/src/solana/`.
+- **Arweave** — current default durable storage. See `core/src/arweave/`.
+- **Chain-pluggable anchor** (Ethereum / Bitcoin / ICP / Arweave-only / none) — Phase 3 of `mnemonic-cli`. See `work/mnemonic-cli/backlog.md`.
+- **ERC-8004 on-chain agent identity** — foreclosed until chain-pluggable anchor lands. Re-evaluate post-Phase-3.
+
+---
+
+## When to update this doc
+
+Add a row to the snapshot table whenever:
+- A new protocol-binding folder appears under `work/`.
+- A backlog binding gets a tech-spec.
+- A binding ships V1 (status flips to "shipped").
+- A protocol enters or leaves "watch & wait" — usually because the protocol itself tagged a stable release.
+
+Source of truth for the *active* binding is its `work/<name>/` folder; this doc is the index.

--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -299,6 +299,8 @@ Open areas before broad production deployment:
 
 ## 14. Roadmap
 
+The roadmap below is organized around a single positioning, locked in 2026-05-01: **Mnemonic is verifiable memory for trustless agents.** Phases 1–3 deliver the core memory primitive; Phases 4–5 compose it into the trustless-agent stack (A2A + ERC-8004) so signed memory becomes a first-class layer underneath multi-agent coordination and on-chain identity.
+
 ### Phase 1: Practical Verifiable Memory
 
 - Harden the Rust MCP implementation.
@@ -319,6 +321,7 @@ Open areas before broad production deployment:
 - Add multi-writer consistency semantics.
 - Support portable memory restore workflows.
 - Expand provenance artifacts beyond simple memory items.
+- Anchor-layer pluggability ("Phase 3α") — narrowed subset that decouples the storage path from Solana SPL Memo, so any chain (or no chain) can serve as anchor. Pulled forward as a prerequisite of Phase 5.
 
 ### Phase 4: Trust And Settlement Network
 
@@ -326,6 +329,19 @@ Open areas before broad production deployment:
 - Mature x402-style agent payment flows.
 - Introduce reliability scoring for shared-memory contributors.
 - Explore ZK proofs for embedding correctness and retrieval correctness.
+
+### Phase 5: Trustless-Agent Stack Integration
+
+This phase locks in the "verifiable memory for trustless agents" positioning by composing Mnemonic's signed-memory primitive into the multi-agent and on-chain identity standards that shipped during 2026.
+
+- **A2A bridge V1.** First-class binding to Google's Agent2Agent protocol (v1.0.0-rc, JSON-RPC + SSE). Three new CBOR schemas (`A2A_TASK_V1`, `A2A_MESSAGE_V1`, `A2A_ARTIFACT_V1`), an adapter crate, two new MCP tools (`mnemonic_attest_a2a`, `mnemonic_recall_a2a`), reference middleware sidecar, and a published byte-for-byte conformance suite. Turns six A2A-shaped use cases (`task-memory-ledger`, `shared-memory-layer`, `shared-project-memory-namespace`, `artifact-attestation-service`, `provenance-attestation-layer`, `reliability-oracle-for-orchestration`) from aspirational into executable.
+- **ERC-8004 follow-on.** Integration with the on-chain trustless-agent registries (Identity / Reputation / Validation), live on Ethereum mainnet since 2026-01-29. Four paths: validator-as-a-service on the Validation Registry, agent registration-file binding, Mnemonic-attested entries in the Reputation Registry, and `did:mnemonic:` resolver for cross-ecosystem identity reconciliation. Mnemonic occupies a third trust category — *signed-memory* — distinct from the TEE and crypto-economic validators already filling.
+- **AgentCard `x-mnemonic` extension.** Publishes the agent's Ed25519 attestation key alongside its A2A capability declaration, so any A2A-native verifier can locate the Mnemonic verification key without a separate lookup. Composes with A2A's existing AgentCard JWS authentication.
+- **Threat model and conformance.** Publishes the first formal threat-model document covering the A2A and ERC-8004 boundaries (canonicalization mismatches, replay, identity substitution, contextId forking) and a portable conformance vector suite (`@mnemonik-xyz/conformance`) so any third-party implementation in any language can prove byte-for-byte parity.
+
+After Phase 5: Mnemonic is the only primitive in the trustless-agent stack that gives cryptographic provenance over content the agent itself claims to remember, cross-vendor temporal coherence via lineage, and semantic recall over that signed history — composable underneath A2A, anchored through ERC-8004's existing on-chain commitments without binding the agent's signing identity to a wallet.
+
+Detailed plan, task breakdown, and decision rationale: `work/a2a-bridge/` (`user-spec.md`, `tech-spec.md`, `tasks/`, `backlog.md`, `decisions.md`, `research/positioning-trustless-agents.md`).
 
 ## 15. Conclusion
 

--- a/work/a2a-bridge/backlog.md
+++ b/work/a2a-bridge/backlog.md
@@ -4,6 +4,20 @@ Items deliberately out of A2A-V1 scope. Architecture must remain open for them �
 
 ---
 
+## Positioning (locked-in 2026-05-01)
+
+This entire body of work — A2A bridge V1, ERC-8004 follow-on, MCP-to-MCP delegation, ACP, AGNTCY, framework adapters — exists to deliver a single positioning:
+
+> **Mnemonic is verifiable memory for trustless agents.**
+
+Not "memory for AI agents" (head-to-head with letta / zep / mem0 / cognee on retrieval quality, where we lose). Not "agent identity" (head-to-head with ERC-8004 / DIDs, where we compose rather than compete). Not "execution attestation" (TEE territory). The defensible niche is **cryptographic provenance over content the agent itself claims to remember**, composed underneath the trustless-agent stack (A2A + ERC-8004).
+
+Full gap analysis, what we explicitly do not close, three-regime decision rationale, and what the positioning forecloses: see [`research/positioning-trustless-agents.md`](research/positioning-trustless-agents.md). Anyone touching this backlog should read that document first — every sequencing decision below derives from it.
+
+Decision log entry: `decisions.md` → "2026-05-01 — Positioning lock-in: verifiable memory for trustless agents".
+
+---
+
 ## A2A — V2 / future scope
 
 - **Streaming chunk attestation (`A2A_STREAM_CHUNK_V1`)** — per-SSE-chunk attestations for `SendStreamingMessage` / `SubscribeToTask`. V1 only fixes the final task state. Cost: high write-amplification; needs batched / Merkle-root strategy.

--- a/work/a2a-bridge/backlog.md
+++ b/work/a2a-bridge/backlog.md
@@ -76,11 +76,159 @@ Not protocols — frameworks. Each has its own message and run abstractions.
 
 ---
 
-## ERC-8004 / on-chain agent identity
+## ERC-8004 — Phase 2 of the bridge stack (post A2A V1)
 
-Ethereum L2-native agent identity registries (ERC-8004 draft, plus AGNTCY-on-chain experiments). When + if they stabilize, Mnemonic attestations could register the producer pubkey there directly, giving a single verifiable identity from a Web3 audience without changing the off-chain envelope.
+**Status as of 2026-05-01:** ERC-8004 ("Trustless Agents") shipped on Ethereum mainnet on **2026-01-29**. It is *literally designed* to extend A2A with a trust layer via three on-chain registries (Identity / Reputation / Validation), each pointing at off-chain content-addressed documents. Mnemonic's signed-CBOR-with-Ed25519 envelope is one of the cleanest off-chain attestation shapes that fits the spec's "responseURI + responseHash" pattern. First-mover window is closing — TEE-attestation validators (Phala, Marlin) are already moving in. Mnemonic occupies a third, distinct trust category (signed-memory) that no current ERC-8004 participant holds.
 
-**Cost:** Trivial once the chain-pluggable anchor (Phase 3 of `mnemonic-cli`) lands. Pre-Phase-3: foreclosed.
+**Hard prerequisite — break the Solana lock during or before this stage.** Path-b ("validator-as-a-service that still anchors via Solana memo and only *posts* to ERC-8004 off-chain") is explicitly REJECTED. Reason: it ships ERC-8004 integration while *deepening* the SVM dependency the protocol is trying to escape (Phase 3 of `work/mnemonic-cli/backlog.md`). We do not double-anchor. The chain-pluggable anchor work either (a) lands first and ERC-8004 inherits Ethereum as one of the supported anchors, or (b) lands inside this same effort. Status of `mnemonic-cli` Phase 3 is upgraded from "future Phase 3" to **"prerequisite or co-requisite of ERC-8004"** — see decision entry in `decisions.md` and the cross-reference in `work/mnemonic-cli/backlog.md`.
+
+### What we're integrating with
+
+ERC-8004 = three on-chain registries on Ethereum mainnet:
+
+- **Identity Registry** — ERC-721 NFT per agent. `agentId = tokenId`. `tokenURI` resolves to off-chain JSON registration file with `services[]` (a2a, mcp), `supportedTrust[]` (reputation, crypto-economic, tee-attestation), `registrations[]` (cross-chain bindings). Reserved metadata key `agentWallet` managed via EIP-712 / ERC-1271.
+- **Reputation Registry** — `giveFeedback(agentId, value, valueDecimals, tag1, tag2, feedbackURI, feedbackHash)`; `appendResponse(...)`; `revokeFeedback(...)`; `readAllFeedback(...)`; `getSummary(...)`. On-chain commits a hash; off-chain JSON carries the rich payload.
+- **Validation Registry** — `validationRequest(validator, agentId, requestURI, requestHash)` then `validationResponse(requestHash, response, responseURI, responseHash, tag)`. Spec status: "still under active update and discussion with the TEE community" → schema-lock against current rev would create migration debt; ship behind `experimental` feature flag until stable, same discipline as A2A.
+
+Off-chain registration file (the `tokenURI` target):
+
+```jsonc
+{
+  "type": "schema identifier",
+  "name": "...",
+  "services": [
+    { "type": "a2a", "uri": "https://my-agent.example/a2a" },
+    { "type": "mnemonic", "uri": "https://mcp.mnemonik.xyz/agent/<pubkey>" }
+  ],
+  "supportedTrust": ["reputation", "tee-attestation", "signed-memory-attestation"],
+  "registrations": [{ "agentRegistry": "eip155:1:0x...", "agentId": "<tokenId>" }]
+}
+```
+
+### Four integration paths
+
+#### Path 1 — Mnemonic as a registered validator (Validation Registry)
+
+Strongest fit. The Validation Registry is exactly an off-chain-attestation hook. Mnemonic registers as a validator address; agents call `validationRequest(MNEMONIC_VALIDATOR_ADDRESS, agentId, taskURI, taskHash)`; the validator service consumes the referenced A2A task through the existing `bridge-a2a/` middleware, produces an `A2A_TASK_V1` attestation, hosts it on Arweave (already in `core/src/arweave/`), and posts `validationResponse(requestHash, OK, mnemonic_attestation_uri, blake3_hash, tag="mnemonic-a2a-v1")`.
+
+Verification by any third party: fetch `responseURI` → COSE_Sign1-verify against Mnemonic's published Ed25519 pubkey → recompute blake3 → compare with on-chain `responseHash`. Trustless; no `mcp.mnemonik.xyz` in the trust path.
+
+This becomes a **new product surface**: validator-as-a-service on ERC-8004. Maps cleanly onto existing `mcp/src/payment.rs` (x402 / balance) — per-validation fee, same flow as `mnemonic_sign_memory`.
+
+#### Path 2 — Mnemonic declared in agents' own registration files
+
+Minimal integration. Any agent that uses Mnemonic to sign its memory adds in its registration file:
+
+- `services[]`: `{ type: "mnemonic", uri: "https://mcp.mnemonik.xyz/agent/<pubkey>" }`
+- `supportedTrust`: include `"signed-memory-attestation"` (proposed value; document upstream to ERC-8004 working group).
+- `setMetadata(agentId, "mnemonic.ed25519_pubkey", <bytes>)` on the Identity Registry.
+
+On-chain consumer resolves `agentId → registration file → Mnemonic pubkey` in two reads, then verifies any subsequent Mnemonic attestation independently.
+
+Ship: a CLI command `mnemonic erc8004 register-file --pubkey ...` emitting the JSON, plus a small Solidity helper or doc explaining `setMetadata` from the agent owner's wallet.
+
+#### Path 3 — Mnemonic-attested entries in the Reputation Registry
+
+`giveFeedback` accepts `feedbackURI` + `feedbackHash` for off-chain richness. The spec example payload already carries `a2a` and `mcp` namespaces. Add a third:
+
+```jsonc
+{
+  "agentRegistry": "eip155:1:0x...",
+  "agentId": "<tokenId>",
+  "clientAddress": "0x...",
+  "createdAt": "2026-...",
+  "value": 9800, "valueDecimals": 2,
+  "mnemonic": {
+    "schema": "MEMORY_V1",
+    "attestation_id": "...",
+    "cose_envelope_uri": "ar://...",
+    "blake3": "..."
+  }
+}
+```
+
+`feedbackHash` = blake3 of canonical JSON. Trust upgrade: today any wallet can spam `giveFeedback`; Mnemonic-signed feedback proves the rater is the same long-lived signing identity that produced N other attestations. Ship: SDK + CLI helper that produces the URI bytes, hashes, and emits the on-chain call.
+
+#### Path 4 — Three-way identity reconciliation via `did:mnemonic:`
+
+Today three identifiers coexist:
+
+| Layer | Identity |
+|---|---|
+| A2A | AgentCard JWS pubkey |
+| Mnemonic | Ed25519 pubkey, base58 |
+| ERC-8004 | ERC-721 `tokenId` (+ `agentWallet`) |
+
+The reconciliation chain already has its first link in `work/a2a-bridge/tasks/4.md` (the AgentCard `x-mnemonic` extension). ERC-8004 closes it: `tokenId → registration file → AgentCard URL → x-mnemonic.ed25519_pubkey_base58`, with Mnemonic envelopes carrying that pubkey directly.
+
+Ship: a `did:mnemonic:` resolver as the unified handle. Format: `did:mnemonic:<namespace>:<chainId>:<contract>:<tokenId>` (eip155 namespace) or `did:mnemonic:solana:<base58_pubkey>` (Solana namespace, legacy). One agent, multiple ecosystems, one cryptographic root.
+
+### Solana decoupling — what counts as "broken"
+
+For ERC-8004 V1 we do NOT need full Phase-3 chain-pluggability across every code path. We need a strict subset:
+
+- **Anchor layer must be pluggable.** `core/src/storage/sqlite.rs` schema today encodes Solana-specific anchor fields. New abstraction: `Anchor::{Solana(memo_sig), Ethereum(tx_hash, contract_addr), Arweave(tx_id), None}` — discriminated, additive, idempotent migration.
+- **Anchor writer is a trait, not a function.** `trait AnchorWriter { fn anchor(&self, blake3: &[u8; 32]) -> Result<AnchorRecord> }`. Solana SPL Memo path becomes one impl; Ethereum-via-ERC-8004-Validation-Registry call becomes another impl. Selection via config (`STORAGE_MODE` extends to carry anchor preference).
+- **What we explicitly do NOT need for ERC-8004 V1:** off-chain envelope alg-pluggability (Option B of `mnemonic-cli` Phase 2). Ed25519 stays as the off-chain signer; only the *anchor* gains a second backend. This narrows the scope versus full Phase 3 — call it "Phase 3α".
+
+For the validator-as-a-service in Path 1, the ERC-8004 `validationResponse` Ethereum tx **is** the anchor. No separate Solana memo needed. This is the architectural insight that makes the decoupling cheap: ERC-8004 doesn't *add* a new anchor — it reveals that the existing on-chain `responseHash` already commits the data, so for ERC-8004-routed attestations we get anchoring for free with the protocol call.
+
+### Tasks (estimated)
+
+- **erc8004-0 — Anchor pluggability (Phase 3α)** [PREREQUISITE]
+  - Refactor `core/src/storage/sqlite.rs` to carry `Anchor` enum instead of solana-only columns.
+  - Define `AnchorWriter` trait in `core/src/anchor/`.
+  - Wrap existing Solana SPL Memo path as `SolanaAnchor`.
+  - Add `EthereumAnchor` stub (no Ethereum client yet; just the type).
+  - Idempotent SQLite migration; legacy rows = `Anchor::Solana(...)`.
+  - **~5 dev-days.**
+
+- **erc8004-1 — Registration file generator + identity binding**
+  - CLI command `mnemonic erc8004 register-file --pubkey ... --a2a-card-url ...` emits JSON.
+  - SDK helper `buildErc8004RegistrationFile(...)`.
+  - Doc + smoke against an ERC-8004 testnet registry.
+  - **~2 dev-days.**
+
+- **erc8004-2 — Validator service**
+  - Built on `bridge-a2a/`. Watches Validation Registry events, consumes A2A task, produces attestation, posts `validationResponse`.
+  - Hosts attestation on Arweave (re-uses `core/src/arweave/`).
+  - Ethereum client integration (`alloy-rs` is the leading candidate; vet during this task).
+  - **~5 dev-days.**
+
+- **erc8004-3 — Reputation feedback helper**
+  - SDK + CLI: `submitMnemonicFeedback(agentId, value, attestationId)`.
+  - Off-chain JSON document spec for the `mnemonic` namespace inside feedback payload (open PR to ERC-8004 working group proposing canonical schema).
+  - **~2 dev-days.**
+
+- **erc8004-4 — `did:mnemonic:` resolver**
+  - DID method spec (lightweight; mirror established DID patterns).
+  - Resolver in `mnemonic-core` (pure function, given a `did:mnemonic:` string returns a verified Ed25519 pubkey + linked identifiers).
+  - Tests covering eip155 + solana namespaces.
+  - **~3 dev-days.**
+
+- **erc8004-5 — Ethereum anchor end-to-end**
+  - Implement `EthereumAnchor` against ERC-8004 Validation Registry and/or generic Ethereum-tx anchoring contract.
+  - Integration with Path 1's validator service (anchor falls out of `validationResponse` automatically).
+  - **~3 dev-days.**
+
+**Total: ~20 dev-days**, ordered as: erc8004-0 → (erc8004-1 || erc8004-3) → erc8004-2 → erc8004-5 → erc8004-4. Roughly half the size of A2A bridge V1, riding entirely on its substrate.
+
+### What it brings Mnemonic
+
+- **Position on the highest-leverage substrate.** ERC-8004 is *built on* A2A and went mainnet five months ago. Validators that show up first own the namespace. The two declared validator categories already filling are TEE (Phala, Marlin) and crypto-economic (staking) — Mnemonic occupies a third (signed-memory) that nobody else holds.
+- **Stacks atop the A2A bridge for free.** Path 1 is essentially "the A2A bridge with an Ethereum tx at the end". Most engineering is already in `work/a2a-bridge/`.
+- **On-chain reputation surface** that no off-chain memory competitor (letta / zep / mem0 / cognee) can replicate without first building signed attestations — a moat compounding on a moat.
+- **New revenue surface** — validator-as-a-service is a per-call fee market; infrastructure already exists in `mcp/src/payment.rs`.
+- **Forces the missing identity story.** `did:mnemonic:` driven by ERC-8004 binding turns identity from "Ed25519 base58" into something with a concrete on-chain anchor.
+- **Closes the SVM-lock concern** as a side effect — the ERC-8004 trigger is the cleanest argument for landing Phase 3α now rather than later.
+
+### Costs / risks
+
+- **Validation Registry API is unstable** ("under active update and discussion with the TEE community"). Mitigation: ship behind `erc8004-experimental` feature flag, freeze schemas only at ERC-8004's next stable rev.
+- **Hosting / availability of off-chain attestation files.** Arweave covers it; if a consumer can't fetch the URI they can't verify. Same liveness assumption as everywhere off-chain. Document explicitly in `references/threat-model.md`.
+- **Ethereum gas costs for `validationResponse`** — every validation costs gas. Pricing engine in `mcp/src/pricing.rs` extends to include gas estimate; pass-through to the requesting agent via x402.
+- **EIP-712 / ERC-1271 `agentWallet` mapping** is Ethereum-native; mapping `agentWallet` ↔ Ed25519 pubkey is new ground. Registration file is the natural binding document — declares both, signed by both keys; document the security model.
+- **Adoption tied to ERC-8004 adoption.** Hedge same as A2A — the anchor pluggability we land is reusable for any future on-chain-anchor protocol (Polygon, Base, Arbitrum-native registries, Solana on-chain identity once it exists).
 
 ---
 

--- a/work/a2a-bridge/backlog.md
+++ b/work/a2a-bridge/backlog.md
@@ -1,0 +1,89 @@
+# Backlog — a2a-bridge and adjacent protocol integrations
+
+Items deliberately out of A2A-V1 scope. Architecture must remain open for them — no V1 decision should foreclose any.
+
+---
+
+## A2A — V2 / future scope
+
+- **Streaming chunk attestation (`A2A_STREAM_CHUNK_V1`)** — per-SSE-chunk attestations for `SendStreamingMessage` / `SubscribeToTask`. V1 only fixes the final task state. Cost: high write-amplification; needs batched / Merkle-root strategy.
+- **Push-notification config attestation** — A2A's `CreateTaskPushNotificationConfig` registers webhooks; attesting these closes a side-channel where a malicious agent could exfiltrate task results.
+- **Cross-A2A-server lineage** — V1's `prev_id` lineage is per-Mnemonic-store. Cross-server lineage needs a portable handle (e.g. `did:mnemonic:<pubkey>/<attestation_id>`). Belongs together with the Phase 3 chain-pluggable anchor (see `work/mnemonic-cli/backlog.md`).
+- **AgentCard discovery indexing** — store + recall AgentCards themselves (with their JWS signatures) so a Mnemonic store becomes a queryable agent registry.
+
+---
+
+## MCP-to-MCP delegation
+
+When an MCP server (A) delegates a tool call to another MCP server (B) on behalf of a user, today there is no signed record of "A asked B to run tool T with args X, B returned Y". This is the same shape as A2A's task delegation but on the MCP transport.
+
+**What a binding would do:**
+
+- Define `MCP_DELEGATION_V1` schema: `{caller_pubkey, callee_pubkey, tool_name, request_hash, response_hash, started_at, completed_at, status}`.
+- Reuse the `mnemonic-a2a` adapter pattern: `attest_delegation(...)`, `recall_delegations(caller, callee?, tool?)`.
+- Sidecar deployment is straightforward — MCP transport is JSON-RPC over HTTP/stdio, same shape as A2A.
+
+**Value:**
+
+- Closes the audit gap for "agent toolchains where an MCP server forwards calls to another MCP server" — currently the user only sees the outermost server's logs.
+- Mnemonic itself becomes a first-class delegation target (you can prove "agent X called mnemonic_sign_memory Y times in this session").
+- Differentiates Mnemonic against generic MCP-server registries (smithery, etc.) — they list servers, we attest interactions between them.
+
+**Cost:** ~70% reuse of A2A adapter; ~30% new schema + sidecar variant. Single mid-sized feature folder.
+
+---
+
+## ACP (Agent Communication Protocol — IBM/BeeAI)
+
+ACP is IBM/Linux Foundation's agent protocol — REST-based (not JSON-RPC), messages-as-first-class-objects, async-by-default, framework-agnostic. Different surface, same problem.
+
+**What a binding would do:**
+
+- `ACP_RUN_V1`, `ACP_MESSAGE_V1`, `ACP_AWAIT_V1` schemas — distinct from A2A because ACP's `Run` lifecycle (`created → in-progress → awaiting → completed/failed/cancelled`) and message-array shape do not 1:1 map to A2A Task/Message.
+- Adapter: `mnemonic-acp` crate, same one-way dependency rule.
+- Sidecar variant for ACP servers running on `acp-sdk`.
+
+**Value:**
+
+- Captures the IBM / Watsonx / open-source-research-pipeline ecosystem that ACP targets, distinct from A2A's Google-led one.
+- Two protocol bindings (A2A + ACP) makes "vendor-neutral attestation layer" a real claim, not an aspirational one.
+- ACP's `Run.await` semantics (long-running, human-in-the-loop) make signed audit-trail genuinely valuable — these are the runs that matter most for compliance.
+
+**Cost:** Same shape as A2A bridge; estimate ~80% of A2A effort because the adapter pattern is now established.
+
+---
+
+## AGNTCY (Agent Connect Protocol)
+
+AGNTCY is Cisco / Outshift's open-source initiative — broader than a single wire protocol; aims to standardize agent identity, discovery, and message-passing, with their own `AgentCard`-like spec (`agp`). Less mature than A2A or ACP but well-funded.
+
+**What a binding would do:**
+
+- Watch and wait until protocol surface stabilizes. Adapter would mirror A2A: identity binding via AGNTCY's own descriptor, message/task schemas as `AGNTCY_*_V1`.
+- AGNTCY identity layer is closer to DIDs than A2A's JWS model; this is the integration that would force `did:mnemonic:` design (a Phase 3 question, not Phase 1).
+
+**Cost:** Premature today — schema would churn. Re-evaluate when AGNTCY tags v1.
+
+---
+
+## LangGraph / AutoGen / CrewAI direct integrations
+
+Not protocols — frameworks. Each has its own message and run abstractions.
+
+**Approach:** Do NOT define new core schemas per framework. Instead provide framework-specific *adapters in `@mnemonik-xyz/sdk`* that translate framework events → A2A/ACP/MCP_DELEGATION envelope and route through the appropriate bridge. Frameworks are users, not protocols.
+
+**Why:** preserves the one-way dependency graph in `core/`; keeps schema count bounded; lets us pick whichever protocol binding (A2A vs ACP vs MCP-delegation) most naturally fits each framework's call shape.
+
+---
+
+## ERC-8004 / on-chain agent identity
+
+Ethereum L2-native agent identity registries (ERC-8004 draft, plus AGNTCY-on-chain experiments). When + if they stabilize, Mnemonic attestations could register the producer pubkey there directly, giving a single verifiable identity from a Web3 audience without changing the off-chain envelope.
+
+**Cost:** Trivial once the chain-pluggable anchor (Phase 3 of `mnemonic-cli`) lands. Pre-Phase-3: foreclosed.
+
+---
+
+## Cross-cutting: shared `mnemonic-protocols/` crate
+
+If we build A2A + MCP-delegation + ACP bindings, the `attest_*` / `recall_by_context` skeleton repeats. Refactor target: extract the common adapter pattern into `mnemonic-protocols/` with per-protocol modules. Premature for V1 (one binding); revisit at V2.

--- a/work/a2a-bridge/decisions.md
+++ b/work/a2a-bridge/decisions.md
@@ -45,6 +45,37 @@ Why: A2A messages are mostly short and structured; embedding them adds noise and
 
 ---
 
+## 2026-05-01 — Decision: Positioning lock-in — "verifiable memory for trustless agents"
+
+The body of work in this folder + ERC-8004 follow-on commits the project to a single positioning statement:
+
+> Mnemonic is verifiable memory for trustless agents.
+
+Explicit consequences:
+
+- Adjacent positions are foreclosed: general AI-agent memory (head-to-head with letta / zep / mem0 / cognee on retrieval quality), agent identity standard (head-to-head with DIDs / ERC-8004), execution attestation (head-to-head with TEEs), pure on-chain protocol. We compose with these standards; we do not compete on their primary axis.
+- Story is true *only if* all four pieces ship: A2A bridge V1, ERC-8004 V1 (four paths), Phase 3α anchor pluggability, `did:mnemonic:` resolver. Any one missing collapses the pitch back to "we have a nice memory format" — competitive but not differentiated.
+- Any future pull toward an adjacent position must revisit `research/positioning-trustless-agents.md` before re-pivoting.
+
+Downstream: this decision drives the sequencing in `backlog.md`, the table reorderings in `.claude/skills/project-knowledge/references/protocol-integrations.md`, and the public roadmap rewrite in `docs/WHITEPAPER.md` §14 (new Phase 5).
+
+---
+
+## 2026-05-01 — Decision: ERC-8004 trigger pulls Phase 3α (anchor pluggability) forward
+
+ERC-8004 V1 has a hard prerequisite that the SVM lock be broken **during or before** the integration work. Path-b ("ship ERC-8004 while keeping Solana SPL Memo as the only anchor") is rejected: it would deepen the SVM dependency the protocol is trying to escape (`work/mnemonic-cli/backlog.md` Phase 3) at exactly the moment we extend the anchor surface to a new chain.
+
+Scope clarification — "Phase 3α":
+
+- *In scope for the ERC-8004 trigger:* anchor-layer pluggability only. `core/src/storage/sqlite.rs` schema migrates from solana-specific anchor columns to a discriminated `Anchor::{Solana, Ethereum, Arweave, None}` enum. New `AnchorWriter` trait under `core/src/anchor/`. Solana SPL Memo path becomes one impl; Ethereum-via-ERC-8004-Validation-Registry becomes another. Idempotent SQLite migration; legacy rows = `Anchor::Solana(...)`.
+- *Out of scope:* off-chain envelope alg-pluggability (Option B of `mnemonic-cli` Phase 2). Ed25519 stays as the off-chain signer in this stage. That work remains separately tracked under `mnemonic-cli` Phase 2 / Phase 3 Option A.
+
+Architectural insight that makes this cheap: the ERC-8004 `validationResponse` Ethereum tx **is** the anchor for any attestation routed through Path 1 (validator-as-a-service). We do not add a new anchor backend on top of Solana; we replace the anchor for ERC-8004-routed flows with the registry call itself. ~5 dev-days for `erc8004-0`.
+
+Cross-link: a corresponding note has been added to `work/mnemonic-cli/backlog.md` "TOP PRIORITY 2 — Crypto-flexibility" so future readers there know Phase 3 is no longer purely sequential — a strict subset is pulled forward.
+
+---
+
 ## Audit findings (placeholder)
 
 To be populated by code-reviewer / security-auditor / test-writer agents during their respective audit waves. Format: `### YYYY-MM-DD — <agent> — <severity>: <one-line>` then bullet body.

--- a/work/a2a-bridge/decisions.md
+++ b/work/a2a-bridge/decisions.md
@@ -1,0 +1,50 @@
+# Decisions — a2a-bridge
+
+Append-only log. Each entry: date, who, what, why, what changes downstream.
+
+---
+
+## 2026-05-01 — Feature folder created
+
+Author: claude (research synthesis from `work/docs-actualization/` review).
+
+Origin: gap analysis on this branch (`claude/document-architecture-gaps-vfUxJ`) identified the missing A2A bridge as the highest-leverage of five gaps:
+- Six of eleven `docs/usecases/*.md` are A2A-shaped today but have no implementation glue.
+- Whitepaper §8 explicitly positions Mnemonic underneath A2A; no code matches the prose.
+- Differentiation against unsigned-memory competitors (letta / zep / mem0 / cognee) is strongest along the signed-attestation × multi-agent-protocol-binding axis, which no competitor occupies.
+
+Scope locked-in for V1: Task / Message / Artifact attestation; `contextId`-keyed recall; AgentCard `x-mnemonic` extension; sidecar + library + SDK + MCP exposure; conformance fixtures; threat model.
+
+Out of V1: SSE per-chunk attestation, semantic recall over A2A events, chain-pluggable anchor (inherits from `mnemonic-cli` Phase 3).
+
+---
+
+## 2026-05-01 — Decision: dual canonicalization preserved
+
+Do not merge JCS (RFC 8785, JSON) and deterministic CBOR. The bridge canonicalizes A2A objects via JCS and wraps the resulting bytes verbatim inside a CBOR envelope. Two canonical forms, both stable, neither modified.
+
+Why: JCS is what A2A's own AgentCard JWS uses. Re-canonicalizing through CBOR would mean any A2A-native verifier diverges from us. Preserving JCS bytes verbatim means a verifier with only A2A tooling can still verify the inner payload and a verifier with only Mnemonic tooling can still verify the COSE envelope.
+
+Downstream: `core/src/codec/a2a/` modules expose both `to_jcs_bytes(...)` and `to_canonical_cbor_envelope(...)`. The signing path is JCS → CBOR-envelope → blake3 → COSE_Sign1. The verifying path runs the same chain in reverse plus an independent JCS re-canonicalization check.
+
+---
+
+## 2026-05-01 — Decision: schema lock waits for A2A v1.0.0 GA
+
+A2A is at v1.0.0-rc. Shipping `A2A_*_V1` schemas before GA risks frozen bytes diverging from the protocol. We ship the modules behind a cargo feature `a2a-experimental` until GA. At GA we flip the feature default and emit golden fixtures. Anyone using the experimental flag accepts schema mutability.
+
+Downstream: `core/Cargo.toml` adds `a2a-experimental` feature. `bridge-a2a` and `mnemonic-a2a` require it pre-GA. Documentation in `references/conformance.md` flags the experimental window.
+
+---
+
+## 2026-05-01 — Decision: V1 does not embed A2A events
+
+`MEMORY_V1` carries TurboQuant-compressed embeddings; `A2A_*_V1` does not. Recall on the bridge is `context_id`-keyed and time-ordered, no cosine. Users who want semantic recall over A2A content attest a parallel `MEMORY_V1` with the same `context_id`.
+
+Why: A2A messages are mostly short and structured; embedding them adds noise and ~5x storage with low retrieval value. Composability via shared `context_id` keeps the door open without baking the cost into V1.
+
+---
+
+## Audit findings (placeholder)
+
+To be populated by code-reviewer / security-auditor / test-writer agents during their respective audit waves. Format: `### YYYY-MM-DD — <agent> — <severity>: <one-line>` then bullet body.

--- a/work/a2a-bridge/research/positioning-trustless-agents.md
+++ b/work/a2a-bridge/research/positioning-trustless-agents.md
@@ -1,0 +1,135 @@
+---
+created: 2026-05-01
+status: locked-in (2026-05-01)
+type: research / positioning
+audience: contributors, reviewers, future-self
+---
+
+# Positioning: Verifiable Memory for Trustless Agents
+
+This document is the strategic rationale behind the `work/a2a-bridge/` body of work and its ERC-8004 follow-on (see `backlog.md`). It locks in the positioning the project is committing to:
+
+> **Mnemonic is verifiable memory for trustless agents.**
+
+Not "memory for AI agents" (broader, head-to-head with letta / zep / mem0 / cognee on retrieval quality). Not "agent identity" (head-to-head with ERC-8004 / DIDs). Not "execution attestation" (head-to-head with TEE attestations). The specific, defensible niche is **cryptographic provenance over content the agent itself claims to remember**, composed underneath the trustless-agent stack.
+
+The rest of the document substantiates this: what gaps in the trustless-agent stack we close, what we explicitly do not close, why the composition story works, and the three regimes under which we should expect the bet to pay off.
+
+---
+
+## 1. The trustless-agent stack as it exists in May 2026
+
+After A2A v1.0.0-rc and ERC-8004 mainnet (2026-01-29), the stack of standards that defines a "trustless agent" looks like this:
+
+| Layer | Standard / primitive | What it proves |
+|---|---|---|
+| Wire protocol | A2A (JSON-RPC + SSE), MCP | Agents can talk in standard shapes |
+| Identity (off-chain) | A2A AgentCard JWS | This is who *claims* to be the agent |
+| Identity (on-chain) | ERC-8004 Identity Registry (ERC-721) | There is a wallet-owned on-chain handle |
+| Reputation | ERC-8004 Reputation Registry | Other parties have rated this agent |
+| Validation hook | ERC-8004 Validation Registry | An external validator attested *something* |
+| Execution attestation | TEE validators (Phala, Marlin) | The code ran in attested hardware |
+| Economic guarantee | Crypto-economic validators | Stake is at risk to back a claim |
+
+Every layer above is a real, deployed standard with running code in May 2026. None of them does what Mnemonic does. The next section enumerates the precise gaps.
+
+---
+
+## 2. The five gaps Mnemonic closes
+
+### Gap 1 — Persistent, portable memory
+
+A2A explicitly disclaims memory: agents collaborate "without needing access to each other's internal state, memory, or tools." ERC-8004 is identity + reputation + validation hooks — no memory layer. Without Mnemonic the only memory in the stack is whatever vendor-specific store the agent runs on (OpenAI Assistants memory, Anthropic projects, vendor-locked vector DB). Switch vendor, lose memory. This is the original Mnemonic problem statement and **the trustless-agent stack does not provide a substitute**.
+
+### Gap 2 — Verifiable provenance over *content*, not just execution
+
+TEE attestations prove "the hardware was real when this ran." Crypto-economic validators prove "stake is at risk." Neither validates *what the agent claims to remember*. A TEE can faithfully execute a model that fabricates a memory — the attestation says nothing about whether the memory is the same one the agent recorded last week.
+
+Mnemonic's envelope says: *"this exact memory bytes existed at time T, signed by this identity, links to these prior memories. If anyone — including the agent — modifies them, the chain breaks visibly."* That is a structurally different proof from "execution was attested."
+
+### Gap 3 — Cross-vendor, cross-session temporal coherence (lineage)
+
+A2A `contextId` is local to a single A2A server. ERC-8004 entries are independent on-chain calls. Neither has any notion of "memory M2 succeeds M1 in this agent's timeline." Mnemonic's `prev_id` lineage DAG provides exactly that — and `recall_by_context` makes it queryable. This is what makes claims like *"agent X has consistently held this position across 2,400 tasks over six months"* provable rather than narrative.
+
+### Gap 4 — Semantic recall over signed history
+
+ERC-8004's read paths (`readAllFeedback`, `getAgentValidations`, etc.) are exact-handle lookups. A2A's are session-scoped. Mnemonic adds **cosine search over the agent's signed memory** — *"what has this agent recorded about topic X across vendors and sessions?"* That is a different query class. No layer in the trustless-agent stack offers it.
+
+### Gap 5 — Long-lived signing identity decoupled from wallet identity
+
+ERC-8004 agent identity = ERC-721 NFT owned by a wallet. Wallets get rotated, NFTs get transferred, custody changes. Mnemonic's Ed25519 signing identity is stable across all of that, and the registration-file binding (Path 2 of ERC-8004 V1, see `backlog.md`) reconciles them: an agent can change wallets, get its NFT transferred, and still have a continuous, verifiable signing history. **The reputation flywheel doesn't reset every time the wallet does.**
+
+---
+
+## 3. The composition advantage — Mnemonic is the off-chain layer the others assume but don't define
+
+ERC-8004 is intentionally a thin on-chain layer pointing at off-chain content-addressed documents. It does not specify what those documents look like. The off-chain doc standard is currently a wide-open ecosystem question — TEE parties use their attestation formats, JWS parties use JWS, custom validators ship custom JSON. Mnemonic's COSE_Sign1 over deterministic CBOR with a published conformance suite (see Task 8 in `tasks/`) is one of the cleanest, most independently-verifiable shapes available, and the only one that's natively designed for **memory** rather than retrofitted from another problem domain.
+
+Same story with A2A: it has `contextId` but no spec for what a "session memory" *is*. Mnemonic provides the canonical envelope.
+
+If the integration work in `tasks/` and `backlog.md` ships well, Mnemonic is positioned to be **the canonical signed-memory off-chain format the trustless-agent ecosystem converges on**, similar to how DID Documents converged once W3C ratified the DID Core spec.
+
+---
+
+## 4. What we are NOT closing — being honest
+
+This section exists to keep us from overclaiming, the same way the second message in this branch's research history (`docs-actualization` review) flagged earlier. Self-correction is cheap; reputation damage from over-pitching is not.
+
+- **Trustless execution.** TEE attestations close that. Mnemonic envelopes say "I claim I produced this output"; they do not say "this code ran in a verified enclave." The two compose, but Mnemonic alone does not attest execution.
+- **Economic skin in the game.** Crypto-economic validators bond stake; we do not.
+- **Consensus / adjudication.** If two agents claim contradictory things, our DAG records both. We surface forks; we do not resolve them.
+- **Better recall than mature memory systems.** Letta / zep / mem0 / cognee have years of retrieval-quality work. We are not strictly better at *recall quality*. We are better at *verifiable* recall — a different axis. Anyone whose primary need is "best possible memory" without provenance gets less from us than from them.
+- **Magic for unsigned events.** If an A2A message goes through without bridge attestation, it's gone — same as today. Mnemonic does not retroactively prove anything; it has to be in the loop at write time.
+
+---
+
+## 5. The single-sentence pitch
+
+Once the work in `work/a2a-bridge/tasks/` (A2A bridge V1) **and** the ERC-8004 follow-on in `backlog.md` (V1 + Phase 3α anchor pluggability) **and** the `did:mnemonic:` resolver (erc8004-4) all ship:
+
+> Mnemonic is the only primitive in the trustless-agent stack that gives **cryptographic provenance over content the agent itself claims to remember, cross-vendor temporal coherence via lineage, and semantic recall over that signed history** — composable underneath A2A, anchored through ERC-8004's existing on-chain commitments without binding the agent's signing identity to a wallet.
+
+That sentence is true *only if* all four pieces ship. Any one missing and the story collapses to "we have a nice memory format" — competitive with letta / zep / mem0 but not differentiated.
+
+---
+
+## 6. Three-regime decision analysis
+
+We commit to this work knowing the outcome depends on adoption beyond our control. Three plausible regimes:
+
+**Regime 1 — Trustless-agent stack takes off** (A2A + ERC-8004 reach meaningful adoption; multiple ecosystems converge).
+This work is the *cheapest* way to occupy the canonical-signed-memory position. Roughly 30 dev-days total (A2A V1 ~12d + ERC-8004 V1 ~20d, of which ~5d is anchor pluggability). Disproportionate leverage. Network effects compound — every signed attestation makes the next more valuable.
+
+**Regime 2 — The stack stalls but signed memory still matters** (some teams want verifiable memory regardless of multi-agent protocols).
+The A2A bridge surface is wasted; the ERC-8004 anchor pluggability is half-wasted (it's still useful as plain Ethereum anchoring); the core schema and conformance work was useful. Roughly 40% salvage value.
+
+**Regime 3 — Neither stack nor signed memory takes off**.
+Most of this work is wasted. Hedge: keep schemas extensible, do not couple our roadmap to A2A's GA timeline, ship behind feature flags so we can deprecate without breaking core.
+
+We commit because regime 1 is plausible (mainnet ERC-8004 + A2A v1.0.0-rc are not vapor, and the first-mover window for validator-class participation is closing on a months-not-years timescale) and regime 2's salvage value is meaningful enough to make the bet asymmetric.
+
+---
+
+## 7. What this positioning *forecloses*
+
+Locking in "verifiable memory for trustless agents" means we explicitly decline several adjacent positions, listed here so the trade-off is explicit:
+
+- **General-purpose AI agent memory** (head-to-head with letta / zep / mem0 / cognee on quality alone). We will lose that fight; we are not optimizing for it.
+- **Agent identity standard** (head-to-head with W3C DIDs / ERC-8004 directly). We compose with these standards, we don't replace them. `did:mnemonic:` is a *binding*, not a competing identity scheme.
+- **General storage / KV** (head-to-head with Arweave SDK, IPFS, etc.). Storage is an anchor option; it is not the product.
+- **Pure on-chain protocol**. The off-chain envelope is the product; on-chain is one of several anchor backends.
+
+If at any point we feel the pull toward one of these adjacent positions, this document is the artifact to revisit before re-pivoting.
+
+---
+
+## 8. References
+
+- `work/a2a-bridge/user-spec.md`, `tech-spec.md` — feature plan.
+- `work/a2a-bridge/backlog.md` — ERC-8004 detailed plan + other protocol integrations.
+- `work/a2a-bridge/decisions.md` — decision log including the Solana-decoupling and positioning lock-in entries.
+- `.claude/skills/project-knowledge/references/protocol-integrations.md` — protocol-integration index across A2A, ERC-8004, MCP-delegation, ACP, AGNTCY.
+- `.claude/skills/project-knowledge/references/project.md` — high-level project doc, updated to reflect this positioning.
+- `docs/WHITEPAPER.md` §14 Roadmap — public roadmap, updated with Phase 5 reflecting this work.
+- A2A: https://a2a-protocol.org/latest/specification/
+- ERC-8004: https://eips.ethereum.org/EIPS/eip-8004

--- a/work/a2a-bridge/tasks/1.md
+++ b/work/a2a-bridge/tasks/1.md
@@ -1,0 +1,40 @@
+---
+status: pending
+depends_on: []
+wave: 1
+skills: [code-writing]
+verify: [unit, golden]
+reviewers: [code-reviewer]
+teammate_name:
+---
+
+# Task 1: A2A binding schemas in `mnemonic-core`
+
+## Description
+
+Define and register `A2A_TASK_V1`, `A2A_MESSAGE_V1`, `A2A_ARTIFACT_V1` in `core/src/codec/schema.rs`. Add a new submodule `core/src/codec/a2a/` with type-safe Rust mirrors of A2A wire types and JCS canonicalization. Gate everything behind a new cargo feature `a2a-experimental` per Decision 5.
+
+## What to do
+
+1. Add `a2a-experimental` feature to `core/Cargo.toml`. Pull in `serde_jcs` (vetted candidate; if rejected during this task, drop in a ~150 LOC in-house JCS implementation — note in `decisions.md`).
+
+2. In `core/src/codec/schema.rs`, register three new schema constants alongside `MEMORY_V1`. Each constant follows the existing pattern: `id_bytes` (16 bytes, deterministic), `version: 1`, `name`. Do NOT mutate `MEMORY_V1`.
+
+3. Create `core/src/codec/a2a/{mod.rs, task.rs, message.rs, artifact.rs}` (each ≤150 lines per CLAUDE.md). Define structs that match A2A v1.0.0-rc field names exactly: `Task{id, contextId, status, history, artifacts}`, `Message{role, parts, messageId, taskId, contextId}`, `Artifact{artifactId, name, parts}`, `Part{kind, ...}`.
+
+4. Each module exposes `to_jcs_bytes(&Self) -> Result<Vec<u8>>` (RFC 8785 canonical JSON) and `to_canonical_envelope(&Self, agent_pubkey, prev_id?) -> Result<Vec<u8>>` (CBOR-wrapped per Decision 1).
+
+5. Re-export under `pub mod a2a` in `core/src/codec/mod.rs`. Gate with `#[cfg(feature = "a2a-experimental")]`.
+
+## TDD anchors
+
+- `core/src/codec/a2a/task.rs::tests::roundtrip_jcs_stable` — canonicalize twice → identical bytes.
+- `...::roundtrip_envelope_signs_and_verifies` — wrap → sign → verify with Ed25519 keypair → assert ok.
+- `...::tests::field_order_invariance` — same logical Task with reordered JSON keys → identical canonical bytes.
+
+## Done when
+
+- `cargo build --features a2a-experimental -p mnemonic-core` succeeds.
+- `cargo test --features a2a-experimental -p mnemonic-core codec::a2a` all green.
+- `cargo build --workspace` (without the feature) still green — proves gating works.
+- Native build with default features unchanged.

--- a/work/a2a-bridge/tasks/2.md
+++ b/work/a2a-bridge/tasks/2.md
@@ -1,0 +1,38 @@
+---
+status: pending
+depends_on: [1]
+wave: 1
+skills: [code-writing]
+verify: [unit, golden]
+reviewers: [code-reviewer]
+teammate_name:
+---
+
+# Task 2: SQLite `context_id` column + index + golden fixture emitter
+
+## Description
+
+Storage-side support for `recall_by_context` (Decision 2) and conformance-fixture infrastructure (Decision 7).
+
+## What to do
+
+1. **Schema migration.** In `core/src/storage/sqlite.rs`, add `context_id TEXT NULL` column to the `attestations` table. Idempotent migration — guard with a `PRAGMA table_info` check or a versioned migrations vector that already exists; do NOT rewrite migration framework. Index: `CREATE INDEX IF NOT EXISTS idx_attestations_context_created ON attestations(context_id, created_at)`.
+
+2. **Backfill semantics.** Existing rows have NULL `context_id`. `recall_by_context(ctx)` returns rows WHERE `context_id = ?` — NULL rows are invisible to that query, which is the correct semantic (legacy `MEMORY_V1` rows have no A2A context).
+
+3. **API surface.** New method on `AttestationStore`: `recall_by_context(&self, context_id: &str, limit: Option<usize>) -> Result<Vec<Attestation>>`. Honours the existing Mutex pattern; never hold the lock across `.await`.
+
+4. **Golden fixture emitter.** Extend `core/tests/golden_fixtures.rs` (or create `core/tests/a2a_golden_fixtures.rs` if cleaner) with a `#[ignore]` test gated by both `golden-fixtures` AND `a2a-experimental` features. Emits 20+ vectors covering: text-only message, file-part message, data-part message, single-turn task, multi-turn task, completed task, failed task, single artifact, multi-artifact task. Each entry: `{name, a2a_json, jcs_canonical_hex, cbor_envelope_hex, cose_signed_hex, keypair_secret_hex}`.
+
+## TDD anchors
+
+- Migration runs twice without error (idempotency).
+- `recall_by_context` returns rows in `created_at DESC` order, respects `limit`.
+- Existing `MEMORY_V1` tests still pass (backward compat).
+- Fixture emitter produces deterministic output across two runs (seed the keypair).
+
+## Done when
+
+- `cargo test -p mnemonic-core --features a2a-experimental storage::` all green.
+- `cargo test --features "golden-fixtures a2a-experimental" -p mnemonic-core --test a2a_golden_fixtures emit_fixtures -- --ignored --nocapture` produces JSON.
+- Existing default-feature test suite unchanged.

--- a/work/a2a-bridge/tasks/3.md
+++ b/work/a2a-bridge/tasks/3.md
@@ -1,0 +1,46 @@
+---
+status: pending
+depends_on: [1, 2]
+wave: 2
+skills: [code-writing]
+verify: [unit, integration]
+reviewers: [code-reviewer]
+teammate_name:
+---
+
+# Task 3: `mnemonic-a2a` adapter crate
+
+## Description
+
+New workspace member providing pure-Rust adapter functions over `mnemonic-core` primitives. No network, no async beyond what `core` already requires, no own state. Sole consumer of the schemas from Task 1.
+
+## What to do
+
+1. Add `mnemonic-a2a/` to the workspace. `Cargo.toml` depends on `mnemonic-core` with `features = ["a2a-experimental"]`. Re-export the required types from core to keep downstream consumers from depending on core directly.
+
+2. `src/lib.rs` — public surface only:
+   - `attest_message(&store, msg: &Message, agent_keypair: &Keypair, prev_id: Option<&str>) -> Result<AttestationId>`
+   - `attest_task(&store, task: &Task, agent_keypair: &Keypair, prev_id: Option<&str>) -> Result<AttestationId>`
+   - `attest_artifact(&store, art: &Artifact, ctx_id: &str, agent_keypair: &Keypair, prev_id: Option<&str>) -> Result<AttestationId>`
+   - `recall_by_context(&store, ctx_id: &str, limit: Option<usize>) -> Result<Vec<Attestation>>`
+   - `verify_a2a_attestation(envelope_bytes: &[u8], expected_pubkey: Option<&str>) -> Result<VerifiedA2AContent>`
+
+3. `src/attest.rs` — implementation. Each `attest_*` does: canonicalize via the schema's `to_jcs_bytes` → wrap in CBOR envelope → blake3 → COSE_Sign1 → write to store with `context_id` populated → return id. Reuses `core::codec::sign::sign_artifact`.
+
+4. `src/recall.rs` — implementation. Wraps `AttestationStore::recall_by_context`. No new logic; just a stable public-API location so consumers do not depend on `core::storage` directly.
+
+5. Documentation: README.md explaining the one-way dependency rule (this crate never depends on `mcp/` or `bridge-a2a/`) and the relationship to A2A's wire types.
+
+## TDD anchors
+
+- `tests/attest_task.rs` — round-trip: build Task, attest, recall by context, verify envelope, assert content matches.
+- `tests/attest_artifact.rs` — same shape.
+- `tests/lineage.rs` — three-message conversation: m1.prev_id=None, m2.prev_id=m1.id, m3.prev_id=m2.id; assert chain validates.
+- `tests/cross_context_isolation.rs` — attest in ctx_A and ctx_B; `recall_by_context(ctx_A)` returns only A's rows.
+
+## Done when
+
+- `cargo test -p mnemonic-a2a` all green.
+- `cargo build --workspace` green.
+- No new transitive dependency from `core/` on this crate (one-way graph preserved).
+- Public surface documented in `mnemonic-a2a/src/lib.rs` doc comments.

--- a/work/a2a-bridge/tasks/4.md
+++ b/work/a2a-bridge/tasks/4.md
@@ -1,0 +1,48 @@
+---
+status: pending
+depends_on: [1]
+wave: 2
+skills: [code-writing]
+verify: [unit, integration]
+reviewers: [code-reviewer, security-auditor]
+teammate_name:
+---
+
+# Task 4: AgentCard `x-mnemonic` extension binding
+
+## Description
+
+Define and implement the AgentCard extension descriptor (Decision 3) that publishes the agent's Ed25519 pubkey alongside its A2A capability declaration, so any A2A-native verifier can locate the Mnemonic-attestation key without a separate lookup.
+
+## What to do
+
+1. **Spec the extension.** Add `core/src/codec/a2a/extension.rs` with:
+   - Extension URI: `https://mnemonik.xyz/extensions/x-mnemonic/v1`
+   - Payload: `{ ed25519_pubkey_base58: String, attestation_endpoint: Option<String>, conformance_version: String }`
+   - JSON schema in code as a serde struct + serializer.
+
+2. **Helpers.**
+   - `build_x_mnemonic_extension(pubkey: &str, endpoint: Option<&str>) -> Value` — emits the extension JSON object.
+   - `extract_x_mnemonic(agent_card: &Value) -> Result<Option<XMnemonicExtension>>` — pulls the extension out of an AgentCard JSON, returns None if absent (extension is optional).
+   - `verify_card_covers_extension(agent_card: &Value, jws_signatures: &[Value]) -> Result<()>` — checks that the AgentCard's JWS `signatures[]` covers the extension payload (per the security note in `tech-spec.md` Risks).
+
+3. **Authority rules** (from Decision 3 + Risks):
+   - JWS verifies AgentCard authenticity.
+   - `x-mnemonic` declares the Mnemonic attestation key.
+   - Both must be present and the JWS must cover the extension payload.
+   - Mismatch (JWS-covered card declares pubkey A; attestation envelope claims pubkey B) → verification fails.
+
+4. **Sample AgentCards** in `mnemonic-a2a/tests/fixtures/` — three cards: well-formed with extension, well-formed without extension, well-formed with extension but JWS does not cover extension (must fail).
+
+## TDD anchors
+
+- `tests::extension::extract_present` / `extract_absent`.
+- `tests::extension::roundtrip_serialization` — extension survives serde JSON round-trip byte-for-byte.
+- `tests::extension::reject_jws_not_covering_extension` — security regression.
+- `tests::extension::reject_pubkey_substitution` — card says pubkey A, attestation signed by pubkey B → verify fails.
+
+## Done when
+
+- `cargo test -p mnemonic-core --features a2a-experimental codec::a2a::extension` green.
+- Three fixture cards parse correctly per their expected outcomes.
+- Security-auditor reviewer signs off on the JWS-coverage check.

--- a/work/a2a-bridge/tasks/5.md
+++ b/work/a2a-bridge/tasks/5.md
@@ -1,0 +1,42 @@
+---
+status: pending
+depends_on: [3, 4]
+wave: 3
+skills: [code-writing]
+verify: [unit, integration, smoke]
+reviewers: [code-reviewer]
+teammate_name:
+---
+
+# Task 5: MCP tools `mnemonic_attest_a2a` and `mnemonic_recall_a2a`
+
+## Description
+
+Expose the `mnemonic-a2a` adapter through the MCP server as two new tools, raising the `mcp.mnemonik.xyz` tool count from 5 to 7. Conforms to existing tool dispatch pattern in `mcp/src/mcp.rs`.
+
+## What to do
+
+1. **`mcp/src/tools.rs`** — add two new tool definitions and handler functions:
+   - `mnemonic_attest_a2a(kind: "task" | "message" | "artifact", payload: object, context_id: string, prev_id?: string) -> { attestation_id, blake3, cose_envelope_hex }`
+   - `mnemonic_recall_a2a(context_id: string, limit?: number, kind?: "task" | "message" | "artifact" | "all") -> Attestation[]`
+   - Both reuse `mnemonic_a2a::{attest_task, attest_message, attest_artifact, recall_by_context}`. Discriminate on `kind` for `attest`.
+
+2. **`mcp/src/mcp.rs`** — register both tools in the listing array (lines 156–195) and add dispatch arms in `handle_tool_call` (around line 489).
+
+3. **Schema declaration.** JSON-schema entries for input validation, mirroring the existing 5 tools' style. Errors map to existing error envelope.
+
+4. **Payment.** `mnemonic_attest_a2a` is paid (per CLAUDE.md hard rule "only `mnemonic_sign_memory` is paid" — this rule will need an update for the new paid tool). Update CLAUDE.md and the payment dispatcher in `mcp/src/mcp.rs:403` accordingly. `mnemonic_recall_a2a` is free (read-only). Add a unit test that asserts the payment middleware fires for `attest` and not for `recall`.
+
+5. **Storage mode awareness.** In `local` storage mode: synthetic `local:` tx ids per existing pattern. In `full` mode: optional Arweave anchor for the attestation bytes (gated by request flag, default off — A2A events are noisy and most don't need permanent storage).
+
+## TDD anchors
+
+- `tests/integration_a2a_mcp_tools.rs` — start MCP server in test mode, call `attest_a2a` with kind="task", expect attestation_id; then `recall_a2a` returns it.
+- Payment-middleware test: `attest_a2a` in `payment-required` mode without bearer → 402; `recall_a2a` without bearer → 200.
+
+## Done when
+
+- Tool listing returns 7 tools.
+- `cargo test -p mnemonic-mcp` all green including new integration tests.
+- Manual smoke against running MCP HTTP server documented in task log.
+- CLAUDE.md updated re: the new paid tool, and the payment audit rule still passes.

--- a/work/a2a-bridge/tasks/6.md
+++ b/work/a2a-bridge/tasks/6.md
@@ -1,0 +1,46 @@
+---
+status: pending
+depends_on: [3, 4]
+wave: 3
+skills: [code-writing]
+verify: [unit, integration, smoke]
+reviewers: [code-reviewer, security-auditor]
+teammate_name:
+---
+
+# Task 6: `bridge-a2a/` reference sidecar middleware
+
+## Description
+
+A new workspace member: a minimal axum-based middleware sidecar that sits between an A2A client and an A2A server. It intercepts JSON-RPC calls (`message/send`, `tasks/get`, artifact emissions on streaming), produces Mnemonic attestations via `mnemonic-a2a`, and returns attestation ids in an A2A `Extension` field on the response.
+
+Native-only (no Wasm); reuses `mnemonic-core` for storage / crypto.
+
+## What to do
+
+1. **Crate skeleton.** `bridge-a2a/` workspace member, `Cargo.toml` deps: `mnemonic-a2a`, `mnemonic-core`, `axum`, `tokio`, `serde_json`, `tracing`. CLI: `--upstream <url>` (the real A2A server), `--listen <addr>`, `--keypair <path>`, `--storage <local|full>`, `--context-strategy <pass-through|generate>`.
+
+2. **Middleware logic.**
+   - On `message/send` request: forward upstream as-is; on response, attest the message + the resulting task state via `mnemonic_a2a::attest_message` / `attest_task`; mutate response to include `extensions: { x-mnemonic: { attestation_id, blake3 } }`.
+   - On `tasks/get` request: forward; if status is `completed` or `failed` and we don't already have an attestation for this `(taskId, status)`, attest it.
+   - On artifact emissions in SSE streams (V1 fixes only the final task; per Decision 8 we do not per-chunk attest): once stream completes, attest each artifact with `attest_artifact`.
+
+3. **Idempotency.** Track `(method, taskId, messageId)` keys in a small in-memory LRU to avoid re-attesting on retries. Persistence is `core/src/storage` — already idempotent at the row level (unique on `blake3`).
+
+4. **Lineage.** Within a `contextId`, the previous attestation's id is the next attestation's `prev_id`. Bridge maintains an in-memory map `contextId -> last_attestation_id` (eventual-consistent; if the bridge restarts, lineage continuation is best-effort and falls back to None — documented in `decisions.md`).
+
+5. **Configurable failure modes.** Two strategies: `attest-best-effort` (logs the attestation failure but does not break the upstream call — default) and `attest-strict` (fails the A2A call if attestation fails — for compliance environments).
+
+6. **Reference Dockerfile + docker-compose example** under `bridge-a2a/examples/`. Demonstrates running the sidecar in front of a stub A2A server.
+
+## TDD anchors
+
+- `tests/end_to_end.rs` — stub A2A server, sidecar in front, send a message, assert response includes `x-mnemonic.attestation_id` and that `mnemonic_a2a::recall_by_context` returns it.
+- `tests/idempotency.rs` — replay the same `message/send` twice; one DB row, two responses.
+- `tests/strict_failure_mode.rs` — make storage write fail; in `attest-strict` mode the upstream call returns an error.
+
+## Done when
+
+- `cargo test -p bridge-a2a` green.
+- Example docker-compose runs locally, smoke-tested end-to-end.
+- Security-auditor reviewer signs off on the strict/best-effort failure-mode boundary.

--- a/work/a2a-bridge/tasks/7.md
+++ b/work/a2a-bridge/tasks/7.md
@@ -1,0 +1,46 @@
+---
+status: pending
+depends_on: [5]
+wave: 3
+skills: [code-writing]
+verify: [unit, integration]
+reviewers: [code-reviewer]
+teammate_name:
+---
+
+# Task 7: SDK + CLI helpers for A2A attestation
+
+## Description
+
+Surface the new MCP tools through `@mnemonik-xyz/sdk` and `@mnemonik-xyz/cli`. Same contract as the existing `signMemory` / `verify` / `recall` helpers.
+
+## What to do
+
+1. **SDK** — `packages/sdk/src/a2a.ts`:
+   - `MnemonicClient.attestA2ATask(task: A2ATask, contextId: string, opts?: { prevId?: string }): Promise<AttestationId>`
+   - `MnemonicClient.attestA2AMessage(msg: A2AMessage, contextId: string, opts?: ...): Promise<AttestationId>`
+   - `MnemonicClient.attestA2AArtifact(art: A2AArtifact, contextId: string, opts?: ...): Promise<AttestationId>`
+   - `MnemonicClient.recallA2AContext(contextId: string, opts?: { limit?: number; kind?: "task" | "message" | "artifact" | "all" }): Promise<Attestation[]>`
+   - All wrap `callTool("mnemonic_attest_a2a" | "mnemonic_recall_a2a", ...)`.
+
+2. **TS types** — `packages/sdk/src/types.ts`: add `A2ATask`, `A2AMessage`, `A2AArtifact`, `A2APart`. Field names match A2A v1.0.0-rc.
+
+3. **Re-exports** — `packages/sdk/src/index.ts`: surface the new methods, types, and any error subclasses.
+
+4. **CLI** — `packages/cli/src/commands/a2a.ts`. Three subcommands: `mnemonic a2a attest --kind <task|message|artifact> --file <path> --context <id> [--prev <id>]`, `mnemonic a2a recall --context <id> [--limit N]`, `mnemonic a2a verify --attestation <id>` (re-uses existing verify). Wire through SDK.
+
+5. **Tests**:
+   - `packages/sdk/test/a2a.test.ts` — mock fetch; assert correct MCP tool invocation + response parsing.
+   - `packages/cli/test/a2a.test.ts` — exercise the three subcommands against a stub server.
+   - Golden-fixture test (uses the published `@mnemonik-xyz/conformance` JSON): canonicalize the same A2A object on the JS side, hash, compare against the fixture's `jcs_canonical_hex`. Proves byte-for-byte parity with the Rust side.
+
+## TDD anchors
+
+- See above; all four test files are TDD anchors.
+
+## Done when
+
+- `npm -w @mnemonik-xyz/sdk run test` and `npm -w @mnemonik-xyz/cli run test` green.
+- `npm -w @mnemonik-xyz/sdk run build` succeeds.
+- CLI smoke: `mnemonic a2a attest --kind task --file fixtures/task.json --context demo` returns an id.
+- README.md updated in both packages with the new helpers.

--- a/work/a2a-bridge/tasks/8.md
+++ b/work/a2a-bridge/tasks/8.md
@@ -1,0 +1,43 @@
+---
+status: pending
+depends_on: [5, 6, 7]
+wave: 4
+skills: [code-writing]
+verify: [audit, conformance]
+reviewers: [security-auditor, code-reviewer, test-writer]
+teammate_name:
+---
+
+# Task 8: Conformance package, threat model, and use-case wiring
+
+## Description
+
+Closes the three open documentation gaps that the bridge enables and validates: a portable conformance suite, a real threat model for the A2A boundary, and a wiring section in each of the six A2A-shaped use case docs proving the pattern is now executable.
+
+## What to do
+
+1. **Conformance package.** New npm package `@mnemonik-xyz/conformance` under `packages/conformance/`. Contents: a single `vectors.json` produced by Task 2's emitter, a tiny README with the schema. CI publishes on every tagged release. Versioned to track A2A protocol version (`vectors-a2a-v1.0.0.json`). Third-party implementations load this and prove byte-for-byte parity.
+
+2. **`references/conformance.md`.** Document in `.claude/skills/project-knowledge/references/`. Covers: how to use the fixtures, what each field means, schema-compatibility matrix (A2A version × Mnemonic schema version), how to regenerate, what byte-for-byte parity proves and what it does not.
+
+3. **`references/threat-model.md`.** Cover the A2A boundary explicitly. STRIDE-style table:
+   - **Spoofing:** identity-substitution (card claims pubkey A; envelope signed by B). Mitigation: Task 4's JWS-coverage check.
+   - **Tampering:** in-flight Task / Message mutation. Mitigation: JCS canonicalization preserves bytes, COSE_Sign1 covers them.
+   - **Repudiation:** "I didn't send this message". Mitigation: per-message attestation with producer pubkey.
+   - **Information disclosure:** leakage through `recall_by_context` cross-tenant. Mitigation: contextId is opaque + per-tenant; document it does NOT prevent guessing if context ids are predictable.
+   - **DoS:** flood attestation requests. Mitigation: existing rate-limit + payment middleware on `mnemonic_attest_a2a`.
+   - **Elevation:** crafted A2A object that triggers core panic / OOM. Mitigation: fuzz testing in this task.
+   - **Canonicalization mismatch:** two valid canonicalizations of "the same" object produce different bytes. Mitigation: Decision 1 — preserve JCS bytes verbatim, do not re-canonicalize; explicit regression test.
+   - **ContextId forking:** two divergent attestation chains for the same contextId. Mitigation: lineage `prev_id` + recall ordering surfaces forks; not prevented at write time (cannot be without consensus). Document.
+
+4. **Fuzz harness.** `bridge-a2a/fuzz/` cargo-fuzz target on `attest_message` accepting arbitrary JSON. Run for 30 min in CI on PRs touching `core/src/codec/a2a/` or `mnemonic-a2a/`.
+
+5. **Use-case wiring.** In each of the six A2A-shaped docs (`task-memory-ledger.md`, `shared-memory-layer.md`, `shared-project-memory-namespace.md`, `artifact-attestation-service.md`, `provenance-attestation-layer.md`, `reliability-oracle-for-orchestration.md`), append a "Reference implementation" section with: (a) which bridge mode (sidecar / library / SDK) fits the pattern, (b) which schemas are involved, (c) a 5-line code snippet, (d) what `recall_by_context` query realizes the pattern.
+
+## Done when
+
+- `@mnemonik-xyz/conformance` published to npm under a tag.
+- `references/conformance.md` and `references/threat-model.md` committed.
+- 30-min fuzz run produces no crashes.
+- Six use case docs updated with reference-implementation sections.
+- Security-auditor reviewer approves the threat model coverage.

--- a/work/a2a-bridge/tech-spec.md
+++ b/work/a2a-bridge/tech-spec.md
@@ -1,0 +1,109 @@
+---
+created: 2026-05-01
+status: draft
+size: L
+branch: feat/a2a-bridge
+---
+
+# Tech Spec: A2A Bridge
+
+## Solution
+
+Three layers, deployable independently:
+
+1. **Schema layer (`mnemonic-core`)** — three new CBOR schemas (`A2A_TASK_V1`, `A2A_MESSAGE_V1`, `A2A_ARTIFACT_V1`) registered in `core/src/codec/schema.rs`. Each is canonicalized through the existing `to_canonical_cbor` path, blake3-hashed, COSE_Sign1-signed via `codec::sign::sign_artifact`. Lineage links (`prev_id`) carry intra-context ordering. Zero new crypto primitives — all reuse.
+
+2. **Adapter layer (new crate `mnemonic-a2a`)** — pure-Rust, depends on `mnemonic-core` only. Surface: `attest_message(msg, ctx) -> AttestationId`, `attest_task(task, ctx) -> AttestationId`, `attest_artifact(art, ctx) -> AttestationId`, `recall_by_context(ctx, query?) -> Vec<Attestation>`. No network, no I/O beyond `core`'s `AttestationStore`. Stateless functions; storage handle injected.
+
+3. **Surface layer (existing `mcp/` + new `bridge-a2a/` + SDK)** — three deployment shapes consume the adapter:
+   - **MCP tools** (`mnemonic_attest_a2a`, `mnemonic_recall_a2a`) added to `mcp/src/tools.rs` + `mcp/src/mcp.rs`.
+   - **Reference sidecar** (`bridge-a2a/`) — axum middleware, intercepts A2A JSON-RPC, attests via the adapter, returns the attestation id in the `x-mnemonic` extension on the A2A response.
+   - **SDK helpers** in `@mnemonik-xyz/sdk` — `attestA2ATask`, `attestA2AArtifact`, `recallA2AContext`, calling the MCP tools over HTTP.
+
+## Architecture
+
+### Files added
+
+- `core/src/codec/schema.rs` — three new schema constants (extension; do not mutate `MEMORY_V1`).
+- `core/src/codec/a2a/` — new submodule: `task.rs`, `message.rs`, `artifact.rs`, `mod.rs`. Type-safe Rust mirrors of the A2A wire types, plus `to_canonical_cbor_bytes` helpers.
+- `core/tests/a2a_golden_fixtures.rs` — emitter for `{a2a_json, canonical_cbor_hex, cose_envelope_hex}` triples (gated by `golden-fixtures` feature, mirrors existing pattern).
+- `bridge-a2a/` — new workspace member, `Cargo.toml` + `src/{main.rs, middleware.rs, agentcard.rs, config.rs}`. Native-only, axum-based.
+- `mnemonic-a2a/` — new workspace member, `Cargo.toml` + `src/{lib.rs, attest.rs, recall.rs}`. Pure library, no async runtime requirement (storage Mutex pattern follows CLAUDE.md rule).
+- `packages/sdk/src/a2a.ts` — three thin TS helpers; tests in `packages/sdk/test/a2a.test.ts`.
+- `.claude/skills/project-knowledge/references/threat-model.md` — first version, A2A-boundary-focused.
+- `.claude/skills/project-knowledge/references/conformance.md` — companion doc describing the published fixtures.
+
+### Files modified
+
+- `Cargo.toml` (workspace root) — add `mnemonic-a2a`, `bridge-a2a` to members.
+- `core/src/codec/mod.rs` — re-export new submodule under `pub mod a2a`.
+- `mcp/src/tools.rs` — two new tool definitions.
+- `mcp/src/mcp.rs` — dispatch arms for `mnemonic_attest_a2a` and `mnemonic_recall_a2a`.
+- `core/src/storage/sqlite.rs` — additive: `context_id TEXT NULL` column on `attestations` (idempotent migration), index on `(context_id, created_at)` for `recall_by_context`.
+- `docs/usecases/*.md` (the six A2A-shaped ones) — append "Reference implementation" section pointing to bridge-a2a.
+
+### Architectural rules (preserve)
+
+- `mnemonic-a2a` and `bridge-a2a` depend on `mnemonic-core` only. Same one-way graph as `mcp/`.
+- No payment / pricing logic in either new crate. Attestation cost (if any) flows through the existing `mcp/src/payment.rs` when the call enters via the MCP tool path.
+- No new direct embedder providers — A2A_*_V1 attestations do **not** require an embedder (no semantic recall over A2A events in V1; recall is keyed by `context_id`, not by cosine).
+- `rusqlite::Connection` lock discipline unchanged — never hold across `.await`.
+- Schema bytes are immutable post-V1. Breaking change → V2.
+
+## Decisions
+
+### Decision 1 — Two canonicalization formats, one attestation envelope
+
+A2A AgentCard signing uses RFC 8785 (JCS) over JSON. Mnemonic uses deterministic CBOR. We do NOT merge them. Instead the bridge canonicalizes the A2A object via JCS, then wraps the canonical JSON bytes verbatim inside a CBOR envelope (`A2A_TASK_V1` = `{schema, jcs_bytes, agent_pubkey, ts, prev_id?}`). The CBOR is canonicalized and COSE-signed; the inner JCS-bytes are byte-for-byte the same A2A canonical form. Verification: re-canonicalize A2A object via JCS → compare bytes → check COSE signature. Two independent canonicalizations, neither modified.
+
+### Decision 2 — `contextId` is the primary index, not `messageId`
+
+A2A's discriminator for "a multi-turn collaboration" is `contextId`. We index attestations by it and expose `recall_by_context`. `messageId` and `taskId` are secondary keys.
+
+### Decision 3 — AgentCard binding via `x-mnemonic` extension
+
+A2A has a first-class `Extension` mechanism. We define a single extension descriptor publishing `{ ed25519_pubkey_base58, attestation_endpoint?, conformance_version }`. No DID. No new identity crypto. Verifier resolves AgentCard → extracts `x-mnemonic.ed25519_pubkey_base58` → uses it directly with `core::codec::sign::verify_artifact`.
+
+### Decision 4 — Sidecar AND library, not one or the other
+
+Sidecar maximizes adoption (zero agent-side changes). Library minimizes latency and gives full control. Both reuse `mnemonic-a2a`. Sidecar is a single binary using the library; library users skip the network hop.
+
+### Decision 5 — Schema lock against A2A v1.0.0 GA only
+
+A2A is at v1.0.0-rc. We ship V1 schemas as `experimental` flag-gated until A2A GA. On GA: flip the flag, freeze the bytes, publish conformance fixtures. Any A2A breaking change after that → `*_V2` schemas, V1 stays valid for replay.
+
+### Decision 6 — V1 does not embed-and-recall A2A events semantically
+
+`MEMORY_V1` carries TurboQuant-compressed embeddings for semantic recall. A2A events do not — recall is by `context_id`, ordered by time + lineage. Reasoning: (a) A2A messages are often short and structured (tool calls, status updates); cosine search adds noise. (b) Embedding every A2A event would explode storage. (c) Users who want semantic recall of A2A content can attest a `MEMORY_V1` *alongside* the A2A_*_V1 — same `context_id`, different schema. Composable.
+
+### Decision 7 — Conformance fixtures published as a separate npm artifact
+
+`@mnemonik-xyz/conformance` — JSON file with golden vectors, no runtime code. Any third-party implementation (Go, Python, Java, Wasm-in-browser) can load it and prove byte-for-byte parity. Published from CI on every tagged release.
+
+### Decision 8 — Streaming attestation deferred
+
+A2A's `SendStreamingMessage` and `SubscribeToTask` produce SSE chunks. V1 attests only the final task state. Per-chunk attestation = future feature (`A2A_STREAM_CHUNK_V1`), goes in backlog.
+
+## Testing
+
+- **Unit:** each schema module has round-trip tests (encode → decode → assert equal) and canonicalization stability tests (two encodes of same input → identical bytes).
+- **Property:** proptest for `attest_task` ensuring any valid A2A Task JSON produces a verifiable attestation.
+- **Integration:** end-to-end test under `bridge-a2a/tests/` — start a mock A2A server, run sidecar in front, call `SendMessage`, assert response carries `x-mnemonic.attestation_id`, fetch via MCP `mnemonic_verify`, assert valid.
+- **Conformance:** `golden-fixtures` feature emits 20+ vectors covering text/file/data parts, single + multi-turn, completed + failed tasks. SDK test loads the published JSON and asserts JS-side canonicalization matches.
+- **Threat-model regression:** explicit tests for the cases enumerated in `references/threat-model.md` (replay, identity-substitution, JCS-CBOR canonicalization mismatch, contextId forking).
+
+## Sequencing (waves)
+
+- **Wave 1 — schemas** (foundation; nothing else compiles without): tasks 1, 2.
+- **Wave 2 — adapter + identity binding** (parallel; different files): tasks 3, 4.
+- **Wave 3 — surface** (parallel; different files): tasks 5 (MCP), 6 (sidecar), 7 (SDK).
+- **Wave 4 — conformance + audit** (parallel): tasks 8.
+
+Common conflict points: `Cargo.toml` (root), `core/src/codec/mod.rs`, `mcp/src/mcp.rs`. Schedule those touches inside single tasks.
+
+## Risks
+
+- **A2A pre-GA churn** — V1 schema lock would create migration debt if A2A renames a Task field. Mitigation: ship behind `experimental` feature flag until A2A GA; final schema bytes only frozen at flip.
+- **JCS implementation in Rust** — the canonical-json crate ecosystem is thinner than serde_json. Mitigation: vet the crate during Wave 1 (`serde_jcs` is the leading candidate); fallback is a small in-house implementation since JCS is ~150 LOC.
+- **Identity binding ambiguity** — if AgentCard has both a `signatures[]` JWS and our `x-mnemonic.ed25519_pubkey_base58`, which is authoritative? Decision: JWS verifies the AgentCard itself; `x-mnemonic` declares the Mnemonic attestation key; both must be present and the JWS must cover the extension payload. Tested explicitly.
+- **Adoption tied to A2A adoption** — if A2A flatlines, bridge ROI drops. Mitigation: same adapter pattern is reusable for ACP / MCP-to-MCP delegation (see `backlog.md`).

--- a/work/a2a-bridge/user-spec.md
+++ b/work/a2a-bridge/user-spec.md
@@ -1,0 +1,69 @@
+---
+created: 2026-05-01
+status: draft
+type: feature
+size: L
+---
+
+# User Spec: A2A Bridge — Mnemonic as the durable memory layer for Agent2Agent workflows
+
+## Что делаем
+
+Шипаем «мост» между Mnemonic Protocol и Agent2Agent (A2A) — открытым протоколом межагентного взаимодействия (Google, v1.0.0-rc, JSON-RPC + SSE по HTTP). Bridge превращает каждое A2A-взаимодействие — `Task`, `Message`, `Artifact` — в подписанный, проверяемый, durable Mnemonic-attestation, индексированный по A2A `contextId`.
+
+Конкретно поставляем:
+
+1. **Три новые CBOR-схемы** в `mnemonic-core` (`A2A_TASK_V1`, `A2A_MESSAGE_V1`, `A2A_ARTIFACT_V1`) — детерминированные, COSE_Sign1, blake3-хешированные, пристёгнутые к существующему lineage-DAG через `prev_id`.
+2. **Адаптер-крейт `mnemonic-a2a`** — pure-Rust функции `attest_message`, `attest_task`, `attest_artifact`, `recall_by_context` поверх `mnemonic_core`.
+3. **Identity binding** — расширение AgentCard `x-mnemonic` (через A2A `Extension`-механизм), публикующее Ed25519 pubkey агента, чтобы потребитель A2A-карточки сразу мог проверять Mnemonic-подписи.
+4. **Два новых MCP-инструмента** (`mnemonic_attest_a2a`, `mnemonic_recall_a2a`) на `mcp.mnemonik.xyz` — чтобы A2A-агент, уже подключённый к Mnemonic через MCP, мог фиксировать события в одну строчку.
+5. **Reference-сайдкар `bridge-a2a/`** — минимальный axum-middleware который сидит перед A2A-сервером, перехватывает `SendMessage` / `GetTask completed` / artifact emission и автоматически производит attestation. Sidecar — это «опциональный путь, без переписывания агента»; библиотечный путь (`use mnemonic_a2a::attest_task`) — для тех, кто хочет интегрироваться напрямую.
+6. **SDK-хелперы** в `@mnemonik-xyz/sdk`: `attestA2ATask`, `attestA2AArtifact`, `recallA2AContext` — чтобы TS/JS-агент получил тот же контракт, что и Rust-сторона.
+7. **Conformance-фикстуры** — golden vectors `{a2a_task_json, canonical_cbor_hex, cose_envelope_hex}`, публикуемые отдельным npm-артефактом, чтобы любая сторонняя реализация могла доказать byte-for-byte parity.
+8. **Threat-model** — новый документ `references/threat-model.md`, покрывающий A2A-границу: канонические mismatches, replay, forking, identity-substitution.
+
+Schema-policy: фиксируем `*_V1` против A2A v1.0.0 GA. До GA — `experimental` в `decisions.md`.
+
+## Зачем
+
+A2A — это «движение», а не «память»: спецификация явно говорит, что агенты сотрудничают «without needing access to each other's internal state, memory, or tools». Tasks живут до `completed/failed`, после чего их сохранение — частное дело конкретного A2A-сервера. Никакого cross-session, cross-vendor, signed audit trail протокол не предлагает.
+
+Whitepaper Mnemonic уже занимает эту нишу позиционно (`docs/WHITEPAPER.md`: «A2A makes agents interoperable in motion; Mnemonic makes them coherent over time»). Но в коде моста нет: каждый интегратор вынужден руками маппить `Task`/`Message`/`Artifact` на `MEMORY_V1` и тащить эту склейку через ребрейки A2A.
+
+Что закрывает A2A bridge:
+
+- **Шесть из одиннадцати use-case'ов** в `docs/usecases/` явно построены на A2A: `task-memory-ledger`, `shared-memory-layer`, `shared-project-memory-namespace`, `artifact-attestation-service`, `provenance-attestation-layer`, `reliability-oracle-for-orchestration`. Сейчас все они — «впишите glue-код сами». Bridge превращает их в «подключите sidecar / импортируйте крейт».
+- **Дифференциация против letta / zep / mem0 / cognee** — никто из них не подписывает память и не имеет A2A-binding'а. Двойной moat: «мы attest» × «мы нативно говорим на multi-agent протоколе». Ретроспективно повторить трудно: схемы должны быть детерминированными и version-stable.
+- **Reputation / reliability oracle становится исполнимым** — `contextId` как индексируемый ключ позволяет считать «agent X выполнил 2400 задач в этом контексте без разрывов lineage». Это переводит use-case `reliability-oracle-for-orchestration` и `trust-reputation-layer` из speculative в executable.
+- **Композируется с AgentCard JWS** — A2A v0.3+ уже подписывает AgentCard через JWS (RFC 8785). Mnemonic-attestation — это естественный следующий слой: card доказывает «кто», Mnemonic-envelope — «что сделал».
+
+## Как должно работать
+
+### Сценарий 1 — Drop-in sidecar
+
+DevOps команды разворачивает `bridge-a2a` как контейнер перед существующим A2A-сервером. На каждый `SendMessage` / `GetTask` (status=completed) / artifact-emission sidecar:
+
+1. Канонизирует A2A JSON через RFC 8785 (как делает A2A AgentCard signing).
+2. Оборачивает канонические байты в Mnemonic-CBOR-envelope с соответствующей `*_V1` схемой.
+3. Подписывает через `mnemonic_core::codec::sign` Ed25519-ключом агента.
+4. Кладёт в Mnemonic SQLite + (optional, full-mode) Arweave + Solana memo.
+5. Возвращает ответ A2A с extension-полем `x-mnemonic: { attestation_id }`.
+
+### Сценарий 2 — Library integration
+
+Агент-разработчик импортирует `mnemonic_a2a` крейт (Rust) или `@mnemonik-xyz/sdk` (TS) и явно вызывает `attest_task(...)` после завершения задачи. Применимо когда нет separate A2A-сервера или хочется полный контроль над тем, что попадает в memory.
+
+### Сценарий 3 — Cross-agent recall
+
+Любой A2A-агент с access к Mnemonic-MCP вызывает `mnemonic_recall_a2a(context_id, query?)` и получает упорядоченный список всех attested сообщений / задач / артефактов в этом A2A-контексте, через любые vendor'ы и сессии. Это то, что A2A сама по себе не даёт.
+
+### Сценарий 4 — Independent verification
+
+Третья сторона получает A2A `Task` JSON + Mnemonic `attestation_id`. Через published conformance fixtures и любую реализацию `mnemonic-core` (включая Wasm-сборку) она перепроверяет: канонический CBOR совпадает, blake3 совпадает, COSE_Sign1 валиден против Ed25519-pubkey, опубликованного в `x-mnemonic` extension AgentCard'а. Никакого доверия к `mcp.mnemonik.xyz` не нужно.
+
+## Out of scope (Phase 1 of the bridge)
+
+- Streaming SSE chunk-level attestation — Phase 1 фиксирует только финальное состояние Task. Per-chunk attestation — backlog.
+- Полная chain-pluggability anchor'а — наследуем текущий Solana lock из `core/`. После того как `mnemonic-cli` Phase 3 сделает chain-pluggable anchor, A2A bridge получит это бесплатно.
+- Schema-эволюция выше V1 — V1 фиксируется против A2A v1.0.0 GA. Любые breaking changes — новый `*_V2`, не мутируем V1 (та же дисциплина что у `MEMORY_V1`).
+- Non-A2A protocol integrations (MCP-to-MCP, ACP, AGNTCY) — см. `backlog.md`.

--- a/work/mnemonic-cli/backlog.md
+++ b/work/mnemonic-cli/backlog.md
@@ -46,12 +46,13 @@ Touchpoints (Option B):
 
 Phase 1's `Signer` interface in SDK was deliberately abstract precisely to enable this. The blocker is server-side + WASM exports + storage schema + migration UX.
 
-### Recommended sequencing — LOCKED IN (2026-04-30)
+### Recommended sequencing — LOCKED IN (2026-04-30, amended 2026-05-01)
 
 - **Phase 2 — confirmed:** Option B → unblock'ает passkey + KMS users. Anchor stays Solana.
 - **Phase 3 — confirmed:** Option A → free protocol from SVM dependency. Chain-pluggable anchor (Ethereum, Bitcoin, ICP, etc.).
+- **Phase 3α — pulled forward (2026-05-01) by ERC-8004 trigger:** the *anchor-only* subset of Phase 3 (chain-pluggable anchor; off-chain envelope alg unchanged) is no longer purely sequential after Phase 2. It is now a **prerequisite or co-requisite** of ERC-8004 V1 (`work/a2a-bridge/backlog.md` § "ERC-8004 — Phase 2 of the bridge stack"). Reason: shipping ERC-8004 while keeping Solana SPL Memo as the only anchor would deepen the SVM dependency at exactly the moment we extend the anchor surface to a new chain. Path-b ("validator-as-a-service that still anchors via Solana") is explicitly REJECTED. The Ethereum-via-ERC-8004-Validation-Registry call **is** the anchor for ERC-8004-routed flows — we do not double-anchor.
 
-This sequencing is treated as an architectural decision, not a "maybe". Phase 1.5 (on-chain + billing) lands first because real anchoring is the protocol's headline value. Phase 2 follows because passkey / KMS unlocks corporate + consumer-grade identity. Phase 3 closes the SVM dependency.
+This sequencing is treated as an architectural decision, not a "maybe". Phase 1.5 (on-chain + billing) lands first because real anchoring is the protocol's headline value. Phase 2 follows because passkey / KMS unlocks corporate + consumer-grade identity. Phase 3α follows alongside or before ERC-8004 V1 to close the SVM lock without shipping a second anchor on top of the first. Phase 3 (full off-chain alg pluggability) remains separately tracked as the Option-A finish-line.
 
 ---
 


### PR DESCRIPTION
…ns index

New backlog feature `work/a2a-bridge/` plans Mnemonic's binding to Google's Agent2Agent (A2A) protocol — three new CBOR schemas (`A2A_TASK_V1`, `A2A_MESSAGE_V1`, `A2A_ARTIFACT_V1`), an adapter crate `mnemonic-a2a`, AgentCard `x-mnemonic` extension, two new MCP tools, reference sidecar `bridge-a2a/`, SDK helpers, and a published conformance package. Eight atomic tasks across four waves; ties together six A2A-shaped use case docs.

`.claude/skills/project-knowledge/references/protocol-integrations.md` indexes the A2A bridge alongside the rest of the protocol-integration backlog: MCP-to-MCP delegation, ACP (IBM/BeeAI), AGNTCY (Cisco), framework adapters (LangGraph / AutoGen / CrewAI), and ERC-8004 anchor identity. SKILL.md updated to link the new reference plus the existing crypto-design.md and economics.md docs that were not yet listed.

https://claude.ai/code/session_01WHYvdzuBz2rL5VPZNsM3HZ