### PR TITLE
fix(webapp): VS Code MCP install — opaque URI + no JWT headers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,45 @@ jobs:
       - name: Validate smithery.yaml against schema
         run: yamale -s scripts/smithery-schema.yaml smithery.yaml
 
+  # Webapp gates — vitest unit tests + tsc typecheck.
+  #
+  # Why this exists: on 2026-05-02 commits a5ee738 and 2fad606 broke the
+  # VS Code MCP install deeplink for every user (URL-form regression +
+  # JWT-headers regression). Both shipped because the webapp had NO CI
+  # coverage — vitest unit tests had to be run manually, the Playwright
+  # e2e (which would have caught it) also wasn't gated. Adding this gate
+  # so install-button regressions are caught before merge, not in prod.
+  webapp:
+    name: webapp (vitest + tsc)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: webapp
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      # No `npm ci` because the lockfile lives at repo root.
+      # `npm install --no-audit --no-fund` resolves devDeps from webapp/package.json.
+      - name: Install webapp deps
+        run: npm install --no-audit --no-fund
+      # Typecheck. Catches drifted types (e.g. removed exports referenced
+      # by tests) without running the WASM build pipeline.
+      - name: Typecheck
+        run: npx tsc -b --noEmit
+      # Vitest — scoped to InstallButtons for now. The full suite has a
+      # pre-existing flake in Sign.test.tsx (`countdown_displays_mm_ss`,
+      # timer race) that fails on `dev` too — broaden this run to
+      # `npx vitest run` once that's fixed.
+      #
+      # The InstallButtons.test.tsx file holds the regression guards
+      # against the 2026-05-02 install-deeplink breakages:
+      #   - opaque vs hierarchical URL form (`vscode:` vs `vscode://`)
+      #   - extra `headers` field in the install JSON
+      - name: Vitest (InstallButtons regression guards)
+        run: npx vitest run src/components/InstallButtons.test.tsx
+
   # Optional opt-in job: runs the network-touching `stdio_backward_compat`
   # integration test that's `#[ignore]`d by default. Triggered manually via
   # workflow_dispatch or scheduled (daily) — not on every PR — because it

--- a/webapp/src/components/InstallButtons.test.tsx
+++ b/webapp/src/components/InstallButtons.test.tsx
@@ -23,13 +23,22 @@ describe("InstallButtons", () => {
       type: "http",
     });
 
-    // VS Code deeplink: scheme + url-encoded JSON config (single param, NOT
-    // separate `name=&url=` query params — VS Code MCP install dialog only
-    // recognizes the JSON-blob format).
+    // VS Code deeplink: opaque URI (`vscode:`, NO `//`) + url-encoded JSON
+    // config as a single param (NOT separate `name=&url=` query params).
+    //
+    // Regression guard — both shape errors below have shipped before and
+    // produce the SAME symptom (VS Code opens, dialog never appears):
+    //   1. `vscode://mcp/install?...` — hierarchical form. Parser sees
+    //      authority="mcp", path="/install"; install handler matches
+    //      path="mcp/install" so handler never fires.
+    //   2. {..., headers: ...} — VS Code's install-link JSON validator
+    //      is strict; only {name, type:"http", url} is accepted. Extra
+    //      fields silently abort the install dialog.
     const vscode = screen.getByTestId("install-vscode") as HTMLAnchorElement;
-    expect(vscode.href.startsWith("vscode://mcp/install?")).toBe(true);
+    expect(vscode.href.startsWith("vscode:mcp/install?")).toBe(true);
+    expect(vscode.href.startsWith("vscode://mcp/install?")).toBe(false);
     const vscodeConfig = decodeURIComponent(
-      vscode.href.replace("vscode://mcp/install?", "")
+      vscode.href.replace("vscode:mcp/install?", "")
     );
     const parsedVscode = JSON.parse(vscodeConfig);
     expect(parsedVscode).toEqual({
@@ -37,6 +46,7 @@ describe("InstallButtons", () => {
       type: "http",
       url: "https://mcp.mnemonik.xyz/mcp",
     });
+    expect(parsedVscode.headers).toBeUndefined();
 
     // Claude.ai is a button, not an anchor — it opens a modal that exposes
     // the paste URL — must include scheme so Claude.ai accepts it.
@@ -62,11 +72,16 @@ describe("InstallButtons", () => {
     });
   });
 
