### PR TITLE
feat(webapp): group Whitepaper + ResearchGate into a Docs dropdown

### DIFF
--- a/webapp/src/components/SiteHeader.tsx
+++ b/webapp/src/components/SiteHeader.tsx
@@ -1,10 +1,12 @@
+import { useEffect, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { EXTERNAL_LINKS } from "../lib/links";
 
 /**
  * Sticky minimal site header. Three zones:
- *   left  — wordmark anchored to /
- *   right — terse mono links to the public resources
+ *   left   — wordmark anchored to /
+ *   centre — Docs dropdown (Whitepaper, ResearchGate) + GitHub link
+ *   right  — Install pill (desktop only)
  *
  * Designed to read like a research-paper masthead, not a marketing nav.
  */
@@ -29,20 +31,11 @@ export default function SiteHeader() {
           aria-label="External resources"
           className="flex items-center gap-1 sm:gap-3"
         >
+          <DocsMenu />
           <ResourceLink
             href={EXTERNAL_LINKS.github}
             label="GitHub"
             srLabel="GitHub repository"
-          />
-          <ResourceLink
-            href={EXTERNAL_LINKS.whitepaper}
-            label="Whitepaper"
-            srLabel="Read the whitepaper"
-          />
-          <ResourceLink
-            href={EXTERNAL_LINKS.researchgate}
-            label="ResearchGate"
-            srLabel="ResearchGate publication"
           />
           <Link
             to="/install"
@@ -76,6 +69,121 @@ function ResourceLink({ href, label, srLabel }: ResourceLinkProps) {
         className="absolute inset-x-1 -bottom-0.5 h-px origin-left scale-x-0 bg-accent-primary/70 transition-transform duration-300 group-hover:scale-x-100"
       />
       {label}
+    </a>
+  );
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                Docs dropdown                                */
+/* -------------------------------------------------------------------------- */
+
+function DocsMenu() {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onPointerDown(e: PointerEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("pointerdown", onPointerDown);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className="group inline-flex items-center gap-1 px-1.5 py-1 font-mono text-[11px] uppercase tracking-[0.16em] text-text-muted transition-colors hover:text-text-primary sm:px-2"
+      >
+        <span className="relative">
+          <span
+            aria-hidden="true"
+            className={`absolute inset-x-0 -bottom-0.5 h-px origin-left bg-accent-primary/70 transition-transform duration-300 ${
+              open ? "scale-x-100" : "scale-x-0 group-hover:scale-x-100"
+            }`}
+          />
+          Docs
+        </span>
+        <span
+          aria-hidden="true"
+          className={`text-[9px] transition-transform duration-200 ${
+            open ? "rotate-180" : ""
+          }`}
+        >
+          ▾
+        </span>
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          aria-label="Documentation"
+          className="absolute right-0 top-full z-40 mt-2 min-w-[14rem] overflow-hidden rounded-md border border-white/10 bg-background/95 shadow-[0_14px_32px_-12px_rgba(0,0,0,0.6)] backdrop-blur-md"
+        >
+          <DocsMenuItem
+            href={EXTERNAL_LINKS.whitepaper}
+            label="Whitepaper"
+            sub="Architecture · threat model · rationale"
+            onSelect={() => setOpen(false)}
+          />
+          <div className="h-px bg-white/5" aria-hidden="true" />
+          <DocsMenuItem
+            href={EXTERNAL_LINKS.researchgate}
+            label="ResearchGate"
+            sub="Sublinear Verifiable Recall — publication"
+            onSelect={() => setOpen(false)}
+          />
+        </div>
+      )}
+    </div>
+  );
+}
+
+function DocsMenuItem({
+  href,
+  label,
+  sub,
+  onSelect,
+}: {
+  href: string;
+  label: string;
+  sub: string;
+  onSelect: () => void;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      role="menuitem"
+      onClick={onSelect}
+      className="group block px-4 py-3 transition-colors hover:bg-white/[0.04] focus-visible:bg-white/[0.06] focus-visible:outline-none"
+    >
+      <div className="flex items-center justify-between gap-3 font-mono text-[11px] uppercase tracking-[0.18em] text-accent-primary">
+        <span>{label}</span>
+        <span
+          aria-hidden="true"
+          className="transition-transform group-hover:translate-x-0.5 group-hover:-translate-y-0.5"
+        >
+          ↗
+        </span>
+      </div>
+      <p className="mt-1 font-sans text-[12px] leading-snug text-text-muted">
+        {sub}
+      </p>
     </a>
   );
 }


### PR DESCRIPTION
Header replaces the two flat paper links with a single 'Docs ▾' menu containing Whitepaper and ResearchGate (each with a short subtitle). Click-outside and Escape close. ARIA roles in place.