### PR TITLE
feat(webapp): landing redesign — quickstart + site header/footer

### DIFF
--- a/webapp/src/components/SiteFooter.tsx
+++ b/webapp/src/components/SiteFooter.tsx
@@ -1,0 +1,143 @@
+import { Link } from "react-router-dom";
+import { EXTERNAL_LINKS } from "../lib/links";
+
+/**
+ * Site-wide footer. Designed to read like the colophon of a technical paper:
+ * groups of links with mono labels, hairline separators, no marketing flourish.
+ */
+export default function SiteFooter() {
+  return (
+    <footer className="relative mt-24 border-t border-white/5 bg-background/40">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-accent-primary/30 to-transparent"
+      />
+
+      <div className="mx-auto grid max-w-6xl gap-10 px-4 py-12 sm:px-6 md:grid-cols-[1.4fr_1fr_1fr_1fr]">
+        <div className="space-y-4">
+          <Link
+            to="/"
+            className="flex items-center gap-2 font-mono text-xs uppercase tracking-[0.18em] text-text-primary"
+          >
+            <span
+              aria-hidden="true"
+              className="inline-block h-1.5 w-1.5 rounded-full bg-accent-primary shadow-[0_0_12px_var(--color-accent-primary)]"
+            />
+            <span className="font-semibold">Mnemonic</span>
+            <span className="text-text-muted/60">/ protocol</span>
+          </Link>
+          <p className="max-w-sm text-sm leading-relaxed text-text-muted">
+            Verifiable, persistent memory for AI agents. Open-source under
+            Apache 2.0. Built with care, designed to be inspected.
+          </p>
+        </div>
+
+        <FooterColumn title="Read">
+          <FooterLink external href={EXTERNAL_LINKS.whitepaper}>
+            Whitepaper
+          </FooterLink>
+          <FooterLink external href={EXTERNAL_LINKS.howItWorks}>
+            How it works
+          </FooterLink>
+          <FooterLink external href={EXTERNAL_LINKS.quickstart}>
+            Quickstart
+          </FooterLink>
+          <FooterLink external href={EXTERNAL_LINKS.paper}>
+            Foundational paper
+          </FooterLink>
+        </FooterColumn>
+
+        <FooterColumn title="Build">
+          <FooterLink external href={EXTERNAL_LINKS.github}>
+            GitHub
+          </FooterLink>
+          <FooterLink external href={EXTERNAL_LINKS.issues}>
+            Issues
+          </FooterLink>
+          <FooterLink internal href="/install">
+            Install
+          </FooterLink>
+          <FooterLink internal href="/chat">
+            Protocol chat
+          </FooterLink>
+        </FooterColumn>
+
+        <FooterColumn title="Talk">
+          <FooterLink external href={EXTERNAL_LINKS.discord}>
+            Discord
+          </FooterLink>
+          <FooterLink external href={EXTERNAL_LINKS.telegram}>
+            Telegram
+          </FooterLink>
+        </FooterColumn>
+      </div>
+
+      <div className="border-t border-white/5">
+        <div className="mx-auto flex max-w-6xl flex-col gap-2 px-4 py-5 font-mono text-[11px] uppercase tracking-[0.16em] text-text-muted/70 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+          <span>© {new Date().getFullYear()} Mnemonic Protocol</span>
+          <span className="flex items-center gap-3">
+            <span aria-hidden="true" className="h-px w-6 bg-text-muted/30" />
+            <span>Apache 2.0 · v0.1</span>
+          </span>
+        </div>
+      </div>
+    </footer>
+  );
+}
+
+function FooterColumn({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-3">
+      <h3 className="font-mono text-[11px] uppercase tracking-[0.18em] text-text-muted">
+        {title}
+      </h3>
+      <ul className="space-y-2 text-sm">{children}</ul>
+    </div>
+  );
+}
+
+function FooterLink({
+  href,
+  children,
+  external,
+  internal,
+}: {
+  href: string;
+  children: React.ReactNode;
+  external?: boolean;
+  internal?: boolean;
+}) {
+  if (internal) {
+    return (
+      <li>
+        <Link
+          to={href}
+          className="text-text-primary/80 transition-colors hover:text-accent-primary"
+        >
+          {children}
+        </Link>
+      </li>
+    );
+  }
+  if (external) {
+    return (
+      <li>
+        <a
+          href={href}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-text-primary/80 transition-colors hover:text-accent-primary"
+        >
+          {children}
+        </a>
+      </li>
+    );
+  }
+  return null;
+}

