### PR TITLE
fix(webapp): move Discord and Telegram out of the header

### DIFF
--- a/webapp/src/components/SiteHeader.tsx
+++ b/webapp/src/components/SiteHeader.tsx
@@ -39,16 +39,6 @@ export default function SiteHeader() {
             label="Whitepaper"
             srLabel="Read the whitepaper"
           />
-          <ResourceLink
-            href={EXTERNAL_LINKS.discord}
-            label="Discord"
-            srLabel="Join the Discord server"
-          />
-          <ResourceLink
-            href={EXTERNAL_LINKS.telegram}
-            label="Telegram"
-            srLabel="Join the Telegram group"
-          />
           <Link
             to="/install"
             className="ml-2 hidden rounded-sm border border-accent-primary/40 bg-accent-primary/10 px-3 py-1.5 font-mono text-[11px] uppercase tracking-[0.16em] text-accent-primary transition-colors hover:border-accent-primary hover:bg-accent-primary/20 sm:inline-flex"


### PR DESCRIPTION
## Summary

Discord and Telegram links removed from the site header. They remain in two lower locations: the resource strip near the bottom of the landing page, and the footer's \"Talk\" column.

The masthead now carries only GitHub, Whitepaper, and the Install CTA — primary navigation only.

## Test plan

- [ ] Header shows GitHub, Whitepaper, and Install only.
- [ ] Discord and Telegram still reachable in the resource strip and the footer.
- [ ] Mobile masthead unchanged in shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)