-  it("install_deeplinks_bake_jwt_when_logged_in", () => {
-    // When the webapp has a non-expired JWT in localStorage, both Cursor
-    // and VS Code deeplinks include the JWT in `headers.Authorization`.
-    // The IDE's deeplink handler stores it in mcp.json and sends it on
-    // every MCP call — bypasses the IDE's broken OAuth UX.
+  it("cursor_deeplink_bakes_jwt_when_logged_in", () => {
+    // When the webapp has a non-expired JWT in localStorage, the Cursor
+    // deeplink includes the JWT in `headers.Authorization`. Cursor's
+    // deeplink handler stores it in mcp.json and sends it on every MCP
+    // call — bypasses Cursor 3.2.16's broken OAuth UX (no Connect button
+    // for non-directory MCP servers).
+    //
+    // VS Code is INTENTIONALLY excluded — its install-link JSON validator
+    // rejects extra fields like `headers`. See `vscode_deeplink_never_bakes_jwt`
+    // below for the regression guard.
     const futureExp = Math.floor(Date.now() / 1000) + 3600; // 1h from now
     const headerB64 = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }))
       .replace(/=+$/, "")
@@ -91,14 +106,43 @@ describe("InstallButtons", () => {
     expect(cursorConfig.headers).toEqual({
       Authorization: `Bearer ${jwt}`,
     });
+  });
+
+  it("vscode_deeplink_never_bakes_jwt", () => {
+    // REGRESSION GUARD (2026-05-02): commit 2fad606 baked the JWT into
+    // both Cursor and VS Code deeplinks. The `headers` field in VS Code's
+    // install-link JSON makes VS Code's validator silently reject the
+    // install — VS Code opens but the install dialog never appears.
+    //
+    // VS Code 1.93+ does MCP OAuth natively, so the JWT bake-in is
+    // unneeded for VS Code anyway. This test asserts that VS Code's
+    // deeplink contains ONLY {name, type, url} regardless of login state.
+    const futureExp = Math.floor(Date.now() / 1000) + 3600;
+    const headerB64 = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }))
+      .replace(/=+$/, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+    const payloadB64 = btoa(
+      JSON.stringify({ sub: "test-pubkey", exp: futureExp })
+    )
+      .replace(/=+$/, "")
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_");
+    const jwt = `${headerB64}.${payloadB64}.fakesignature`;
+    localStorage.setItem("mnemonic.jwt", jwt);
+
+    render(<InstallButtons />);
 
     const vscode = screen.getByTestId("install-vscode") as HTMLAnchorElement;
     const vscodeConfig = JSON.parse(
-      decodeURIComponent(vscode.href.replace("vscode://mcp/install?", ""))
+      decodeURIComponent(vscode.href.replace("vscode:mcp/install?", ""))
     );
-    expect(vscodeConfig.headers).toEqual({
-      Authorization: `Bearer ${jwt}`,
+    expect(vscodeConfig).toEqual({
+      name: "Mnemonic",
+      type: "http",
+      url: "https://mcp.mnemonik.xyz/mcp",
     });
+    expect(vscodeConfig.headers).toBeUndefined();
   });
 
   it("install_deeplinks_skip_jwt_when_expired", () => {

--- a/webapp/src/components/InstallButtons.tsx
+++ b/webapp/src/components/InstallButtons.tsx
@@ -31,6 +31,23 @@ const MCP_URL = "https://mcp.mnemonik.xyz/mcp";
 const MCP_HOST = "https://mcp.mnemonik.xyz/mcp";
 
 /**
+ * VS Code MCP install-link scheme — opaque URI form per VS Code docs:
+ *   https://code.visualstudio.com/docs/copilot/customization/mcp-servers
+ *   §"Use MCP install links"
+ *
+ * MUST be `vscode:mcp/install?<JSON>` (single colon, NO `//`). With the
+ * hierarchical `vscode://mcp/install?...` form, VS Code's URI parser
+ * yields authority="mcp" + path="/install", which does not match the
+ * MCP install handler (registered for path `mcp/install`). Result:
+ * VS Code window opens, install dialog never appears.
+ *
+ * Do not change without verifying in actual VS Code on macOS+Windows.
+ * Both InstallButtons.test.tsx (unit) and webapp/e2e/install.spec.ts
+ * (Playwright) assert this exact prefix as a regression guard.
+ */
+export const VSCODE_INSTALL_PREFIX = "vscode:mcp/install?";
+
+/**
  * Read the webapp's current JWT from localStorage IF it exists AND has not
  * expired. Returns null otherwise.
  *
@@ -63,22 +80,40 @@ function readWebappJwt(): string | null {
 }
 
 /**
- * Build the IDE config object passed via the install deeplink. When the
- * webapp has a non-expired JWT, bake it into the `headers` field so the
- * IDE sends `Authorization: Bearer <jwt>` on every MCP call from the
- * moment of install — no OAuth dance needed inside the IDE.
+ * Build the IDE config object passed via the install deeplink.
+ *
+ * `bakeJwt` controls whether a non-expired webapp JWT is included as
+ * `headers: { Authorization: "Bearer <jwt>" }`. This is intentionally
+ * opt-in per IDE:
+ *
+ *   - Cursor: `bakeJwt = true`. Cursor 3.2.16's MCP UI does not surface
+ *     a Connect / Authorize button for non-directory MCP servers, so we
+ *     hand the JWT off via the install deeplink to skip OAuth entirely.
+ *     Cursor's deeplink JSON validator is lenient and forwards arbitrary
+ *     fields through to mcp.json.
+ *
+ *   - VS Code: `bakeJwt = false`. VS Code's install-link JSON validator
+ *     is STRICT — it accepts only `{name, type, url}` for HTTP MCP entries
+ *     (per the docs). Including `headers` causes the install dialog to
+ *     silently abort: VS Code opens but no UI appears. VS Code 1.93+
+ *     handles MCP OAuth natively, so the JWT bake-in isn't needed there
+ *     anyway. (Past regression: 2026-05-02 — `headers` field broke VS
+ *     Code install for every logged-in user.)
  */
 function buildInstallConfig(
-  extras: Record<string, unknown> = {}
+  extras: Record<string, unknown> = {},
+  bakeJwt: boolean = false
 ): Record<string, unknown> {
   const config: Record<string, unknown> = {
     url: MCP_URL,
     type: "http",
     ...extras,
   };
-  const jwt = readWebappJwt();
-  if (jwt) {
-    config.headers = { Authorization: `Bearer ${jwt}` };
+  if (bakeJwt) {
+    const jwt = readWebappJwt();
+    if (jwt) {
+      config.headers = { Authorization: `Bearer ${jwt}` };
+    }
   }
   return config;
 }
@@ -98,41 +133,52 @@ function cursorDeeplink(): string {
   // This bypasses Cursor's MCP-OAuth UI (which doesn't render a Connect
   // button for non-directory servers) and skips the OAuth dance entirely.
   // Reference: https://cursor.com/docs/context/mcp/install-links
-  const config = JSON.stringify(buildInstallConfig());
+  const config = JSON.stringify(buildInstallConfig({}, /* bakeJwt */ true));
   const b64 = btoa(config);
   const params = new URLSearchParams({ name: "Mnemonic", config: b64 });
   return `cursor://anysphere.cursor-deeplink/mcp/install?${params.toString()}`;
 }
 
 function vscodeDeeplink(): string {
-  // VS Code 1.93+ MCP install deeplink format:
+  // VS Code 1.93+ MCP install deeplink format (per VS Code docs
+  // code.visualstudio.com/docs/copilot/customization/mcp-servers
+  // → "Use MCP install links"):
   //
   //     vscode:mcp/install?<URL-encoded-JSON-config>
   //
+  // Two things are easy to get wrong here — both have shipped as
+  // regressions in this repo before, both produce the SAME symptom
+  // (VS Code window opens, no install dialog):
+  //
+  //  1. URL FORM: must be the opaque `vscode:` (single colon, no `//`).
+  //     With `vscode://mcp/install?...` VS Code's URI parser yields
+  //     authority="mcp" + path="/install"; the install handler matches
+  //     on path === "mcp/install" and never fires. macOS launches VS
+  //     Code for both forms (scheme-only dispatch), but only the opaque
+  //     form actually triggers the install handler. See
+  //     VSCODE_INSTALL_PREFIX above.
+  //
+  //  2. CONFIG SHAPE: VS Code's install-link JSON validator is strict —
+  //     accepts ONLY {name, type:"http", url} for HTTP. Extra fields
+  //     (e.g. `headers`) make the validator silently reject. The on-disk
+  //     mcp.json schema DOES allow `headers` for HTTP entries, but the
+  //     install-deeplink schema is a separate, stricter code path.
+  //     Therefore: never pass JWT/headers via this deeplink. VS Code
+  //     1.93+ handles MCP OAuth natively, so it's not needed.
+  //
+  // Both regressions actually shipped on 2026-05-02 (a5ee738 + 2fad606),
+  // breaking the install for every user until reverted.
+  //
   // The whole query string is a single URL-encoded JSON object, NOT
-  // multiple `key=value` query params. Using URLSearchParams here would
-  // produce `?name=Mnemonic&url=...` which VS Code does not parse — the
-  // browser opens VS Code but the install dialog never appears (this is
-  // exactly the bug a user hit during T15 post-deploy QA).
-  //
-  // Per VS Code MCP docs (code.visualstudio.com/docs/copilot/customization/mcp-servers
-  // → "Use MCP install links"):
-  //   - HTTP transport: { name, type: "http", url }
-  //   - stdio transport: { name, command, args }
-  // We use HTTP (streamable per Decision 1).
-  //
-  // The double-slash after the scheme matters for Safari (16+) and some
-  // mobile browsers: they reject opaque URIs (`vscode:mcp/...` with no
-  // authority component) as malformed and surface "address is invalid"
-  // before the OS scheme handler ever sees the URL. macOS's URL routing
-  // accepts both `vscode:` and `vscode://` for VS Code, so always emit the
-  // hierarchical form for cross-browser compatibility. (Confirmed-failing
-  // user report on Safari with the single-slash form on 2026-05-02.)
-  //
-  // Same JWT-baked-in-headers pattern as cursorDeeplink — gives the user
-  // a one-click install that works without OAuth round-trips inside the IDE.
-  const config = buildInstallConfig({ name: "Mnemonic" });
-  return `vscode://mcp/install?${encodeURIComponent(JSON.stringify(config))}`;
+  // multiple `key=value` query params (that's a third easy mis-step:
+  // URLSearchParams output is also unrecognized).
+  const config = buildInstallConfig(
+    { name: "Mnemonic" },
+    /* bakeJwt — see fn docs, MUST stay false for VS Code */ false
+  );
+  return `${VSCODE_INSTALL_PREFIX}${encodeURIComponent(
+    JSON.stringify(config)
+  )}`;
 }
 
 // JSON snippet that goes into `~/.codeium/windsurf/mcp_config.json`. WindSurf


### PR DESCRIPTION
The 2026-05-02 release shipped two independent regressions in `vscodeDeeplink()` that both produce the same symptom — VS Code window opens, install dialog never appears:

1. `a5ee738` switched the URL form from the documented opaque `vscode:mcp/install?...` to hierarchical `vscode://mcp/install?...`. VS Code's URI parser yields authority="mcp" + path="/install" for the `//` form, which doesn't match the install handler (registered for path "mcp/install"). Justification in the original commit ("Safari rejects opaque URIs", "VS Code accepts both") was wrong on both counts: Safari routes opaque schemes inside `<a href>` clicks, and while macOS *launches* VS Code for both forms, only the opaque form actually triggers the install handler.

2. `2fad606` (JWT bake-in for the CLI) added `headers: { Authorization: "Bearer <jwt>" }` to the install JSON. VS Code's install-link JSON validator is strict — it accepts only `{name, type, url}` for HTTP — and silently aborts the install dialog on extra fields. (The on-disk `mcp.json` schema does allow `headers`, but it's a separate validator.) The JWT bake-in is Cursor-specific anyway: VS Code 1.93+ handles MCP OAuth natively; only Cursor needs the bypass.

Fix:
  - Restore opaque `vscode:mcp/install?<encoded-JSON>` form.
  - Make `buildInstallConfig`'s JWT bake-in opt-in via `bakeJwt` param; Cursor passes true, VS Code passes false.
  - Promote the URL prefix to an exported `VSCODE_INSTALL_PREFIX` constant with docs reference + regression note inline.
  - Tests:
      * `vscode_deeplink_never_bakes_jwt` — new regression guard
      * `deeplink_url_well_formed` — assert opaque URL form + `headers` undefined * `cursor_deeplink_bakes_jwt_when_logged_in` — replaces the former cursor+vscode shared test

Why this kept slipping: the webapp had no CI. Vitest never ran on PRs, Playwright e2e (which already had the right assertion at `webapp/e2e/install.spec.ts:77`) wasn't gated either. Adding a webapp job to ci.yml that runs typecheck + the InstallButtons regression guards on every PR. Scoped to InstallButtons for now because the full vitest run has an unrelated pre-existing flake in
`Sign.test.tsx::countdown_displays_mm_ss` that fails on `dev` too — broaden once that's fixed.