--- a/webapp/src/components/SiteHeader.tsx
+++ b/webapp/src/components/SiteHeader.tsx
@@ -1,0 +1,86 @@
+import { Link } from "react-router-dom";
+import { EXTERNAL_LINKS } from "../lib/links";
+
+/**
+ * Sticky minimal site header. Three zones:
+ *   left  — wordmark anchored to /
+ *   right — terse mono links to the public resources
+ *
+ * Designed to read like a research-paper masthead, not a marketing nav.
+ */
+export default function SiteHeader() {
+  return (
+    <header className="sticky top-0 z-30 border-b border-white/5 bg-background/80 backdrop-blur-md">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-3 sm:px-6">
+        <Link
+          to="/"
+          className="group flex items-center gap-2 font-mono text-xs uppercase tracking-[0.18em] text-text-primary"
+          aria-label="Mnemonic Protocol — home"
+        >
+          <span
+            aria-hidden="true"
+            className="inline-block h-1.5 w-1.5 rounded-full bg-accent-primary shadow-[0_0_12px_var(--color-accent-primary)] transition-transform group-hover:scale-125"
+          />
+          <span className="font-semibold">Mnemonic</span>
+          <span className="text-text-muted/60">/ protocol</span>
+        </Link>
+
+        <nav
+          aria-label="External resources"
+          className="flex items-center gap-1 sm:gap-3"
+        >
+          <ResourceLink
+            href={EXTERNAL_LINKS.github}
+            label="GitHub"
+            srLabel="GitHub repository"
+          />
+          <ResourceLink
+            href={EXTERNAL_LINKS.whitepaper}
+            label="Whitepaper"
+            srLabel="Read the whitepaper"
+          />
+          <ResourceLink
+            href={EXTERNAL_LINKS.discord}
+            label="Discord"
+            srLabel="Join the Discord server"
+          />
+          <ResourceLink
+            href={EXTERNAL_LINKS.telegram}
+            label="Telegram"
+            srLabel="Join the Telegram group"
+          />
+          <Link
+            to="/install"
+            className="ml-2 hidden rounded-sm border border-accent-primary/40 bg-accent-primary/10 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.16em] text-accent-primary transition-colors hover:border-accent-primary hover:bg-accent-primary/20 sm:inline-flex"
+          >
+            Install →
+          </Link>
+        </nav>
+      </div>
+    </header>
+  );
+}
+
+interface ResourceLinkProps {
+  href: string;
+  label: string;
+  srLabel: string;
+}
+
+function ResourceLink({ href, label, srLabel }: ResourceLinkProps) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group relative px-1.5 py-1 font-mono text-[11px] uppercase tracking-[0.16em] text-text-muted transition-colors hover:text-text-primary sm:px-2"
+      aria-label={srLabel}
+    >
+      <span
+        aria-hidden="true"
+        className="absolute inset-x-1 -bottom-0.5 h-px origin-left scale-x-0 bg-accent-primary/70 transition-transform duration-300 group-hover:scale-x-100"
+      />
+      {label}
+    </a>
+  );
+}

