### PR TITLE
fix(webapp): Quickstart link → docs/quickstart.md (lowercase)

### DIFF
--- a/webapp/src/lib/links.ts
+++ b/webapp/src/lib/links.ts
@@ -9,7 +9,7 @@ export const EXTERNAL_LINKS = {
   whitepaper:
     "https://github.com/mnemonik-xyz/monorepo/blob/main/docs/WHITEPAPER.md",
   quickstart:
-    "https://github.com/mnemonik-xyz/monorepo/blob/main/docs/QUICKSTART.md",
+    "https://github.com/mnemonik-xyz/monorepo/blob/main/docs/quickstart.md",
   howItWorks:
     "https://github.com/mnemonik-xyz/monorepo/blob/main/docs/how-it-works.md",
   paper:


### PR DESCRIPTION
Resolves 'Read the doc' to the canonical lowercase quickstart file.