--- a/webapp/src/lib/links.ts
+++ b/webapp/src/lib/links.ts
@@ -1,0 +1,23 @@
+/**
+ * Single source of truth for external resource URLs surfaced in the UI.
+ *
+ * Update here once and every header/footer/button picks it up.
+ */
+
+export const EXTERNAL_LINKS = {
+  github: "https://github.com/mnemonik-xyz/monorepo",
+  whitepaper:
+    "https://github.com/mnemonik-xyz/monorepo/blob/main/docs/WHITEPAPER.md",
+  quickstart:
+    "https://github.com/mnemonik-xyz/monorepo/blob/main/docs/QUICKSTART.md",
+  howItWorks:
+    "https://github.com/mnemonik-xyz/monorepo/blob/main/docs/how-it-works.md",
+  paper:
+    "https://github.com/mnemonik-xyz/monorepo/blob/main/docs/research/paper.pdf",
+  discord: "https://discord.gg/ws6wruJj",
+  // Telegram group — placeholder; swap in the real invite link when issued.
+  telegram: "https://t.me/mnemonik_xyz",
+  issues: "https://github.com/mnemonik-xyz/monorepo/issues",
+} as const;
+
+export type ExternalLinkKey = keyof typeof EXTERNAL_LINKS;

--- a/webapp/src/pages/Landing.tsx
+++ b/webapp/src/pages/Landing.tsx
@@ -1,114 +1,453 @@
 import { Link } from "react-router-dom";
+import SiteFooter from "../components/SiteFooter";
+import SiteHeader from "../components/SiteHeader";
+import { EXTERNAL_LINKS } from "../lib/links";
 
 /**
  * Landing page (`/`).
  *
  * Tone per ux-guidelines.md: technical / precise. Short, factual sentences. No
  * marketing fluff, no exclamation marks, no emojis.
+ *
+ * Aesthetic direction: editorial-cryptographic ledger. Mono-numerals as the
+ * personality marker, hairline rules, asymmetric step indices, atmospheric
+ * background mesh — without leaving the existing dark + mint + Solana-purple
+ * palette.
  */
 export default function Landing() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center px-4 py-12">
-      <div className="w-full max-w-2xl space-y-10">
-        <header className="space-y-3 text-center">
-          <h1 className="text-4xl font-bold tracking-tight text-accent-primary sm:text-5xl">
-            Verifiable memory for AI agents
+    <div className="relative min-h-screen overflow-hidden">
+      <BackdropMesh />
+      <SiteHeader />
+
+      <main className="relative">
+        <Hero />
+        <Quickstart />
+        <HowItWorks />
+        <ResourceStrip />
+      </main>
+
+      <SiteFooter />
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                 Backdrop                                   */
+/* -------------------------------------------------------------------------- */
+
+function BackdropMesh() {
+  return (
+    <div
+      aria-hidden="true"
+      className="pointer-events-none absolute inset-0 -z-10 overflow-hidden"
+    >
+      {/* Soft mint glow, top-left */}
+      <div className="absolute -top-40 -left-40 h-[34rem] w-[34rem] rounded-full bg-accent-primary/10 blur-3xl" />
+      {/* Solana-purple counterweight, bottom-right */}
+      <div className="absolute -bottom-32 -right-32 h-[28rem] w-[28rem] rounded-full bg-accent-secondary/10 blur-3xl" />
+      {/* Hairline grid */}
+      <svg
+        className="absolute inset-0 h-full w-full opacity-[0.04]"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <defs>
+          <pattern
+            id="hairgrid"
+            width="48"
+            height="48"
+            patternUnits="userSpaceOnUse"
+          >
+            <path
+              d="M 48 0 L 0 0 0 48"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="0.5"
+            />
+          </pattern>
+        </defs>
+        <rect width="100%" height="100%" fill="url(#hairgrid)" />
+      </svg>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                   Hero                                     */
+/* -------------------------------------------------------------------------- */
+
+function Hero() {
+  return (
+    <section className="mx-auto flex min-h-[78vh] max-w-6xl flex-col justify-center gap-12 px-4 py-20 sm:px-6 md:py-28">
+      <div className="grid gap-12 md:grid-cols-[1.4fr_1fr] md:items-end">
+        <div className="space-y-7">
+          <div className="flex items-center gap-3 font-mono text-[11px] uppercase tracking-[0.22em] text-accent-primary">
+            <span
+              aria-hidden="true"
+              className="inline-block h-px w-10 bg-accent-primary"
+            />
+            <span>Mnemonic Protocol · v0.1</span>
+          </div>
+
+          <h1 className="text-balance text-5xl font-bold leading-[1.05] tracking-tight text-text-primary sm:text-6xl md:text-7xl">
+            Verifiable memory{" "}
+            <span className="block text-accent-primary">for AI agents.</span>
           </h1>
-          <p className="text-lg text-text-muted">
-            Persistent, signed, on-chain-anchored attestations for AI workflows.
+
+          <p className="max-w-xl text-balance text-lg leading-relaxed text-text-muted">
+            Persistent. Signed. Anchored on-chain. Memories your agents can
+            carry across providers, sessions, and tools — and any third party
+            can verify.
           </p>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+            <Link
+              to="/install"
+              className="group inline-flex items-center justify-center gap-2 rounded-md bg-accent-primary px-6 py-3 text-sm font-semibold text-background shadow-[0_0_24px_-6px_var(--color-accent-primary)] transition-all hover:-translate-y-0.5 hover:shadow-[0_0_32px_-4px_var(--color-accent-primary)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-primary"
+              data-testid="cta-get-started"
+            >
+              Get started
+              <span
+                aria-hidden="true"
+                className="transition-transform group-hover:translate-x-0.5"
+              >
+                →
+              </span>
+            </Link>
+            <Link
+              to="/chat"
+              className="inline-flex items-center justify-center gap-2 rounded-md border border-white/15 px-6 py-3 text-sm font-semibold text-text-primary transition-colors hover:border-accent-secondary hover:text-accent-secondary"
+            >
+              Try the protocol chat
+            </Link>
+          </div>
+        </div>
+
+        <aside className="md:pl-6">
+          <blockquote className="border-l border-accent-primary/40 pl-6">
+            <p className="font-serif text-2xl italic leading-snug text-text-primary/90">
+              Trustless agents cannot work without trustless agentic memory.
+            </p>
+            <footer className="mt-4 font-mono text-[11px] uppercase tracking-[0.2em] text-text-muted">
+              — Protocol thesis
+            </footer>
+          </blockquote>
+
+          <dl className="mt-10 grid grid-cols-3 gap-4 text-center">
+            <Stat label="Bits / dim" value="2–4" caption="TurboQuant" />
+            <Stat label="Anchor" value="Solana" caption="SPL Memo" />
+            <Stat label="Storage" value="Arweave" caption="Permanent" />
+          </dl>
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  caption,
+}: {
+  label: string;
+  value: string;
+  caption: string;
+}) {
+  return (
+    <div className="flex flex-col items-center gap-1 rounded-md border border-white/5 bg-white/[0.02] px-2 py-3">
+      <dt className="font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted">
+        {label}
+      </dt>
+      <dd className="text-lg font-semibold tracking-tight text-text-primary">
+        {value}
+      </dd>
+      <span className="font-mono text-[10px] uppercase tracking-[0.16em] text-accent-primary/80">
+        {caption}
+      </span>
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                Quickstart                                  */
+/* -------------------------------------------------------------------------- */
+
+const QUICKSTART_STEPS = [
+  {
+    chip: "Open",
+    title: "Open the install page",
+    body: "Go to mnemonik.xyz/install in your everyday browser. One page handles identity, IDE wiring, and OAuth in a single flow.",
+    meta: "~5s",
+  },
+  {
+    chip: "Identity",
+    title: "Create your identity",
+    body: "Your browser generates an Ed25519 keypair locally. The private key never leaves the device. The public key is your identity across every IDE, every device, every model.",
+    meta: "1 click",
+  },
+  {
+    chip: "Install",
+    title: "Install into the IDE of your choice",
+    body: "Cursor, Claude Desktop, VS Code, Windsurf — pick your tool, click install, finish OAuth. The Mnemonic tools appear in your IDE's tool list automatically.",
+    meta: "Any MCP client",
+  },
+  {
+    chip: "Sign",
+    title: "Ask your agent to store something",
+    body: 'Just talk to it. "Remember that we shipped v0.2 on Tuesday with Alex as release owner." The agent calls mnemonic_sign_memory; the record is signed and anchored on-chain.',
+    meta: "mnemonic_sign_memory",
+  },
+  {
+    chip: "Recall",
+    title: "Recall it from another device, another IDE",
+    body: 'Re-import the same identity on a different device. Ask the agent: "What did we decide about the v0.2 release?" It searches by meaning, not keyword, and returns your signed memories — verifiable by anyone.',
+    meta: "mnemonic_recall",
+  },
+];
+
+function Quickstart() {
+  return (
+    <section
+      aria-labelledby="quickstart"
+      className="border-y border-white/5 bg-white/[0.015]"
+      data-testid="quickstart"
+    >
+      <div className="mx-auto max-w-6xl px-4 py-20 sm:px-6 md:py-24">
+        <header className="mb-14 grid gap-6 md:grid-cols-[1fr_auto] md:items-end">
+          <div className="space-y-3">
+            <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-accent-primary">
+              Quickstart · 5 steps
+            </p>
+            <h2
+              id="quickstart"
+              className="text-balance text-4xl font-bold leading-tight tracking-tight text-text-primary sm:text-5xl"
+            >
+              From zero to{" "}
+              <em className="font-serif text-accent-primary not-italic">
+                cross-device recall
+              </em>
+              .
+            </h2>
+            <p className="max-w-xl text-text-muted">
+              The whole loop — sign on Device A, recall on Device B — runs
+              entirely through the webapp and your IDE of choice.
+            </p>
+          </div>
+          <a
+            href={EXTERNAL_LINKS.quickstart}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group inline-flex items-center gap-2 self-start rounded-sm border border-white/10 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.18em] text-text-muted transition-colors hover:border-accent-primary hover:text-accent-primary md:self-end"
+          >
+            Read the doc
+            <span
+              aria-hidden="true"
+              className="transition-transform group-hover:translate-x-0.5"
+            >
+              ↗
+            </span>
+          </a>
         </header>
 
-        <section className="space-y-6 text-left">
-          <p className="leading-relaxed text-text-primary">
-            Mnemonic Protocol stores agent memory as portable cryptographic
-            attestations: each memory is canonicalized to deterministic CBOR,
-            blake3-hashed, COSE_Sign1-signed with an Ed25519 identity, and
-            optionally anchored on Arweave with a Solana SPL Memo timestamp.
-          </p>
-          <p className="leading-relaxed text-text-primary">
-            Agents recall by semantic similarity over their own attestations,
-            with cryptographic provenance. Memories survive across providers,
-            sessions, and tools — and any tampering is detectable.
-          </p>
-          <p className="leading-relaxed text-text-muted italic">
-            Trustless agents cannot work without trustless agentic memory.
-          </p>
-        </section>
+        <ol className="relative space-y-6">
+          {/* Vertical ledger rail */}
+          <div
+            aria-hidden="true"
+            className="absolute left-[2.65rem] top-2 bottom-2 hidden w-px bg-gradient-to-b from-accent-primary/40 via-white/5 to-transparent md:block"
+          />
 
-        <nav className="flex flex-col items-center gap-4 sm:flex-row sm:justify-center">
+          {QUICKSTART_STEPS.map((step, idx) => (
+            <li
+              key={step.chip}
+              className="group relative grid grid-cols-[auto_1fr] gap-4 sm:grid-cols-[auto_1fr_auto] sm:gap-6"
+            >
+              <Index n={idx + 1} />
+              <div className="flex flex-col gap-2 rounded-md border border-white/5 bg-background/60 px-5 py-4 backdrop-blur-sm transition-colors group-hover:border-accent-primary/40">
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="rounded-sm bg-accent-primary/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.18em] text-accent-primary">
+                    {step.chip}
+                  </span>
+                  <h3 className="text-lg font-semibold tracking-tight text-text-primary">
+                    {step.title}
+                  </h3>
+                </div>
+                <p className="text-[15px] leading-relaxed text-text-muted">
+                  {step.body}
+                </p>
+              </div>
+              <span className="hidden self-center font-mono text-[10px] uppercase tracking-[0.18em] text-text-muted/70 sm:block">
+                {step.meta}
+              </span>
+            </li>
+          ))}
+        </ol>
+
+        <div className="mt-14 flex flex-col items-start gap-4 rounded-md border border-accent-primary/20 bg-accent-primary/[0.04] p-6 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="font-mono text-[11px] uppercase tracking-[0.2em] text-accent-primary">
+              Next
+            </p>
+            <p className="mt-1 max-w-xl text-text-primary">
+              Start with the install page. Generation, signing, and recall all
+              happen behind the same OAuth handshake.
+            </p>
+          </div>
           <Link
             to="/install"
-            className="rounded-md bg-accent-primary px-6 py-3 text-sm font-semibold text-background transition-opacity hover:opacity-90 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-primary"
-            data-testid="cta-get-started"
+            className="inline-flex items-center gap-2 rounded-md bg-accent-primary px-5 py-2.5 text-sm font-semibold text-background transition-opacity hover:opacity-90"
           >
-            Get started
+            Open install
+            <span aria-hidden="true">→</span>
           </Link>
-          <Link
-            to="/chat"
-            className="rounded-md border border-text-muted/30 px-6 py-3 text-sm font-semibold text-text-primary transition-colors hover:border-accent-secondary hover:text-accent-secondary"
-          >
-            Try the protocol chat
-          </Link>
-        </nav>
-
-        <section
-          aria-labelledby="how-it-works"
-          className="space-y-6 text-left"
-          data-testid="how-it-works"
-        >
-          <h2
-            id="how-it-works"
-            className="text-2xl font-semibold text-text-primary"
-          >
-            How it works
-          </h2>
-          <ol className="space-y-4">
-            <li className="rounded-md border border-text-muted/20 bg-white/5 p-4">
-              <p className="text-sm font-semibold text-accent-primary">
-                1 · Generate an Ed25519 keypair
-              </p>
-              <p className="mt-1 text-sm text-text-muted">
-                The keypair lives in your browser&rsquo;s local storage. The
-                public key is your portable identity across providers; the
-                secret key never leaves the device.
-              </p>
-            </li>
-            <li className="rounded-md border border-text-muted/20 bg-white/5 p-4">
-              <p className="text-sm font-semibold text-accent-primary">
-                2 · Install the MCP connector in your AI tool
-              </p>
-              <p className="mt-1 text-sm text-text-muted">
-                Cursor and VS Code accept a deeplink; Claude.ai takes a custom
-                connector URL; WindSurf takes a JSON snippet for
-                <code>mcp_config.json</code>. All four negotiate OAuth 2.1 +
-                PKCE against <code>mcp.mnemonik.xyz</code>.
-              </p>
-            </li>
-            <li className="rounded-md border border-text-muted/20 bg-white/5 p-4">
-              <p className="text-sm font-semibold text-accent-primary">
-                3 · Sign memories from any tool
-              </p>
-              <p className="mt-1 text-sm text-text-muted">
-                When the agent calls <code>mnemonic_sign_memory</code>, the
-                server prepares the canonical-CBOR payload and redirects to this
-                webapp; you approve in-browser, your keypair signs a COSE_Sign1
-                envelope, and the server persists the attestation.
-              </p>
-            </li>
-            <li className="rounded-md border border-text-muted/20 bg-white/5 p-4">
-              <p className="text-sm font-semibold text-accent-primary">
-                4 · Recall and verify across providers
-              </p>
-              <p className="mt-1 text-sm text-text-muted">
-                Any tool authenticated with the same keypair can recall by
-                semantic similarity and verify the Arweave + Solana anchors.
-                Tampering is detectable; provenance is cryptographic.
-              </p>
-            </li>
-          </ol>
-        </section>
+        </div>
       </div>
-    </main>
+    </section>
+  );
+}
+
+function Index({ n }: { n: number }) {
+  return (
+    <div className="relative flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-white/10 bg-background font-mono text-sm tracking-tight text-accent-primary shadow-[inset_0_0_0_1px_rgba(0,212,180,0.08)]">
+      {String(n).padStart(2, "0")}
+    </div>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              How it works                                  */
+/* -------------------------------------------------------------------------- */
+
+function HowItWorks() {
+  const steps = [
+    {
+      label: "01 · Identity",
+      title: "Generate an Ed25519 keypair",
+      body: "The keypair lives in your browser's local storage. The public key is your portable identity across providers; the secret never leaves the device.",
+    },
+    {
+      label: "02 · Install",
+      title: "Connect Mnemonic to your AI tool",
+      body: "Cursor and VS Code accept a deeplink; Claude.ai takes a custom connector URL; Windsurf takes a JSON snippet. All four negotiate OAuth 2.1 + PKCE against mcp.mnemonik.xyz.",
+    },
+    {
+      label: "03 · Sign",
+      title: "Sign memories from any tool",
+      body: "When the agent calls mnemonic_sign_memory, the server prepares the canonical-CBOR payload and redirects here; you approve in-browser, your keypair signs a COSE_Sign1 envelope, and the server persists the attestation.",
+    },
+    {
+      label: "04 · Recall",
+      title: "Recall and verify across providers",
+      body: "Any tool authenticated with the same keypair can recall by semantic similarity and verify the Arweave + Solana anchors. Tampering is detectable; provenance is cryptographic.",
+    },
+  ];
+
+  return (
+    <section
+      aria-labelledby="how-it-works"
+      className="mx-auto max-w-6xl px-4 py-20 sm:px-6 md:py-28"
+      data-testid="how-it-works"
+    >
+      <header className="mb-12 max-w-3xl space-y-3">
+        <p className="font-mono text-[11px] uppercase tracking-[0.22em] text-accent-secondary">
+          Under the hood
+        </p>
+        <h2
+          id="how-it-works"
+          className="text-balance text-4xl font-bold leading-tight tracking-tight text-text-primary sm:text-5xl"
+        >
+          How it works
+        </h2>
+        <p className="text-text-muted">
+          Four moving parts. Each one inspectable, each one independently
+          verifiable, no opaque vendor in the path.
+        </p>
+      </header>
+
+      <ol className="grid gap-px overflow-hidden rounded-lg bg-white/5 md:grid-cols-2">
+        {steps.map((step) => (
+          <li
+            key={step.label}
+            className="relative flex flex-col gap-3 bg-background/95 p-7 transition-colors hover:bg-background"
+          >
+            <span className="font-mono text-[11px] uppercase tracking-[0.2em] text-accent-primary">
+              {step.label}
+            </span>
+            <h3 className="text-lg font-semibold tracking-tight text-text-primary">
+              {step.title}
+            </h3>
+            <p className="text-[15px] leading-relaxed text-text-muted">
+              {step.body}
+            </p>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                              Resource strip                                */
+/* -------------------------------------------------------------------------- */
+
+function ResourceStrip() {
+  const cards = [
+    {
+      label: "Whitepaper",
+      desc: "Architecture, threat model, design rationale.",
+      href: EXTERNAL_LINKS.whitepaper,
+    },
+    {
+      label: "Source",
+      desc: "Open-source Rust workspace + webapp on GitHub.",
+      href: EXTERNAL_LINKS.github,
+    },
+    {
+      label: "Discord",
+      desc: "Builders, researchers, protocol questions.",
+      href: EXTERNAL_LINKS.discord,
+    },
+    {
+      label: "Telegram",
+      desc: "Community channel for ongoing announcements.",
+      href: EXTERNAL_LINKS.telegram,
+    },
+  ];
+
+  return (
+    <section
+      aria-labelledby="resources"
+      className="mx-auto max-w-6xl px-4 pb-20 sm:px-6"
+    >
+      <h2
+        id="resources"
+        className="mb-6 font-mono text-[11px] uppercase tracking-[0.22em] text-text-muted"
+      >
+        Resources
+      </h2>
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        {cards.map((c) => (
+          <a
+            key={c.label}
+            href={c.href}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group relative overflow-hidden rounded-md border border-white/10 bg-white/[0.02] p-5 transition-all hover:-translate-y-0.5 hover:border-accent-primary/40 hover:bg-white/[0.04]"
+          >
+            <div className="flex items-center justify-between font-mono text-[11px] uppercase tracking-[0.18em] text-accent-primary">
+              <span>{c.label}</span>
+              <span
+                aria-hidden="true"
+                className="transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+              >
+                ↗
+              </span>
+            </div>
+            <p className="mt-3 text-sm leading-relaxed text-text-muted">
+              {c.desc}
+            </p>
+          </a>
+        ))}
+      </div>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary

Lands a refreshed landing page with the missing quickstart content and a site-wide masthead/footer, while preserving the existing palette, CSP, and all test hooks. No backend changes, no routing changes, no broken pages.

## What's new

- **Quickstart section** (5 steps, ledger-style) — open install → create identity → install into IDE → ask agent to remember → recall from another device / IDE. Each row carries a mono-padded index, a label chip, body copy, and a metadata column on desktop.
- **`SiteHeader`** — sticky masthead with terse mono links: GitHub, Whitepaper, Discord, Telegram. Pill CTA to `/install`.
- **`SiteFooter`** — research-paper colophon: Read / Build / Talk columns, full external-link inventory, copyright + license line.
- **`webapp/src/lib/links.ts`** — single source of truth for external resource URLs. Update once, every header/footer/button picks it up. Telegram URL is a placeholder (`t.me/mnemonik_xyz`) until the group is live; swap in one place.
- **Hero polish** — tightened type scale, pull-quote in serif italic, three-stat shelf (TurboQuant bit width, Solana SPL Memo anchor, Arweave permanent storage).
- **Backdrop** — layered radial glows + hairline grid SVG. No external assets, no CSP changes.

## Aesthetic direction

Editorial-cryptographic ledger. Mono-numerals as the personality marker, hairline rules at low opacity, asymmetric quickstart rail, accent micro-copy in the existing palette pushed to be more disciplined. No purple gradients, no generic SaaS shapes.

## Compatibility

- Same Tailwind theme tokens (`accent-primary`, `accent-secondary`, `background`, `text-primary`, `text-muted`).
- CSP unchanged. No external font, no external image, no external script.
- All existing test hooks preserved: `data-testid=\"cta-get-started\"`, `data-testid=\"how-it-works\"`, `id=\"how-it-works\"`.
- Routing untouched.

## Build / test

- \`tsc -b\` — clean.
- \`vitest run\` — IdentityPanel + InstallButtons tests pass. Two failing suites (\`Sign.test.tsx\` countdown, \`Sign.cbor.test.tsx\` WASM import) reproduce on \`main\` without this change; pre-existing.
- \`vite dev\` boots clean, landing returns HTTP 200.
- Production \`vite build\` requires \`wasm-pack\` (existing build dependency, unrelated to this PR).

## Test plan

- [ ] Visual review on \`/\` — hero, quickstart, how it works, resource strip, footer all render.
- [ ] Click each header link (GitHub, Whitepaper, Discord, Telegram) — opens the correct URL in a new tab.
- [ ] Click \`Install →\` in header — routes to \`/install\` without a full reload.
- [ ] Hero CTAs (\`Get started\`, \`Try the protocol chat\`) still navigate.
- [ ] Telegram link points to a real invite (currently a placeholder in \`webapp/src/lib/links.ts\`).
- [ ] Mobile: header collapses sensibly (Install pill is desktop-only by design); quickstart steps stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)