### PR TITLE
docs(chrome-extension): seed user-spec, tech-spec, decisions, tasks 01-09

### DIFF
--- a/work/chrome-extension/backlog.md
+++ b/work/chrome-extension/backlog.md
@@ -1,0 +1,87 @@
+# Backlog — `chrome-extension/` (Phase 1.5+)
+
+Items deliberately deferred from Phase 1. Architecture must remain open for them but no implementation work happens until promoted to a task.
+
+## Platform reach
+
+- Firefox port (Manifest V3 in Firefox is now stable). Most code reusable; service-worker → background-script differences abstracted.
+- Safari port (Xcode wrapper, `safari-web-extension-converter`). Embedder model size review (App Store limits).
+- Edge / Brave / Arc — should work as-is on Chromium build; smoke-test before Web Store submission.
+
+## More chat adapters
+
+- Grok (`x.com/i/grok`)
+- Perplexity (`perplexity.ai`)
+- Poe (`poe.com`)
+- OpenRouter playground (`openrouter.ai`)
+- t3.chat
+- Mistral Le Chat (`chat.mistral.ai`)
+- DeepSeek chat
+- Local-LLM web UIs (Ollama UI, LM Studio web export, OpenWebUI)
+- Cursor / Windsurf web (when shipped)
+
+Each = new adapter module + HAR fixture + registry entry. Decision D10 makes this a small, isolated change.
+
+## Capture / recall enhancements
+
+- `findInputBox` impl for Claude.ai + Gemini + others (Phase 1 ships only ChatGPT). Enables "Insert into chat" recall on all platforms.
+- Auto-capture: per-domain background watcher that incrementally builds a draft attestation and signs at session end / user click. Off by default (D12).
+- Inline floating "Save this turn" button next to each assistant message (instead of FAB only).
+- Smart tagging: extract `model:`, `chat_id:`, `topic:` from page meta automatically.
+- Multi-turn snapshotting (snapshot every N turns automatically as separate attestations).
+- Diff between attestations of the same chat over time (was this conversation edited later?).
+- Attach screenshot of chat at capture time (proof-of-rendering).
+
+## Identity & auth
+
+- WebAuthn / passkey wrap (replace Argon2id passphrase) — better UX, no passphrase to remember, but requires per-device passkey enrollment story.
+- Apple Sign-in alongside Google.
+- "Sign in with Solana wallet" alongside Google (for power users; bridge to existing webapp Solana OAuth).
+- Multi-account profiles (`@work`, `@personal` keypairs).
+- Hardware-key (Yubikey/Ledger) signing path.
+- Recovery via Shamir threshold (3-of-5 social recovery, optional alternative to passphrase).
+
+## Cloud / sync
+
+- E2EE attestation content (encrypt payload before upload; recall does encrypted vector search via [Tahoe-LAFS-style] partial decrypt).
+- Selective sync (per-tag sync rules; e.g. `tag:work` syncs to cloud, `tag:personal` stays local).
+- Conflict resolution UI (when two devices add attestations offline).
+- Merkle proof of cloud-hosted attestation set (server publishes daily merkle root on Solana; extension verifies).
+- Incremental sync (delta protocol; not full re-pull on restore).
+
+## Recall UX
+
+- "Smart suggest" — when typing in any AI chat input, popup hint "you have 3 related memories" → click to insert.
+- Memory chains (lineage edges) visualized as a graph in popup.
+- Markdown rendering in recall preview (not just raw text).
+- Filter by source platform (`only ChatGPT`, `only Claude`).
+- Time-decay reranking option.
+
+## Distribution
+
+- Chrome Web Store featured listing application.
+- Microsoft Edge Add-ons store submission (Manifest V3 compatible).
+- Self-hosted `.crx` for enterprise (sideload distribution).
+- Update channel (stable / beta).
+- Telemetry pipeline (opt-in, anonymous adapter-broken / cold-start / sync-error metrics).
+
+## Developer / extensibility
+
+- Public `ChatAdapter` SDK for community-contributed adapters (separate npm package).
+- Extension-to-extension messaging API so other extensions can `signMemory(content)` through Mnemonik.
+- Programmatic recall API (other extensions query Mnemonik for context).
+- MCP-from-extension (extension hosts a tiny MCP-stdio bridge for IDE integrations).
+
+## Performance
+
+- Replace `transformers.js` MiniLM with quantized INT8 build (~10MB) once it ships.
+- Replace `442KB` WASM with `@noble/curves` + custom CBOR (already in `work/mnemonic-cli/backlog.md`); shrink popup cold-start.
+- Pre-warm embedder on extension install (idle service-worker download).
+- IndexedDB compaction on `navigator.storage.persist` quota pressure.
+
+## Compliance / trust
+
+- SOC2 / GDPR data-handling addendum for cloud-tier (when user count justifies).
+- Privacy-policy generator that adapts to active permissions.
+- "Data export" one-click (download all attestations as `.zip` of COSE bundles + .md).
+- "Right to erasure" — DELETE all data on server + local on user request.

--- a/work/chrome-extension/decisions.md
+++ b/work/chrome-extension/decisions.md
@@ -1,0 +1,122 @@
+# Decisions — `work/chrome-extension/`
+
+Append-only log of decisions and audit findings. Each entry: date, decision, rationale, alternatives considered.
+
+---
+
+## 2026-05-10 · D1 — Extension is fully self-contained for local mode
+
+Embed / compress / sign / store all run in the browser via WASM (`@mnemonic/core`) + `transformers.js`. Cloud mode is a thin client to the existing hosted MCP-`full` HTTP surface.
+
+**Rationale:** local-mode true privacy ("data never leaves the device") is a marketable differentiator and matches the project's privacy-first positioning. Reuses already-planned WASM exports.
+
+**Alternatives:** (a) thin UI talking to server in all modes — rejected (no offline, no privacy story, paid even for trivial use); (b) hybrid — rejected as worst-of-both.
+
+---
+
+## 2026-05-10 · D2 — Server `StorageMode` is unchanged
+
+`mcp/src/config.rs:95` keeps `local | full`. "Cloud" is purely UX naming in the extension that maps to hosted-`full`.
+
+**Rationale:** avoids new Rust enum variant, `S3Store` impl, AWS SDK in Cargo. Cloud-tier infra is an operational concern (which AWS region runs `STORAGE_MODE=full`), not a code change.
+
+**Alternatives:** add `cloud` variant with `S3Store` — rejected as scope creep without product benefit.
+
+---
+
+## 2026-05-10 · D3 — Browser embedder
+
+`transformers.js` + `Xenova/all-MiniLM-L6-v2` (384 dim, ~25MB ONNX). Lazy-loaded in a Web Worker on first sign. Cached via Cache API.
+
+**Rationale:** vector dim 384 must match server default (golden-fixture parity). Smallest viable model with strong performance. Web Worker keeps popup responsive.
+
+**Alternatives:** (a) call server embed API — rejected, breaks local-mode offline; (b) larger model — rejected for bundle size; (c) build custom embedder via `core/` WASM — rejected, fastembed not in WASM target today.
+
+**Re-evaluate:** post-MVP if 25MB is too heavy on slow networks; consider quantized MiniLM-INT8 (~10MB).
+
+---
+
+## 2026-05-10 · D4 — Build tool: WXT (default), Vite + crxjs (fallback)
+
+Final pick during T1 spike.
+
+**Rationale:** WXT auto-handles MV3 quirks (HMR for service worker, content-script hot reload), reduces boilerplate. crxjs is more mature but slower dev loop.
+
+---
+
+## 2026-05-10 · D5 — Google OAuth via `chrome.identity.launchWebAuthFlow` + PKCE S256
+
+No Google client_secret in extension; server holds it. Server validates Google `id_token` (issuer + audience + signature against cached JWKS), then issues our own JWT (`aud=mcp` + `google_sub` claim). First link requires possession proof (extension signs a server-issued challenge with the new Ed25519 keypair).
+
+**Rationale:** standard OAuth 2.1 web client flow, no custom secret distribution risk in the extension. Possession proof prevents an attacker who steals a Google account from claiming an existing on-chain identity.
+
+**Alternatives:** (a) `chrome.identity.getAuthToken` (Google-specific, simpler) — rejected, ties us to Chrome-store distribution and Chrome-only; web flow works on Edge/Brave/Arc unchanged.
+
+---
+
+## 2026-05-10 · D6 — One Ed25519 keypair per user across CLI / webapp / extension
+
+Cross-device sync is via either (a) restore-on-Google-signin (new) or (b) existing bootstrap-ticket flow.
+
+**Rationale:** consistent identity across all clients is the protocol's value prop. Multi-account is backlog.
+
+---
+
+## 2026-05-10 · D7 — Mode switching is explicit
+
+Local → Cloud uploads existing attestations one-by-one (best-effort, resumable queue). Cloud → Local exports + disconnects. No silent dual-write.
+
+**Rationale:** silent dual-write creates conflict resolution hell when the user runs offline on one device and online on another. Explicit user gesture sets expectations.
+
+---
+
+## 2026-05-10 · D8 — Primary feature is AI-chat capture, not generic page capture
+
+Phase 1 ships adapters for ChatGPT, Claude.ai, Gemini. Generic page-selection capture is a free fallback via `activeTab`. Auto-capture is opt-in per domain.
+
+**Rationale:** the user-stated primary use case is browser AI chats. Generic-capture-first would dilute positioning and require `<all_urls>` host_permission (Chrome Web Store review risk).
+
+**Alternatives:** (a) generic capture only — rejected, weak product story; (b) ChatGPT-only — rejected, locks out Claude/Gemini users; (c) all 5+ adapters Phase 1 — rejected for scope.
+
+---
+
+## 2026-05-10 · D9 — Encrypted key escrow for Google-login restore
+
+Server stores Ed25519 secret as a passphrase-encrypted blob keyed by Google `sub`.
+
+- KDF: Argon2id (`memory_cost=64MiB, time_cost=3, parallelism=1`, salt = 16 random bytes).
+- Cipher: AES-GCM-256, 96-bit nonce.
+- Server stores: `{ciphertext, nonce, kdf, kdf_params, pubkey_base58}`. No plaintext, no keys.
+- Rate limit: 5 GET fetches / 24h / `google_sub`.
+
+Server cannot decrypt. Lost passphrase = lost restore (user falls back to manual keypair import from another device).
+
+**Rationale:** standard zero-knowledge passphrase wrap. Argon2id parameters meet OWASP 2026 minimums. Rate limit bounds online brute force; KDF cost bounds offline brute force on stolen ciphertext.
+
+**Alternatives:** (a) server-held plaintext (or KMS-wrapped on server) — rejected, server compromise leaks all keys; (b) Shamir/threshold — rejected for MVP scope; (c) WebAuthn passkey wrap — backlog (better UX, harder to ship Phase 1 cross-device); (d) BIP-39 mnemonic — rejected, even worse UX than passphrase.
+
+---
+
+## 2026-05-10 · D10 — `ChatAdapter` interface keeps platform support extensible
+
+Flat registry, one adapter per supported domain. Phase 1: ChatGPT, Claude.ai, Gemini. Backlog: Grok, Perplexity, Poe, OpenRouter, t3.chat.
+
+**Rationale:** AI-chat UIs change; isolating per-platform DOM logic behind a stable interface lets us patch one adapter without touching the rest. Community contributions land as new adapter modules + HAR fixtures + entry in registry.
+
+---
+
+## 2026-05-10 · D11 — Enumerated host_permissions, no `<all_urls>`
+
+`manifest.json` declares only `https://chatgpt.com/*`, `https://claude.ai/*`, `https://gemini.google.com/*` (+ extension origin). Generic page-selection capture works via `activeTab` + user gesture (popup hotkey or context-menu).
+
+**Rationale:** Chrome Web Store review treats `<all_urls>` as high-risk; enumerated permissions ease approval. Adding new platforms is a versioned release.
+
+---
+
+## 2026-05-10 · D12 — Auto-capture is opt-in per domain, off by default
+
+Privacy default. User explicitly enables in options page per supported domain.
+
+**Rationale:** silent capture of every assistant response is a privacy red flag and a Chrome Web Store review risk. Opt-in keeps trust and review-friendliness.
+
+---

--- a/work/chrome-extension/tasks/01.md
+++ b/work/chrome-extension/tasks/01.md
@@ -1,0 +1,36 @@
+---
+status: pending
+depends_on: []
+wave: 1
+skills: [code-writing, ratify-decisions]
+verify: [pnpm-build]
+reviewers: [code-reviewer]
+teammate_name: T01-scaffold
+---
+
+# Task 01: Scaffold `packages/extension/` + ratify Decisions D1–D12
+
+## Description
+
+Create the `packages/extension/` workspace package, choose between WXT and Vite+crxjs (D4 spike), set up MV3 manifest skeleton, wire into root npm workspace. No domain code yet — this task delivers a buildable empty extension that loads in Chrome unpacked.
+
+Ratify D1–D12 in `decisions.md` after spike. If WXT shows blockers, document and fall back to Vite+crxjs as final choice.
+
+## What to do
+
+1. **Spike (≤4h):** create two throwaway scaffolds — one with `pnpm dlx wxt init`, one with `npm create @crxjs/vite-extension`. Compare: HMR for service worker, popup React DX, MV3 quirks, bundle size of empty extension. Record findings in `decisions.md` D4 ratification entry.
+2. Create `packages/extension/` with chosen tool. Layout: `manifest.json`, `src/background/service-worker.ts` (empty handler), `src/popup/index.html` + `src/popup/main.tsx` (React 19, "Hello Mnemonik"), `src/options/`, `tsconfig.json`, `package.json` (`@mnemonik-xyz/extension`, private, ESM).
+3. Add `packages/extension` to root `package.json` `workspaces` array (already includes `packages/*` per `work/mnemonic-cli` Phase 1 — verify).
+4. Manifest fields: `manifest_version: 3`, `name: "Mnemonik"`, `version: "0.1.0"`, `description`, `icons`, `action.default_popup`, `background.service_worker`, `permissions: ["storage", "identity", "contextMenus", "activeTab", "clipboardWrite", "alarms"]`, `host_permissions: []` (filled in T07–T09 per adapter). Set `commands` placeholder for `_execute_action` + `recall-overlay` hotkey.
+5. `pnpm -C packages/extension build` produces `dist/`. `web-ext lint dist/` clean.
+6. Document the chosen tool's dev workflow in `packages/extension/README.md` (one screen).
+
+## TDD Anchor
+
+- `packages/extension/tests/unit/scaffold.test.ts::dist_has_valid_manifest` — build and assert `dist/manifest.json` parses, has `manifest_version: 3`, has the expected permissions array. Drives D11 enumerated permissions.
+
+## Files
+
+- Create: `packages/extension/{manifest.json, package.json, tsconfig.json, vite.config.ts | wxt.config.ts, README.md}`, `packages/extension/src/{background/service-worker.ts, popup/index.html, popup/main.tsx, options/index.html, options/main.tsx}`, `packages/extension/tests/unit/scaffold.test.ts`.
+- Modify: root `package.json` (workspaces), `decisions.md` (ratify D4).
+- Read: `work/mnemonic-cli/tech-spec.md` (workspace pattern), `webapp/package.json` (Tailwind / React 19 versions).

--- a/work/chrome-extension/tasks/02.md
+++ b/work/chrome-extension/tasks/02.md
@@ -1,0 +1,42 @@
+---
+status: pending
+depends_on: []
+wave: 1
+skills: [code-writing]
+verify: [pnpm-build, pnpm-test]
+reviewers: [code-reviewer]
+teammate_name: T02-sdk-browser
+---
+
+# Task 02: SDK browser bundle (`@mnemonik-xyz/sdk` `dist/browser.js`)
+
+## Description
+
+Add a browser-targeted ESM bundle to `packages/sdk/` so the extension can `import { MnemonicClient } from '@mnemonik-xyz/sdk/browser'`. This unblocks the `work/mnemonic-cli/backlog.md` Phase 1.5 line item ("Browser bundle of SDK").
+
+The SDK is already pure-ESM and runtime-agnostic (per `work/mnemonic-cli/tech-spec.md`); this task adds a build target + export field, not new logic.
+
+## What to do
+
+1. Add `browser` build target in `packages/sdk/`: `esbuild` (or tsup) configured for `format: 'esm', platform: 'browser', target: 'es2022'`. Output: `dist/browser.js`, `dist/browser.d.ts`.
+2. Update `packages/sdk/package.json` with conditional exports:
+   ```json
+   "exports": {
+     ".": { "browser": "./dist/browser.js", "default": "./dist/index.js" },
+     "./browser": { "import": "./dist/browser.js", "types": "./dist/browser.d.ts" }
+   }
+   ```
+3. Re-export the WASM from `@mnemonic/core` via the browser-target build (`wasm-pack --target web` artifact). Verify the WASM is loadable in a service-worker context (no `node:fs`).
+4. Bundle-size budget: `dist/browser.js` (excluding WASM) ≤120KB minified. Enforced by `size-limit` in `packages/sdk/.size-limit.json`.
+5. Add `packages/sdk/tests/browser.test.ts` running under vitest's `environment: 'jsdom'` — imports `dist/browser.js`, instantiates `MnemonicClient({baseUrl, jwt})`, mocks `fetch`, asserts request shape.
+
+## TDD Anchor
+
+- `packages/sdk/tests/browser.test.ts::client_works_in_browser_env` — under jsdom, `new MnemonicClient(...)` succeeds, calling `signMemory` produces the deferred-signing flow's `correlation_id` request to `/mcp`. Drives the browser export.
+- `packages/sdk/tests/browser.test.ts::no_node_imports` — static analysis on `dist/browser.js` fails if it contains `require("node:`, `from "node:`, or `process.versions`. Drives runtime-agnostic guarantee.
+
+## Files
+
+- Create: `packages/sdk/build/browser.config.ts` (or tsup config), `packages/sdk/.size-limit.json`, `packages/sdk/tests/browser.test.ts`.
+- Modify: `packages/sdk/package.json` (exports + scripts), `packages/sdk/tsconfig.json` (add `lib: ["DOM", "ES2022", "WebWorker"]` if not present).
+- Read: `packages/sdk/src/index.ts`, `packages/sdk/src/client.ts`, `core/src/wasm/mod.rs`, `work/mnemonic-cli/backlog.md`.

--- a/work/chrome-extension/tasks/03.md
+++ b/work/chrome-extension/tasks/03.md
@@ -1,0 +1,48 @@
+---
+status: pending
+depends_on: [01]
+wave: 2
+skills: [code-writing]
+verify: [pnpm-test]
+reviewers: [code-reviewer, test-reviewer]
+teammate_name: T03-indexeddb-store
+---
+
+# Task 03: `IndexedDbStore` implementing `AttestationStore` shape
+
+## Description
+
+Implement browser-side `IndexedDbStore` that mirrors the `AttestationStore` trait from `core/src/storage/traits.rs`. This is the local-mode storage layer for the extension; cloud-mode also uses it as a cache.
+
+Schema is versioned (`v1`); migrations live in `runtime/store/migrations.ts`.
+
+## What to do
+
+1. **Schema (v1):**
+   - `attestations` (keyPath: `attestation_id`): `{attestation_id, content, content_hash, tags[], embedding f32[384], cose_bytes Uint8Array, created_at, signer_pubkey, owner_pubkey, solana_tx, arweave_tx, source_meta?: {platform, model?, chat_id?, url?}}`. Indexes: `signer_pubkey`, `created_at`, `tags` (multiEntry).
+   - `lineage_edges` (keyPath: `id` autoincrement): `{parent_id, child_id, depth, created_at}`. Indexes: `child_id`, `parent_id`.
+   - `pending_uploads` (keyPath: `attestation_id`): rows queued for cloud sync. Index: `enqueued_at`.
+2. Implement `IndexedDbStore` class in `packages/extension/src/runtime/store/indexeddb.ts`:
+   - `saveAttestation(row)`, `findByTx(tx_id)`, `count(signer)`, `search(queryEmbedding, ownerPubkey, limit)` — cosine similarity computed in-memory over `embedding` field; for MVP scan-all (≤10k rows expected); HNSW backlog.
+   - Lineage: `saveEdge(parent, child, depth)`, `getEdges(child_id)`, `clearEdges(artifact_id)`.
+   - Pending uploads queue: `enqueue(attestation_id)`, `dequeue(attestation_id)`, `listPending()`.
+3. Use `idb` (Jake Archibald) wrapper for ergonomic Promise-based IDB.
+4. **Quota handling:** call `navigator.storage.persist()` on first write; emit warning event if `estimate.usage / estimate.quota > 0.8`.
+5. **Tests** — mirror `core/src/storage/sqlite.rs` tests structurally:
+   - Save → findByTx round-trip.
+   - Search returns top-k by cosine.
+   - Owner-pubkey scoping (other owner's rows invisible).
+   - Tag filter.
+   - Lineage round-trip.
+   - Pending queue enqueue/dequeue.
+   - Schema migration v0 → v1 (synthetic, no real prior version).
+
+## TDD Anchor
+
+- `packages/extension/tests/unit/store/indexeddb.test.ts::cosine_search_top_k_matches_python_fixture` — embed 5 fixed vectors, query with a fixed vector, assert top-3 ids match Python-computed reference. Drives D3 dim parity later.
+- `tests/unit/store/indexeddb.test.ts::owner_scope_isolates_tenants` — two `owner_pubkey`s; `search(q, ownerA)` never returns `ownerB`'s rows. Drives multi-tenancy for shared-device scenarios.
+
+## Files
+
+- Create: `packages/extension/src/runtime/store/{indexeddb.ts, migrations.ts, types.ts}`, `packages/extension/tests/unit/store/indexeddb.test.ts`, `packages/extension/tests/fixtures/store/cosine-fixture.json`.
+- Read: `core/src/storage/traits.rs`, `core/src/storage/sqlite.rs`.

--- a/work/chrome-extension/tasks/04.md
+++ b/work/chrome-extension/tasks/04.md
@@ -1,0 +1,45 @@
+---
+status: pending
+depends_on: [01]
+wave: 2
+skills: [code-writing]
+verify: [pnpm-test]
+reviewers: [code-reviewer, test-reviewer]
+teammate_name: T04-embedder
+---
+
+# Task 04: Browser embedder via `transformers.js` in Web Worker
+
+## Description
+
+Implement the `Embedder` interface for the extension using `@xenova/transformers` running `Xenova/all-MiniLM-L6-v2` (384 dim) in a dedicated Web Worker. Lazy-loaded on first sign; cached via `Cache API` after first download.
+
+Vector dim 384 must match server default (`mcp/src/config.rs`). Golden-fixture test in T05 enforces parity.
+
+## What to do
+
+1. Create Web Worker `packages/extension/src/runtime/embed/worker.ts`:
+   - Import `pipeline` from `@xenova/transformers`.
+   - On first message, lazy-init `pipeline('feature-extraction', 'Xenova/all-MiniLM-L6-v2', {quantized: true})`. Emit progress events.
+   - Handle `{type: 'embed', text}` → reply `{type: 'embedded', vector: Float32Array(384)}`.
+2. Wrapper `packages/extension/src/runtime/embed/transformers-embedder.ts`:
+   - `class TransformersEmbedder implements Embedder { dim = 384; async embed(text: string): Promise<Float32Array> }`.
+   - Lazy-spawns the worker on first call.
+   - Times out at 30s on cold init; surfaces a structured error.
+3. Configure `transformers.js` to cache model bytes via `env.useBrowserCache = true` (defaults to `Cache API`).
+4. `Embedder` TS interface in `packages/extension/src/runtime/embed/types.ts`, mirroring `core/src/embed/mod.rs::Embedder`.
+5. Tests:
+   - Embed deterministic seed (`"hello mnemonik"`) → assert L2 norm ~1.0 and first 8 dims match a recorded fixture (slack 1e-3).
+   - Two calls return identical vectors.
+   - Worker lifecycle: terminate cleanly on `dispose()`.
+
+## TDD Anchor
+
+- `packages/extension/tests/unit/embed/transformers.test.ts::dim_matches_server_default_384` — assert `embedder.dim === 384`. Drives D3 vector-dim parity.
+- `tests/unit/embed/transformers.test.ts::deterministic_seed_matches_fixture` — fixed input → recorded vector (first 8 dims). Drives reproducibility for cross-client recall.
+
+## Files
+
+- Create: `packages/extension/src/runtime/embed/{worker.ts, transformers-embedder.ts, types.ts}`, `packages/extension/tests/unit/embed/transformers.test.ts`, `packages/extension/tests/fixtures/embed/seed-vector.json`.
+- Modify: `packages/extension/package.json` (add `@xenova/transformers`, ~6MB dev dep; runtime model is lazy-loaded).
+- Read: `core/src/embed/mod.rs`, `mcp/src/config.rs`.

--- a/work/chrome-extension/tasks/05.md
+++ b/work/chrome-extension/tasks/05.md
@@ -1,0 +1,40 @@
+---
+status: pending
+depends_on: [01, 02]
+wave: 2
+skills: [code-writing, rust]
+verify: [pnpm-test, cargo-test]
+reviewers: [code-reviewer, security-auditor, test-reviewer]
+teammate_name: T05-wasm-parity
+---
+
+# Task 05: WASM crypto pipeline bindings + golden-fixture parity tests
+
+## Description
+
+Wire the extension to `@mnemonic/core` WASM exports for: `to_canonical_cbor`, `blake3_hash`, `compress_embedding`, `decompress_embedding`, `sign_cose_payload`, `generate_keypair`, `import_keypair_json`, `export_keypair_json`. Verify any missing exports exist; if not, add `#[wasm_bindgen]` to them.
+
+Add a `golden-fixtures` cargo feature in `core/` that emits byte-for-byte canonical CBOR + COSE_Sign1 + compressed-embedding fixtures. Extension's vitest reads these fixtures and asserts WASM output is byte-identical. This is the contract that prevents recall drift between extension and server.
+
+## What to do
+
+1. **`core/src/wasm/mod.rs`** — audit exports. Add bindings for any of the following missing: `compress_embedding(Vec<f32>, u8) -> Vec<u8>`, `decompress_embedding(&[u8], usize) -> Vec<f32>`, `to_canonical_cbor(JsValue) -> Vec<u8>`, `blake3_hash(&[u8]) -> Vec<u8>`. Existing signing exports likely cover the rest.
+2. **`core/Cargo.toml`** — add `[features] golden-fixtures = []`. Gated module `core/src/codec/golden.rs` with `#[cfg(feature = "golden-fixtures")]` `pub fn emit_fixtures(out_dir: &Path)`.
+3. Add `core/examples/emit_golden.rs` calling `emit_fixtures()`. Outputs a JSON manifest: `{cbor_b64, cose_sign1_b64, compressed_emb_b64, plaintext, embedding_f32, signer_pubkey_b58, signer_secret_b58}` for 5 deterministic seeds.
+4. CI step: `cargo run --features golden-fixtures --example emit_golden -- packages/extension/tests/fixtures/golden/`.
+5. **`packages/extension/src/runtime/sign/cose.ts`** — wrapper functions calling the WASM exports. Async-init the WASM module once.
+6. **Tests `packages/extension/tests/unit/sign/cose.test.ts`:**
+   - Load each golden fixture, recompute via WASM in jsdom, assert byte-identity.
+   - Sign deterministic plaintext + embedded keypair → same COSE_Sign1 bytes as fixture.
+   - Hash + compression byte-parity.
+
+## TDD Anchor
+
+- `tests/unit/sign/cose.test.ts::cose_sign1_bytes_match_server_fixture` — deterministic input + secret → output bytes equal `golden/cose_sign1_seed_0.bin` from `core/`. Drives D2: cloud-tier verifies in browser the same bytes server receives.
+- `tests/unit/sign/cose.test.ts::compressed_embedding_bytes_match` — same f32 vector + bits=4 → equal `golden/compressed_emb_seed_0.bin`. Drives D3 parity.
+
+## Files
+
+- Modify: `core/src/wasm/mod.rs` (add exports as needed), `core/Cargo.toml` (feature flag), `core/src/codec/canonical.rs` or new `core/src/codec/golden.rs` (emitter).
+- Create: `core/examples/emit_golden.rs`, `packages/extension/src/runtime/sign/cose.ts`, `packages/extension/tests/unit/sign/cose.test.ts`, `packages/extension/tests/fixtures/golden/.gitkeep` (fixtures generated in CI, committed for offline test).
+- Read: `core/src/codec/canonical.rs`, `core/src/codec/sign.rs`, `core/src/compress/mod.rs`.

--- a/work/chrome-extension/tasks/06.md
+++ b/work/chrome-extension/tasks/06.md
@@ -1,0 +1,54 @@
+---
+status: pending
+depends_on: [01]
+wave: 3
+skills: [code-writing]
+verify: [pnpm-test]
+reviewers: [code-reviewer]
+teammate_name: T06-adapter-framework
+---
+
+# Task 06: `ChatAdapter` framework + registry + serializer
+
+## Description
+
+Build the platform-agnostic adapter framework that powers the extension's primary feature (D8): capturing AI chat conversations from supported browser AI-chat platforms. Per-platform adapters (T07–T09) plug into this registry.
+
+## What to do
+
+1. **Types** (`packages/extension/src/runtime/chat/types.ts`):
+   ```ts
+   export type ChatTurn = {
+     role: 'user' | 'assistant' | 'system';
+     content: string;
+     ts?: string;       // ISO-8601 if extractable
+     modelHint?: string;
+   };
+   export interface ChatAdapter {
+     readonly hostPattern: RegExp;
+     readonly platform: 'chatgpt' | 'claude' | 'gemini' | string;
+     extractConversation(doc: Document): ChatTurn[];
+     findInputBox(doc: Document): HTMLElement | null;
+     getChatId(doc: Document, location: Location): string | null;
+     onNewAssistantTurn?(doc: Document, cb: (turn: ChatTurn) => void): () => void;
+   }
+   ```
+2. **Registry** (`packages/extension/src/runtime/chat/registry.ts`): flat array of adapters; `selectAdapter(url: string): ChatAdapter | null` matches `hostPattern` against `new URL(url).hostname + path`.
+3. **Serializer** (`packages/extension/src/runtime/chat/serializer.ts`):
+   - `serializeMarkdown(turns: ChatTurn[], meta: ChatMeta): string` — produces human-readable markdown body (`### user`, `### assistant`, fenced code blocks preserved, YAML frontmatter with meta).
+   - `serializePayload(turns, meta): {content, tags, source_meta}` — what gets passed to `signMemory`. `tags` = `[`source:${platform}`, `model:${meta.model}`, `chat:${chatId}`]` if present.
+4. **Code-block preservation:** when extracting `content` from DOM, preserve `<pre><code>` blocks as fenced markdown with language hint from `class="language-rust"` or similar.
+5. Tests:
+   - Serialize fixed `ChatTurn[]` → snapshot markdown.
+   - Registry: ChatGPT URL → ChatGPT adapter (mocked); unknown URL → null.
+   - Tag generation correctness.
+
+## TDD Anchor
+
+- `tests/unit/chat/serializer.test.ts::markdown_round_trip_preserves_code_blocks` — input with `\`\`\`python` block → markdown contains it verbatim. Drives faithful capture of code-heavy AI chats.
+- `tests/unit/chat/registry.test.ts::unknown_host_returns_null` — `selectAdapter('https://example.com')` is null. Drives "generic page-selection capture is a different code path."
+
+## Files
+
+- Create: `packages/extension/src/runtime/chat/{types.ts, registry.ts, serializer.ts}`, `packages/extension/tests/unit/chat/{serializer.test.ts, registry.test.ts}`.
+- Read: `core/src/codec/canonical.rs` (CBOR shape consideration for `source_meta` field).

--- a/work/chrome-extension/tasks/07.md
+++ b/work/chrome-extension/tasks/07.md
@@ -1,0 +1,41 @@
+---
+status: pending
+depends_on: [06]
+wave: 3
+skills: [code-writing, dom-scraping]
+verify: [pnpm-test, manual-har-replay]
+reviewers: [code-reviewer]
+teammate_name: T07-chatgpt-adapter
+---
+
+# Task 07: ChatGPT adapter (`chatgpt.com`)
+
+## Description
+
+Implement `ChatAdapter` for ChatGPT. Phase 1 includes `findInputBox` for "insert into chat" recall (other platforms are read-only Phase 1).
+
+## What to do
+
+1. **Record HAR fixtures** of three ChatGPT conversation states:
+   - Empty new chat.
+   - Multi-turn with code blocks (Python + Rust).
+   - Long thread with collapsed long messages (test scrolling).
+   Save to `packages/extension/tests/fixtures/chatgpt/{empty,code,long}.html` (just the rendered DOM dump from DevTools).
+2. **Selectors:** ChatGPT uses `[data-message-author-role]` on each turn (current 2026 DOM; verify on capture day). Role from `data-message-author-role`. Content extraction: walk children, preserve `<pre><code>` as fenced code with `data-language` lookup.
+3. **`getChatId`:** path `/c/<uuid>` → `<uuid>`. Otherwise null.
+4. **`findInputBox`:** `<textarea data-id="root"]` or current equivalent (verify). Returns the element so popup can `.value = recalledText; dispatchEvent(new InputEvent(...))`.
+5. **`onNewAssistantTurn`:** `MutationObserver` on the chat container, fire when an `[data-message-author-role="assistant"]` transitions from "is generating" (has `data-stream` attr) to complete. Stable hook for auto-capture (D12 backlog).
+6. Register in `packages/extension/src/runtime/chat/registry.ts`.
+7. Tests: parse each fixture HTML → assert expected `ChatTurn[]` with role/content. Code blocks intact. Snapshot markdown serialization.
+
+## TDD Anchor
+
+- `tests/unit/chat/chatgpt.adapter.test.ts::extracts_code_block_with_language` — `code.html` → assistant turn contains `\`\`\`python\n...\`\`\``. Drives code-block fidelity for vibe-coders.
+- `tests/unit/chat/chatgpt.adapter.test.ts::role_inferred_from_data_attr` — both user and assistant turns labeled correctly. Drives faithful chat reconstruction.
+- `tests/unit/chat/chatgpt.adapter.test.ts::findInputBox_returns_textarea` — non-null on chat page; null on landing page.
+
+## Files
+
+- Create: `packages/extension/src/runtime/chat/adapters/chatgpt.adapter.ts`, `packages/extension/tests/unit/chat/chatgpt.adapter.test.ts`, `packages/extension/tests/fixtures/chatgpt/{empty,code,long}.html`.
+- Modify: `packages/extension/src/runtime/chat/registry.ts`, `packages/extension/manifest.json` (`host_permissions` adds `https://chatgpt.com/*`).
+- Read: `packages/extension/src/runtime/chat/types.ts`.

--- a/work/chrome-extension/tasks/08.md
+++ b/work/chrome-extension/tasks/08.md
@@ -1,0 +1,35 @@
+---
+status: pending
+depends_on: [06]
+wave: 3
+skills: [code-writing, dom-scraping]
+verify: [pnpm-test]
+reviewers: [code-reviewer]
+teammate_name: T08-claude-adapter
+---
+
+# Task 08: Claude.ai adapter (`claude.ai`)
+
+## Description
+
+Implement `ChatAdapter` for Claude.ai. Read-only Phase 1 (`findInputBox` returns null; insert-into-chat is backlog for Claude).
+
+## What to do
+
+1. **Record HAR fixtures** for three Claude conversation states (empty / code-heavy / long), save to `packages/extension/tests/fixtures/claude/{empty,code,long}.html`.
+2. **Selectors:** Claude.ai turns are typically `[data-testid^="message-"]` with role hint in nested classnames (verify on capture day). Code blocks: `<pre>` with syntax-highlighted spans — concatenate text content, retrieve language hint from class.
+3. **`getChatId`:** path `/chat/<uuid>` → `<uuid>`.
+4. **`findInputBox`:** return null Phase 1.
+5. **`onNewAssistantTurn`:** `MutationObserver` on chat container; fire on assistant turn completion (detected by presence of action buttons like copy/regenerate appearing).
+6. Register in `packages/extension/src/runtime/chat/registry.ts`.
+7. Tests: parse each fixture → assert `ChatTurn[]`; code-block fidelity; correct `getChatId`.
+
+## TDD Anchor
+
+- `tests/unit/chat/claude.adapter.test.ts::extracts_multi_turn_conversation` — `long.html` → ≥6 turns, alternating user/assistant. Drives correct turn segmentation under Claude's nested DOM.
+- `tests/unit/chat/claude.adapter.test.ts::code_blocks_preserved_with_language` — `code.html` → fenced rust block. Drives parity with ChatGPT adapter behavior.
+
+## Files
+
+- Create: `packages/extension/src/runtime/chat/adapters/claude.adapter.ts`, `packages/extension/tests/unit/chat/claude.adapter.test.ts`, `packages/extension/tests/fixtures/claude/{empty,code,long}.html`.
+- Modify: `packages/extension/src/runtime/chat/registry.ts`, `packages/extension/manifest.json` (`host_permissions` adds `https://claude.ai/*`).

--- a/work/chrome-extension/tasks/09.md
+++ b/work/chrome-extension/tasks/09.md
@@ -1,0 +1,35 @@
+---
+status: pending
+depends_on: [06]
+wave: 3
+skills: [code-writing, dom-scraping]
+verify: [pnpm-test]
+reviewers: [code-reviewer]
+teammate_name: T09-gemini-adapter
+---
+
+# Task 09: Gemini adapter (`gemini.google.com`)
+
+## Description
+
+Implement `ChatAdapter` for Google Gemini. Read-only Phase 1.
+
+## What to do
+
+1. **Record HAR fixtures** for three Gemini conversation states, save to `packages/extension/tests/fixtures/gemini/{empty,code,long}.html`.
+2. **Selectors:** Gemini renders as `<message-content>` web components or similar (verify on capture day). Role detection via component tag or attribute. Content extraction: shadow DOM traversal if needed (use `composedPath` / shadow root piercing).
+3. **`getChatId`:** path/query convention TBD on capture (e.g. `?chat=<id>` or hash). If unknown, return null.
+4. **`findInputBox`:** return null Phase 1.
+5. **`onNewAssistantTurn`:** `MutationObserver` accommodating shadow-DOM (re-attach observer on shadow root mutations).
+6. Register in `packages/extension/src/runtime/chat/registry.ts`.
+7. Tests: parse each fixture → assert `ChatTurn[]`; shadow-DOM traversal handled; markdown snapshot.
+
+## TDD Anchor
+
+- `tests/unit/chat/gemini.adapter.test.ts::shadow_dom_pierced_to_extract_content` — fixture with shadow roots → text contents present in extracted turns. Drives shadow-DOM correctness.
+- `tests/unit/chat/gemini.adapter.test.ts::role_correct_for_assistant_and_user` — both roles labeled correctly.
+
+## Files
+
+- Create: `packages/extension/src/runtime/chat/adapters/gemini.adapter.ts`, `packages/extension/tests/unit/chat/gemini.adapter.test.ts`, `packages/extension/tests/fixtures/gemini/{empty,code,long}.html`.
+- Modify: `packages/extension/src/runtime/chat/registry.ts`, `packages/extension/manifest.json` (`host_permissions` adds `https://gemini.google.com/*`).

--- a/work/chrome-extension/tasks/10.md
+++ b/work/chrome-extension/tasks/10.md
@@ -1,0 +1,49 @@
+---
+status: pending
+depends_on: [01, 06, 07, 08, 09]
+wave: 4
+skills: [code-writing]
+verify: [pnpm-build, web-ext-lint]
+reviewers: [code-reviewer, security-auditor]
+teammate_name: T10-manifest-sw
+---
+
+# Task 10: Finalize MV3 manifest + service worker message router
+
+## Description
+
+Pull together the manifest with all permissions, host_permissions per adapter (T07–T09 already added their entries), commands (hotkeys), and a working service-worker message router.
+
+## What to do
+
+1. **Manifest** (`packages/extension/manifest.json`):
+   - `permissions`: `storage`, `identity`, `contextMenus`, `activeTab`, `clipboardWrite`, `alarms`.
+   - `host_permissions`: `https://chatgpt.com/*`, `https://claude.ai/*`, `https://gemini.google.com/*`. (D11 — no `<all_urls>`.)
+   - `content_scripts`: per-adapter entry (one per supported domain) loading the relevant adapter + `fab.ts` + `recall-overlay.ts`.
+   - `background.service_worker`: `src/background/service-worker.ts`, `type: "module"`.
+   - `commands`:
+     - `_execute_action` → `Ctrl+Shift+M` (Cmd on Mac) — opens popup.
+     - `recall-overlay` → `Ctrl+Shift+R` — sends message to active tab to open overlay.
+   - `web_accessible_resources`: WASM, embedder model fetch URL allowance, recall-overlay assets.
+   - `content_security_policy.extension_pages`: strict (no `unsafe-eval`, no remote scripts; allow `wasm-unsafe-eval` for WASM).
+2. **Service worker** (`src/background/service-worker.ts`):
+   - On install: `chrome.contextMenus.create({id: 'save-selection', title: 'Save selection to Mnemonik', contexts: ['selection']})`.
+   - `chrome.contextMenus.onClicked` → message active tab content-script with selected text + URL.
+   - `chrome.commands.onCommand` → dispatch (`recall-overlay` → message tab to open overlay).
+   - Message router: `chrome.runtime.onMessage` with typed `Msg = {type: 'sign', ...} | {type: 'recall', ...} | ...`. Handlers call into `runtime/` modules.
+   - `chrome.alarms.create('cloud-sync-retry', {periodInMinutes: 5})` → flush `pending_uploads` queue.
+3. Stub a typed message protocol in `src/messages.ts` shared between popup, content scripts, service worker.
+4. Tests: vitest with `@webext-pegasus/transport-chrome` or simple manual mock of `chrome.*` APIs:
+   - Context-menu click → emits expected `runtime.sendMessage` to active tab.
+   - Hotkey command → emits expected message.
+
+## TDD Anchor
+
+- `tests/unit/background/service-worker.test.ts::context_menu_save_selection_emits_message` — simulate `onClicked` → assert payload includes `selectionText` + `pageUrl`. Drives generic-capture flow (D11).
+- `tests/unit/background/service-worker.test.ts::alarm_drains_pending_queue` — populate queue, fire alarm → assert calls into `cloud-client.ts`.
+
+## Files
+
+- Modify: `packages/extension/manifest.json` (final), `packages/extension/src/background/service-worker.ts`.
+- Create: `packages/extension/src/messages.ts`, `packages/extension/tests/unit/background/service-worker.test.ts`.
+- Read: `packages/extension/src/runtime/store/indexeddb.ts`, `packages/extension/src/runtime/sync/cloud-client.ts` (T18 may stub for now).

--- a/work/chrome-extension/tasks/11.md
+++ b/work/chrome-extension/tasks/11.md
@@ -1,0 +1,48 @@
+---
+status: pending
+depends_on: [01, 03, 04, 05]
+wave: 4
+skills: [code-writing, ui]
+verify: [pnpm-test, pnpm-build]
+reviewers: [code-reviewer, ux-reviewer]
+teammate_name: T11-popup
+---
+
+# Task 11: Popup UI (Capture / Recall / Verify tabs)
+
+## Description
+
+React + Tailwind popup. Reuses webapp design tokens (`#0A0F1E` bg, `#00D4B4` accent, monospace for hashes, dark theme). Three tabs: Capture, Recall, Verify. Plus a header with identity badge + storage-tier indicator + link to Settings.
+
+## What to do
+
+1. Bootstrap popup React app (`src/popup/main.tsx` → `<App/>`).
+2. **Capture tab:**
+   - If active tab matches a supported chat adapter → show "Save chat" + "Save selection" buttons.
+   - Selection capture: editable textarea prefilled with selection (received from content script via `chrome.runtime.sendMessage`), tag editor, "Sign" button → calls `runtime/sign` → `IndexedDbStore.put`. On Cloud tier, also `cloud-client.signRemote()`.
+   - Show toast on success with `attestation_id` (truncated, copy-able).
+3. **Recall tab:**
+   - Search input → `IndexedDbStore.search(query, owner, k=5)`. Cloud tier merges in `mnemonic_recall` HTTP results.
+   - Each result: snippet + score + source-platform pill + "Copy markdown" / "Insert into chat" (if adapter has `findInputBox`) / "Open" actions.
+4. **Verify tab:**
+   - Paste attestation_id or drop a file → call `runtime/verify` → render verified | tampered | not_found with details (signer, ts, source, tx ids if cloud).
+5. **Header:**
+   - Identity badge: truncated pubkey + tooltip with full DID. Click → opens options page.
+   - Storage-tier pill: "Local" (gray) / "Cloud" (teal). Click → confirm-switch dialog (T12 owns the actual switch logic).
+   - Settings cog → opens options page.
+6. Bundle-budget: popup initial JS ≤50KB (enforced by `size-limit`).
+7. Tests (vitest browser mode + Testing Library):
+   - Capture tab: type in textarea, click Sign → mocked `signMemory` called with expected args.
+   - Recall: search → results render with scores.
+   - Verify: paste valid id → verified UI.
+
+## TDD Anchor
+
+- `tests/component/popup/Capture.test.tsx::sign_button_calls_signMemory` — mock runtime, click Sign with prefilled selection → assert `runtime.signMemory` called with the selection text + tags.
+- `tests/component/popup/Recall.test.tsx::insert_into_chat_disabled_when_no_input_box` — adapter returns null `findInputBox` → button disabled with tooltip.
+
+## Files
+
+- Create: `packages/extension/src/popup/{App.tsx, tabs/Capture.tsx, tabs/Recall.tsx, tabs/Verify.tsx, components/{IdentityBadge.tsx, StorageTierPill.tsx, Toast.tsx}}`, `packages/extension/src/popup/styles.css` (Tailwind entry), `packages/extension/tests/component/popup/{Capture,Recall,Verify}.test.tsx`.
+- Modify: `packages/extension/src/popup/main.tsx`, `packages/extension/.size-limit.json`.
+- Read: `webapp/src/components/IdentityPanel.tsx` (design token reference), `webapp/tailwind.config.js`.

--- a/work/chrome-extension/tasks/12.md
+++ b/work/chrome-extension/tasks/12.md
@@ -1,0 +1,45 @@
+---
+status: pending
+depends_on: [01, 03, 11]
+wave: 4
+skills: [code-writing, ui]
+verify: [pnpm-test, pnpm-build]
+reviewers: [code-reviewer, ux-reviewer]
+teammate_name: T12-options
+---
+
+# Task 12: Options page (Storage / Identity / Security / Per-domain settings)
+
+## Description
+
+Full options page (`chrome://extensions` → details → Extension options). React + Tailwind, reuses popup components.
+
+## What to do
+
+1. **Sections:**
+   - **Storage** — current tier (Local/Cloud) read-only display + "Switch tier" button → confirmation dialog explaining migration (D7 explicit). Local→Cloud: requires Google sign-in if not already, then enqueue all attestations to `pending_uploads`. Cloud→Local: download `.zip` of all attestations as COSE bundles + .md, then prompt "Disconnect cloud account?".
+   - **Identity** — show pubkey, DID (sol + key), QR code of pubkey for sharing. "Export keypair to file" (download encrypted with user-supplied password). "Import keypair from file" (with password decrypt).
+   - **Security** — "Rotate recovery passphrase" (Cloud only): old + new with zxcvbn meter, on submit → re-encrypt blob + `PUT /api/key-escrow`. "Delete cloud escrow" (advanced; warns). "Sign out of Google".
+   - **Per-domain** — list of supported chat domains with toggles for: enabled (content-script active), FAB visible, auto-capture (off by default per D12).
+   - **Telemetry** — opt-in toggle for broken-adapter / cold-start / sync-error metrics. Off by default.
+   - **About** — version, build hash, links to privacy policy + GitHub.
+2. Persist all settings in `chrome.storage.local` under `settings.v1`. Migration helper for future schema bumps.
+3. Local→Cloud migration UX:
+   - Confirmation modal lists count + storage estimate.
+   - On confirm: enqueue all + show progress bar (live updates from service-worker via port).
+   - Resumable: closing options page doesn't cancel; resumes via alarm.
+4. Tests:
+   - Settings round-trip (set in UI → re-render reads value).
+   - Tier switch confirmation flow.
+   - Passphrase rotation calls expected escrow function.
+
+## TDD Anchor
+
+- `tests/component/options/Storage.test.tsx::switching_to_cloud_requires_google_signin` — click switch with no Google session → modal prompts sign-in instead of confirming.
+- `tests/component/options/Security.test.tsx::rotate_passphrase_re_encrypts_blob` — submit form with old+new → assert `key-escrow.rotate(old, new)` called, blob re-uploaded.
+
+## Files
+
+- Create: `packages/extension/src/options/{App.tsx, sections/{Storage,Identity,Security,PerDomain,Telemetry,About}.tsx, components/MigrationProgress.tsx}`, `packages/extension/src/settings.ts` (typed settings + persistence), `packages/extension/tests/component/options/*.test.tsx`.
+- Modify: `packages/extension/src/options/main.tsx`.
+- Read: `packages/extension/src/popup/components/IdentityBadge.tsx`, `packages/extension/src/runtime/sync/cloud-client.ts`.

--- a/work/chrome-extension/tasks/13.md
+++ b/work/chrome-extension/tasks/13.md
@@ -1,0 +1,48 @@
+---
+status: pending
+depends_on: [10, 11]
+wave: 4
+skills: [code-writing, dom-injection]
+verify: [pnpm-test]
+reviewers: [code-reviewer, ux-reviewer]
+teammate_name: T13-fab-overlay
+---
+
+# Task 13: Floating action button (FAB) + Recall overlay (in-page UI)
+
+## Description
+
+In-page UI injected by content scripts on supported domains. FAB sits bottom-right, click expands quick actions ("Save chat", "Save selection", "Open recall"). Recall overlay is a hotkey-triggered modal usable on any page (works on supported chat domains and via `activeTab` elsewhere).
+
+Both must be CSP-safe (no inline event handlers; styles via Shadow DOM to avoid host-page CSS clashes).
+
+## What to do
+
+1. **FAB** (`packages/extension/src/content/fab.ts`):
+   - Inject Shadow DOM root with all styles scoped.
+   - 56px circular button with Mnemonik logo.
+   - Click → expand vertical menu: "Save this chat" / "Save selection" / "Open Mnemonik".
+   - Hide-able via per-domain settings (T12).
+   - Drag to reposition (persist in `chrome.storage.local` per domain).
+2. **Recall overlay** (`packages/extension/src/content/recall-overlay.ts`):
+   - Shadow-DOM modal centered on page; backdrop with `pointer-events: auto`.
+   - Triggered by service-worker message (hotkey or popup→overlay).
+   - Search input → debounced (200ms) call to runtime via `chrome.runtime.sendMessage({type: 'recall', q})`.
+   - Top-5 results with: snippet, score, source pill, actions (Copy / Insert / Open).
+   - Insert action: if active page has a known input via `ChatAdapter.findInputBox`, write text into it; else fall back to copy.
+   - ESC closes; click backdrop closes.
+3. Make sure neither breaks the host page — `host` element uses `all: initial` reset; Shadow DOM isolates everything.
+4. Tests (Playwright):
+   - Inject FAB into a blank `data:text/html` page → assert visible, click expands menu.
+   - Inject overlay → search → mock recall returns 3 results → first result keyboard-navigable.
+
+## TDD Anchor
+
+- `tests/e2e/fab-overlay.spec.ts::fab_does_not_leak_styles_to_host` — host page has `body { background: red }` → FAB renders unaffected and host stays red.
+- `tests/e2e/fab-overlay.spec.ts::overlay_inserts_into_chat_input_when_adapter_supports_it` — load ChatGPT HAR fixture → trigger overlay → select result → adapter's input box has the text.
+
+## Files
+
+- Create: `packages/extension/src/content/{fab.ts, recall-overlay.ts, shadow-styles.ts}`, `packages/extension/tests/e2e/fab-overlay.spec.ts`.
+- Modify: `packages/extension/manifest.json` (`content_scripts` entries reference fab + overlay).
+- Read: `packages/extension/src/runtime/chat/registry.ts`.

--- a/work/chrome-extension/tasks/14.md
+++ b/work/chrome-extension/tasks/14.md
@@ -1,0 +1,45 @@
+---
+status: pending
+depends_on: []
+wave: 5
+skills: [code-writing, rust, security]
+verify: [cargo-test]
+reviewers: [code-reviewer, security-auditor, test-reviewer]
+teammate_name: T14-server-google-oauth
+---
+
+# Task 14: Server — Google OAuth provider in `mcp/src/oauth.rs`
+
+## Description
+
+Add Google OAuth as an alternative provider alongside the existing Solana-wallet OAuth. Server-side validates Google `id_token` against cached JWKS, then issues our own JWT (with extra `google_sub` claim). Includes possession-proof binding on first link.
+
+## What to do
+
+1. **`mcp/src/oauth.rs`** — new endpoints:
+   - `GET /oauth/google/start?client_id=mnemonic-extension&redirect_uri=...&code_challenge=...&state=...` — validates `client_id`, persists PKCE state in existing `pending_oauth` map, redirects to Google consent (`https://accounts.google.com/o/oauth2/v2/auth?...`).
+   - `GET /oauth/google/callback?code=...&state=...` — exchanges Google code for tokens via `https://oauth2.googleapis.com/token`, validates `id_token` (issuer `accounts.google.com` or `https://accounts.google.com`, audience matches `GOOGLE_OAUTH_CLIENT_ID`, signature against cached JWKS), then redirects to caller's `redirect_uri` with our own server-issued auth code (existing flow).
+   - `POST /oauth/google/lookup` (auth: server JWT with `google_sub`) — returns `{existing_pubkey: Option<String>, escrow_present: bool}` from `google_identity_links` + `key_escrow_blobs`.
+   - `POST /oauth/google/link` (auth: server JWT with `google_sub`, no existing link) — body `{pubkey_base58, possession_proof_base64}` — server-issued nonce challenge signed by the Ed25519 keypair; insert into `google_identity_links`.
+2. **JWKS cache** — `mcp/src/oauth/google_jwks.rs`. Fetch `https://www.googleapis.com/oauth2/v3/certs`, cache for 1h, refresh on signature verification miss.
+3. **Config** — `mcp/src/config.rs`: optional `GOOGLE_OAUTH_CLIENT_ID`, `GOOGLE_OAUTH_CLIENT_SECRET`, `GOOGLE_OAUTH_REDIRECT_URI` (default `https://mc.mnemonik.xyz/oauth/google/callback`). If client_id unset → routes return 404 and `main.rs` skips wiring.
+4. **`mcp/src/main.rs`** — conditionally wire the Google router. Log "Google OAuth: enabled/disabled" at startup.
+5. **Tests `mcp/tests/oauth_google.rs`:**
+   - Mock Google JWKS server (axum sub-server) returning a known RS256 keypair.
+   - Mock Google token endpoint returning `id_token` signed by that key.
+   - Full PKCE round-trip: start → callback → lookup → link → token.
+   - Bad signature on `id_token` → reject.
+   - Wrong audience → reject.
+   - `link` requires possession proof matching server-issued challenge.
+
+## TDD Anchor
+
+- `mcp/tests/oauth_google.rs::full_pkce_roundtrip` — start → mocked Google → callback → server JWT issued with `google_sub` claim. Drives D5 standard flow.
+- `mcp/tests/oauth_google.rs::link_requires_possession_proof` — call `link` without sig → 401; with valid sig → row inserted.
+- `mcp/tests/oauth_google.rs::id_token_bad_audience_rejected` — token with `aud != GOOGLE_OAUTH_CLIENT_ID` → 401.
+
+## Files
+
+- Create: `mcp/src/oauth/google.rs` (or extend `mcp/src/oauth.rs`), `mcp/src/oauth/google_jwks.rs`, `mcp/tests/oauth_google.rs`.
+- Modify: `mcp/src/config.rs`, `mcp/src/main.rs`, `mcp/Cargo.toml` (add `jsonwebtoken` features for RS256, `reqwest` already present).
+- Read: existing `mcp/src/oauth.rs`, `mcp/src/api.rs`.

--- a/work/chrome-extension/tasks/15.md
+++ b/work/chrome-extension/tasks/15.md
@@ -1,0 +1,47 @@
+---
+status: pending
+depends_on: [14]
+wave: 5
+skills: [code-writing, rust, security]
+verify: [cargo-test]
+reviewers: [code-reviewer, security-auditor, test-reviewer]
+teammate_name: T15-server-escrow
+---
+
+# Task 15: Server — Extension bootstrap + Key-escrow endpoints + DB migrations
+
+## Description
+
+Server-side counterpart to D9 (key escrow) and the extension-bootstrap flow. Server stores opaque ciphertext + KDF params + bound pubkey; never sees plaintext key. Rate-limits fetches.
+
+## What to do
+
+1. **DB migrations** in `core/src/storage/sqlite.rs::migrations`:
+   - `google_identity_links(google_sub TEXT PRIMARY KEY, owner_pubkey TEXT NOT NULL, linked_at TEXT NOT NULL, last_seen TEXT)`. Index on `owner_pubkey`.
+   - `key_escrow_blobs(google_sub TEXT PRIMARY KEY, ciphertext BLOB NOT NULL, nonce BLOB NOT NULL, kdf TEXT NOT NULL, kdf_params TEXT NOT NULL, pubkey_base58 TEXT NOT NULL, updated_at TEXT NOT NULL, fetch_count_24h INTEGER NOT NULL DEFAULT 0, last_fetch_at TEXT, FOREIGN KEY (google_sub) REFERENCES google_identity_links(google_sub) ON DELETE CASCADE)`.
+2. **Endpoints `mcp/src/api.rs`:**
+   - `POST /api/extension-bootstrap/issue` (auth: server JWT) — issues one-time bootstrap ticket UUID; LRU+TTL map (10 min). Mirrors `/api/cli-bootstrap/*`.
+   - `GET /api/extension-bootstrap/redeem/:ticket` — returns JWT with `aud=extension`, ticket invalidated.
+   - `PUT /api/key-escrow` (auth: server JWT with `google_sub`) — body `{ciphertext_b64, nonce_b64, kdf, kdf_params, pubkey_base58}`. Validates `pubkey_base58` matches the linked owner_pubkey for this `google_sub`. UPSERT row, reset `fetch_count_24h=0`, `last_fetch_at=null`.
+   - `GET /api/key-escrow` (auth: server JWT with `google_sub`) — returns `{ciphertext_b64, nonce_b64, kdf, kdf_params, pubkey_base58}`. Increments `fetch_count_24h`. If `fetch_count_24h >= KEY_ESCROW_RATE_LIMIT` (default 5) within rolling 24h window (compare `last_fetch_at`), return `429 Too Many Requests` with `Retry-After` header. Reset counter when 24h window passes.
+   - `DELETE /api/key-escrow` (auth: server JWT with `google_sub`) — explicit user revocation. Removes row.
+3. **Config** — `KEY_ESCROW_RATE_LIMIT` env var default 5.
+4. **Tests `mcp/tests/key_escrow.rs`:**
+   - PUT then GET round-trip returns identical bytes.
+   - PUT with mismatched pubkey → 403.
+   - Six GETs within 24h → 6th returns 429 with `Retry-After`.
+   - 24h+ later (mock clock) → counter resets, GET succeeds.
+   - DELETE removes row, subsequent GET → 404.
+   - PUT without prior `google_identity_links` row → 403.
+
+## TDD Anchor
+
+- `mcp/tests/key_escrow.rs::rate_limit_blocks_brute_force` — issue 5 GETs, 6th returns 429. Drives D9 rate-limit guarantee.
+- `mcp/tests/key_escrow.rs::pubkey_binding_enforced` — PUT with `pubkey_base58 != linked_owner_pubkey` → 403. Drives D9 binding (prevents stolen-google-account → swap-key attack).
+- `mcp/tests/key_escrow.rs::server_never_stores_plaintext` — manual review: grep `core/src/storage/sqlite.rs` migration for any field that could hold plaintext secret; assert only ciphertext + opaque params.
+
+## Files
+
+- Modify: `core/src/storage/sqlite.rs` (migrations + helpers), `mcp/src/api.rs` (endpoints + handlers), `mcp/src/config.rs` (env).
+- Create: `mcp/tests/key_escrow.rs`.
+- Read: existing `mcp/src/api.rs` (for `cli-bootstrap` pattern), `mcp/src/oauth.rs` (for JWT extraction middleware).

--- a/work/chrome-extension/tasks/16.md
+++ b/work/chrome-extension/tasks/16.md
@@ -1,0 +1,50 @@
+---
+status: pending
+depends_on: [02, 14]
+wave: 5
+skills: [code-writing]
+verify: [pnpm-test]
+reviewers: [code-reviewer, security-auditor]
+teammate_name: T16-ext-google-signin
+---
+
+# Task 16: Extension — Google sign-in client (`chrome.identity.launchWebAuthFlow`)
+
+## Description
+
+Extension-side Google sign-in flow per D5. Uses `chrome.identity.launchWebAuthFlow` to do PKCE against our server's `/oauth/google/start`. On callback, redeems server auth code for JWT.
+
+## What to do
+
+1. `packages/extension/src/auth/google-oauth.ts`:
+   - `signInWithGoogle(): Promise<{jwt, googleSub, profile}>`.
+   - Generates PKCE verifier (`crypto.getRandomValues` 32 bytes, base64url) + challenge (`crypto.subtle.digest('SHA-256', verifier)` base64url) + state.
+   - Computes `redirect_uri = chrome.identity.getRedirectURL('google')`.
+   - Calls `chrome.identity.launchWebAuthFlow({url: '<server>/oauth/google/start?...', interactive: true})`.
+   - On callback URL with `?code=&state=`: validates state, POSTs `/oauth/token` with verifier, gets JWT. Parses claim `google_sub`.
+   - Returns `{jwt, googleSub, profile}` (profile from `id_token` payload — name, email, picture).
+2. `packages/extension/src/auth/session.ts`:
+   - `getSession(): Session | null` reading from `chrome.storage.local.session.v1`.
+   - `setSession(s: Session)`, `clearSession()`.
+   - Auto-refresh stub (Phase 1 prompts re-login on JWT expiry; refresh-tokens are backlog).
+3. `packages/extension/src/auth/lookup.ts`:
+   - `lookupExisting(jwt): Promise<{existingPubkey: string | null, escrowPresent: boolean}>` calls `POST /oauth/google/lookup`.
+4. **Onboarding flow integration:** popup first-run uses `signInWithGoogle()` → `lookupExisting()`. Branches:
+   - No existing pubkey → "Set recovery passphrase" screen → T17 wraps fresh keypair → `POST /oauth/google/link`.
+   - Existing pubkey + escrow_present → "Welcome back" → passphrase prompt → T17 restore flow.
+   - Existing pubkey + no escrow → "Existing identity but no escrow on server. Import keypair from another device?" (rare edge: user previously linked but never enabled escrow).
+5. Tests:
+   - Mock `chrome.identity.launchWebAuthFlow` → assert verifier+challenge correctness.
+   - Mock server token endpoint → assert state validated, JWT extracted, googleSub parsed.
+   - State mismatch → throws.
+
+## TDD Anchor
+
+- `tests/unit/auth/google-oauth.test.ts::pkce_state_mismatch_rejects` — fake callback with wrong state → throws before token exchange. Drives RFC 7636 §4.4 binding.
+- `tests/unit/auth/google-oauth.test.ts::redirect_uri_uses_chrome_identity_helper` — assert `chrome.identity.getRedirectURL('google')` is what's sent to server. Drives D5 (no client_secret in extension).
+
+## Files
+
+- Create: `packages/extension/src/auth/{google-oauth.ts, session.ts, lookup.ts, types.ts}`, `packages/extension/tests/unit/auth/google-oauth.test.ts`, `packages/extension/tests/unit/auth/lookup.test.ts`.
+- Modify: `packages/extension/src/popup/App.tsx` (onboarding wiring; will integrate further in T17).
+- Read: `packages/sdk/src/oauth.ts` (RFC 7636 patterns).

--- a/work/chrome-extension/tasks/17.md
+++ b/work/chrome-extension/tasks/17.md
@@ -1,0 +1,62 @@
+---
+status: pending
+depends_on: [15, 16]
+wave: 5
+skills: [code-writing, security, ui]
+verify: [pnpm-test]
+reviewers: [code-reviewer, security-auditor, test-reviewer]
+teammate_name: T17-key-escrow-restore
+---
+
+# Task 17: Key-escrow client + identity-restore UX (D9)
+
+## Description
+
+Implement client-side passphrase wrap/unwrap and the full restore-on-new-device flow. Argon2id via `hash-wasm`, AES-GCM-256 via WebCrypto.
+
+This is the security-critical task: server never sees plaintext, so all crypto correctness lives here.
+
+## What to do
+
+1. **`packages/extension/src/auth/key-escrow.ts`:**
+   - `deriveKey(passphrase: string, salt: Uint8Array): Promise<CryptoKey>` — Argon2id via `hash-wasm` with parameters `{memory_cost: 65536, time_cost: 3, parallelism: 1, hash_length: 32}`. Import result into WebCrypto as AES-GCM key.
+   - `wrapSecret(secret: Uint8Array, passphrase: string): Promise<EscrowBlob>` — random 16-byte salt, random 12-byte nonce, AES-GCM-256 encrypt. Returns `{ciphertext_b64, nonce_b64, kdf: 'argon2id', kdf_params: {salt_b64, m, t, p}, pubkey_base58}`.
+   - `unwrapSecret(blob: EscrowBlob, passphrase: string): Promise<Uint8Array>` — derive key, AES-GCM decrypt. Throws on tag mismatch (wrong passphrase).
+   - `uploadEscrow(jwt, blob)` → `PUT /api/key-escrow`.
+   - `fetchEscrow(jwt)` → `GET /api/key-escrow`. Surfaces 429 as typed error with `retry_after`.
+   - `deleteEscrow(jwt)` → `DELETE /api/key-escrow`.
+   - `rotatePassphrase(jwt, oldPassphrase, newPassphrase)` — fetch → unwrap → re-wrap → upload.
+2. **Restore UX (`packages/extension/src/popup/onboarding/Restore.tsx`):**
+   - Triggered after `lookupExisting` returns `{existingPubkey, escrowPresent: true}`.
+   - Headline: "Welcome back. Identity `H8x...c4v` detected on this Google account."
+   - Passphrase input (masked, paste-allowed).
+   - "Restore" button → `fetchEscrow` → `unwrapSecret` → `chrome.storage.local.set({keypair})` → success → trigger background sync of `mnemonic_recall` to fill IndexedDB cache.
+   - Wrong passphrase: counter in popup state. After 5 attempts: block input for 24h (UX-level only — server enforces fetch-rate independently).
+   - "Forgot passphrase?" → modal: "We can't recover it for you. Options: (a) start fresh new identity (you'll keep read-only access to old cloud-history but can't sign new attestations under the old key); (b) import existing keypair from another device."
+3. **Set-passphrase UX (`packages/extension/src/popup/onboarding/SetPassphrase.tsx`):**
+   - Used during first-time Cloud onboarding.
+   - Two inputs (passphrase + confirm) with zxcvbn meter; require score ≥3.
+   - Explainer text: "Write this in your password manager. We can't recover it for you."
+   - On submit: `wrapSecret(keypair.secret, passphrase)` → `uploadEscrow` → `POST /oauth/google/link`.
+4. **Rotate passphrase UX (`packages/extension/src/options/sections/Security.tsx` integration):**
+   - Old + new + confirm inputs.
+   - Submit → `rotatePassphrase`.
+5. **Tests:**
+   - `wrap → unwrap` round-trip preserves bytes; wrong passphrase fails with `WrongPassphraseError`.
+   - Tampered ciphertext → fail.
+   - Argon2id parameters reach OWASP minimums (cost-time ≥ 100ms on modern laptop in CI).
+   - Rate-limit 429 from server → typed error with `retry_after_seconds` parsed.
+   - Restore happy path (mocked server) → keypair in `chrome.storage.local`.
+   - 5 wrong attempts → input disabled.
+
+## TDD Anchor
+
+- `tests/unit/auth/key-escrow.test.ts::wrap_unwrap_roundtrip` — random secret + random passphrase → wrap → unwrap → equal. Drives D9 correctness.
+- `tests/unit/auth/key-escrow.test.ts::wrong_passphrase_fails_locally` — wrap with `pw1`, unwrap with `pw2` → throws `WrongPassphraseError`, **no network call** (validates client can detect wrong passphrase without server roundtrip; preserves rate-limit budget).
+- `tests/component/popup/Restore.test.tsx::5_wrong_attempts_blocks_input` — after 5 failures the input is disabled with countdown.
+
+## Files
+
+- Create: `packages/extension/src/auth/key-escrow.ts`, `packages/extension/src/popup/onboarding/{SetPassphrase.tsx, Restore.tsx}`, `packages/extension/tests/unit/auth/key-escrow.test.ts`, `packages/extension/tests/component/popup/Restore.test.tsx`.
+- Modify: `packages/extension/src/options/sections/Security.tsx` (rotate-passphrase wired), `packages/extension/src/popup/App.tsx` (onboarding state machine).
+- Read: existing `mcp/src/api.rs` (for the API contract from T15), `core/src/identity/keypair.rs` (Ed25519 secret format).

--- a/work/chrome-extension/tasks/18.md
+++ b/work/chrome-extension/tasks/18.md
@@ -1,0 +1,51 @@
+---
+status: pending
+depends_on: [02, 03, 05, 16, 17]
+wave: 5
+skills: [code-writing]
+verify: [pnpm-test]
+reviewers: [code-reviewer, test-reviewer]
+teammate_name: T18-cloud-sync
+---
+
+# Task 18: Cloud-tier sync via deferred-signing flow
+
+## Description
+
+Implement `cloud-client.ts` — wraps `MnemonicClient` from SDK to push browser-signed COSE bundles to the server's deferred-signing endpoint, plus background-alarm-driven retry of `pending_uploads` queue.
+
+## What to do
+
+1. **`packages/extension/src/runtime/sync/cloud-client.ts`:**
+   - `signRemote({content, tags, source_meta, embedding, cose_bytes, signer_pubkey, content_hash}): Promise<{attestation_id, solana_tx, arweave_tx}>`:
+     1. `POST /mcp` `mnemonic_sign_memory` (Bearer JWT) → server returns `{correlation_id, expires_in}`.
+     2. `POST /api/sign-callback` with `{correlation_id, cose_signed_bytes_b64, signer_pubkey_base58}`. Server verifies, persists, anchors.
+     3. Returns `{attestation_id, solana_tx, arweave_tx}` from response.
+   - `recallRemote(query, k): Promise<RecallResult[]>` — calls `mnemonic_recall` JSON-RPC.
+   - `verifyRemote(attestation_id): Promise<VerifyResult>` — calls `mnemonic_verify`.
+   - On any 401: trigger re-login flow.
+2. **Offline queue:** if `signRemote` fails (network or 5xx), enqueue in `IndexedDbStore.enqueue(attestation_id)`. The local IDB row already has the COSE bytes; queue is just a reference.
+3. **Background sync (`src/background/cloud-sync.ts`)** — invoked by `chrome.alarms` (5-min interval per T10):
+   - List `pending_uploads`.
+   - For each, attempt `signRemote` with cached bytes.
+   - On success: update local row with `solana_tx` + `arweave_tx`, dequeue.
+   - On 4xx (not 401): mark row as `sync_failed_permanent`; surface error in popup.
+   - On 401: stop, surface re-login prompt.
+4. **Recall merge:** popup Recall tab in Cloud mode calls both `IndexedDbStore.search` and `recallRemote`, merges by `attestation_id`, deduplicates, re-sorts by best score.
+5. **Tests:**
+   - Happy path: mock `fetch` for `/mcp` + `/api/sign-callback` → assert sequence + payload shape.
+   - Offline → enqueue.
+   - Background drain: queue 3 rows → drive alarm → all dequeued, all rows have tx ids.
+   - 401 → halts queue, emits `re-auth-required` event.
+
+## TDD Anchor
+
+- `tests/unit/runtime/sync/cloud-client.test.ts::deferred_signing_flow` — mock both endpoints → assert correlation_id roundtrip and final tx ids set on local row. Drives D2 mapping (cloud = thin client to hosted-`full`).
+- `tests/unit/runtime/sync/cloud-client.test.ts::offline_enqueues_for_later` — `fetch` rejects → row in `pending_uploads`.
+- `tests/unit/background/cloud-sync.test.ts::alarm_drains_queue_on_reconnect` — populate queue, fire alarm with mocked-success fetch → queue empty, rows updated.
+
+## Files
+
+- Create: `packages/extension/src/runtime/sync/cloud-client.ts`, `packages/extension/src/background/cloud-sync.ts`, `packages/extension/tests/unit/runtime/sync/cloud-client.test.ts`, `packages/extension/tests/unit/background/cloud-sync.test.ts`.
+- Modify: `packages/extension/src/background/service-worker.ts` (alarm handler wires to `cloud-sync.ts`), `packages/extension/src/popup/tabs/Recall.tsx` (cloud-merge in Cloud tier).
+- Read: `packages/sdk/src/client.ts`, `mcp/src/api.rs` (sign-callback handler).

--- a/work/chrome-extension/tasks/19.md
+++ b/work/chrome-extension/tasks/19.md
@@ -1,0 +1,47 @@
+---
+status: pending
+depends_on: [10, 11, 12, 13, 17, 18]
+wave: 6
+skills: [code-writing, e2e-testing]
+verify: [pnpm-e2e]
+reviewers: [test-reviewer]
+teammate_name: T19-e2e
+---
+
+# Task 19: End-to-end Playwright suite (extension loaded)
+
+## Description
+
+Full E2E suite running Playwright with `--load-extension=dist/`. Covers all flows from user-spec acceptance criteria.
+
+## What to do
+
+1. **Test harness `packages/extension/tests/e2e/setup.ts`:**
+   - Build the extension (`pnpm build`).
+   - Launch Chromium with `--load-extension=$dist --disable-extensions-except=$dist`.
+   - Open extension popup via `chrome-extension://<id>/popup/index.html`.
+   - Mock Google OAuth + server endpoints (use Playwright `route` to intercept `mc.mnemonik.xyz/*`).
+2. **Specs:**
+   - `chatgpt-capture.spec.ts` — load `tests/fixtures/chatgpt/code.html` via `data:` URL or local server → click FAB "Save chat" → assert IndexedDB row + popup toast.
+   - `claude-capture.spec.ts` — same for Claude fixture.
+   - `gemini-capture.spec.ts` — same for Gemini fixture.
+   - `selection-capture.spec.ts` — generic `<p>` text on `data:text/html` page → context-menu "Save selection" → IndexedDB row.
+   - `recall-overlay.spec.ts` — populate IDB with 5 fixtures → press hotkey → search → results render → "Insert" inserts into mock textarea.
+   - `mode-switch-local-to-cloud.spec.ts` — local with 3 attestations → switch to Cloud → mocked Google sign-in → set passphrase → progress bar drains → all 3 rows have tx ids.
+   - `restore-on-second-profile.spec.ts` — first profile: full Cloud onboarding + 1 attestation. Second profile: install → mocked Google sign-in (same `google_sub`) → "Welcome back" → enter passphrase → identity restored → recall returns the attestation. Wrong-passphrase 5 times → input disabled.
+   - `wrong-passphrase-rate-limit.spec.ts` — server mock returns 429 after 5 GETs → popup shows `Retry-After` countdown.
+3. **CI workflow** `.github/workflows/ext-e2e.yml`:
+   - Trigger: PRs touching `packages/extension/**` or `packages/sdk/**`.
+   - Steps: build, run Playwright with retries, upload trace artifacts on failure.
+4. **Bundle-budget check** (separate CI step in same workflow): `size-limit` runs against `dist/popup/main.js` and total package; fails on > budgets per user-spec.
+
+## TDD Anchor
+
+- `tests/e2e/restore-on-second-profile.spec.ts::welcome_back_then_passphrase_restores_identity` — full restore flow, asserts identity matches first profile's pubkey + cloud attestation appears in recall. Drives D9 end-to-end.
+- `tests/e2e/chatgpt-capture.spec.ts::full_chat_serialized_with_code_blocks` — capture → IDB row → fetch row → markdown contains all turns + code blocks.
+
+## Files
+
+- Create: `packages/extension/tests/e2e/{setup.ts, mocks/{google-oauth.ts, server.ts}, *.spec.ts}` (one spec per scenario above), `packages/extension/playwright.config.ts`, `.github/workflows/ext-e2e.yml`.
+- Modify: `packages/extension/package.json` (add `e2e` script).
+- Read: existing webapp Playwright tests (`webapp/tests/e2e/`) for harness patterns.

--- a/work/chrome-extension/tasks/20.md
+++ b/work/chrome-extension/tasks/20.md
@@ -1,0 +1,61 @@
+---
+status: pending
+depends_on: [19]
+wave: 6
+skills: [release, docs]
+verify: [web-ext-lint, manual-store-review]
+reviewers: [code-reviewer, security-auditor, ux-reviewer]
+teammate_name: T20-store-release
+---
+
+# Task 20: Chrome Web Store packaging + privacy policy + listing assets
+
+## Description
+
+Final release task: prepare the extension for Chrome Web Store submission. Generate listing assets, write privacy policy, finalize manifest, package.
+
+## What to do
+
+1. **Privacy policy** (`packages/extension/PRIVACY.md` + hosted at `mnemonik.xyz/extension/privacy`):
+   - Local mode: data stays on device. No network. No analytics.
+   - Cloud mode: attestations encrypted in transit + at rest on AWS. Server can read attestation content (D8: no E2EE in MVP). Linked to Google account `sub` (opaque id, no email beyond what Google provides).
+   - Key escrow: server holds opaque ciphertext only, cannot decrypt. Passphrase never sent.
+   - Telemetry: opt-in only. Anonymous. Off by default.
+   - Right to deletion: `DELETE /api/key-escrow` + remove user's attestations on request.
+   - Contact email + DPA address.
+2. **Chrome Web Store listing copy** (`packages/extension/store-listing/`):
+   - Short description (132 chars): "Capture context from any AI chat. Verifiable, portable memory across ChatGPT, Claude, Gemini and more."
+   - Detailed description (16000 chars): hero pitch, bullet features, screenshots captions, privacy summary, pricing (Local free / Cloud paid).
+   - Promotional images (440x280 small tile, 920x680 large tile, 1400x560 marquee).
+   - 5 screenshots (1280x800): popup capture / popup recall / FAB on ChatGPT / options storage panel / restore flow.
+   - Single category: "Productivity".
+3. **Permissions justification** (required by Chrome Web Store review):
+   - `storage`: persist identity + settings.
+   - `identity`: Google sign-in via launchWebAuthFlow.
+   - `contextMenus`: "Save selection" right-click action.
+   - `activeTab`: capture text from current page on user gesture.
+   - `clipboardWrite`: "Copy markdown" action in recall.
+   - `alarms`: background retry of cloud sync queue.
+   - host_permissions per chat domain: chat-content extraction.
+4. **Final manifest review:**
+   - Version `1.0.0`.
+   - Strict CSP (no `unsafe-eval`; `wasm-unsafe-eval` allowed for WASM).
+   - All host_permissions enumerated (D11).
+   - `homepage_url` → mnemonik.xyz.
+5. **Build + package:**
+   - `pnpm -C packages/extension build`.
+   - `web-ext build --source-dir dist/ --artifacts-dir packages/extension/web-store/` → `mnemonik-1.0.0.zip`.
+   - Source-code zip for Chrome Web Store source-review (since we use minified WASM).
+6. **Submission checklist** (`packages/extension/RELEASE.md`): manual steps for first submission (developer dashboard, payment, OAuth verification with Google, privacy policy URL).
+7. **`webapp/`** — update `IdentityPanel.tsx` to add "Send to Extension" button (parallel to "Send to CLI"); add `/extension` landing-page section linking to Chrome Web Store post-launch.
+
+## TDD Anchor
+
+- Manual gate (no CI): `web-ext lint dist/` clean. `web-ext build` produces a `.zip` that uploads cleanly to the Chrome Web Store dashboard (dry-run via `chrome-webstore-upload-cli` if available, otherwise manual).
+- Privacy policy reviewed by D6 / security-auditor.
+
+## Files
+
+- Create: `packages/extension/PRIVACY.md`, `packages/extension/RELEASE.md`, `packages/extension/store-listing/{description.md, permissions-justification.md, screenshots/, promo/}`.
+- Modify: `packages/extension/manifest.json` (final version + URLs), `webapp/src/components/IdentityPanel.tsx` ("Send to Extension"), webapp landing page.
+- Read: D8 (no E2EE), D9 (escrow zero-knowledge), D11 (enumerated permissions), D12 (auto-capture opt-in).

--- a/work/chrome-extension/tech-spec.md
+++ b/work/chrome-extension/tech-spec.md
@@ -1,0 +1,265 @@
+---
+created: 2026-05-10
+status: draft
+size: L
+branch: claude/chrome-extension-storage-modes-ukS8l
+---
+
+# Tech Spec: Chrome Extension `Mnemonik` (Phase 1)
+
+## Solution
+
+New npm package `packages/extension/` (`@mnemonik-xyz/extension`), Manifest V3, built with **WXT** (decision in T1, fallback Vite + `@crxjs/vite-plugin`). Pure ESM. Reuses `@mnemonik-xyz/sdk` (browser-bundle from T2) and `@mnemonic/core` WASM. Distributed as `.zip` via Chrome Web Store; dev `pnpm -C packages/extension dev` produces `dist/` for unpacked load.
+
+The extension is a third public MCP-consumer (alongside CLI from `work/mnemonic-cli/` and webapp). Its **primary use case** is capturing AI-chat context (selections, messages, full conversations) from supported web AI-chat platforms — ChatGPT, Claude.ai, Gemini in Phase 1; Grok / Perplexity / Poe / OpenRouter in backlog. Secondary use case is generic page-selection capture on any site.
+
+Two user-visible storage tiers:
+- **Local** — fully self-contained in the browser (IndexedDB + WASM signing). Free, offline, no account.
+- **Cloud** — same client-side pipeline, plus push to hosted MCP server (existing `STORAGE_MODE=full` deployment) for Arweave + Solana anchoring and cross-device sync. Requires Google sign-in. Paid (existing `PAYMENT_MODE` flow).
+
+Server-side `StorageMode` enum in `mcp/src/config.rs` is **unchanged** (still `local | full`). "Cloud" is purely UX naming in the extension that maps to the existing hosted-`full` HTTP surface.
+
+Identity model: one Ed25519 keypair per user across all clients. Cloud-tier signs the keypair's secret with a user passphrase (Argon2id+AES-GCM-256) and escrows the ciphertext on the server keyed by Google `sub`. New-device sign-in fetches and decrypts client-side. Server cannot decrypt.
+
+## Architecture
+
+### What we build / modify
+
+**New (`packages/extension/`):**
+
+- `manifest.json` — MV3. Permissions: `storage`, `identity`, `contextMenus`, `activeTab`, `clipboardWrite`, `alarms`. host_permissions enumerated: `https://chatgpt.com/*`, `https://claude.ai/*`, `https://gemini.google.com/*` (+ extension origin for OAuth callback). Avoids `<all_urls>` to keep Chrome Web Store review simple. Generic page-selection capture works via `activeTab` + user gesture.
+- `src/background/service-worker.ts` — message router (popup ↔ content ↔ runtime), `chrome.commands` hotkey handler, `chrome.alarms` for cloud-sync retries, OAuth bootstrap.
+- `src/popup/` — React + Tailwind, dark theme, reuses webapp tokens (`#0A0F1E` bg, `#00D4B4` accent, monospace for hashes). Tabs: Capture · Recall · Verify · Settings-link.
+- `src/options/` — Settings, storage-mode toggle, identity management, security (rotate passphrase, export keypair), per-domain auto-capture toggles, telemetry opt-in.
+- `src/content/` — Per-domain content scripts:
+  - `chatgpt.adapter.ts`, `claude.adapter.ts`, `gemini.adapter.ts` — implement the `ChatAdapter` interface (see below).
+  - `selection.ts` — generic selection capture (works on any page; injected via `activeTab`).
+  - `fab.ts` — floating action button injected on supported domains.
+  - `recall-overlay.ts` — modal opened by hotkey on any page.
+- `src/runtime/` — domain logic, runtime-agnostic (no chrome.* APIs):
+  - `store/indexeddb.ts` — `IndexedDbStore implements AttestationStore` (TS interface mirroring `core/src/storage/traits.rs::AttestationStore`). Schema: object stores `attestations` (keyed by `attestation_id`), `lineage_edges`, `pending_uploads` (queue for cloud sync). Indexes on `signer_pubkey`, `created_at`, `tags` (multi-entry). Versioned schema (`v1`).
+  - `embed/transformers-embedder.ts` — `transformers.js` with `Xenova/all-MiniLM-L6-v2` (384 dim, ~25MB). Lazy-loaded in a Web Worker on first sign. Implements TS `Embedder` shape mirroring `core/src/embed/mod.rs::Embedder`. Vector dim 384 must match `mcp/src/config.rs` default — golden-fixture test enforces.
+  - `compress/turboquant.ts` — calls `@mnemonic/core` WASM `compress_embedding(emb, bits=4)`.
+  - `sign/cose.ts` — calls WASM `to_canonical_cbor`, `blake3_hash`, `sign_cose_payload`. Identical bytes to server (golden-fixture parity).
+  - `sync/cloud-client.ts` — talks to existing MCP HTTP server using `MnemonicClient` from SDK. Cloud-mode sign uses deferred-signing flow (`POST /mcp` `mnemonic_sign_memory` returns `correlation_id` → `POST /api/sign-callback` with COSE bytes).
+  - `chat/` — `ChatAdapter` interface (see below) + adapter registry + serializer (chat → `{messages: [{role, content, ts}], meta: {model, source, url, chat_id}}`).
+- `src/auth/`:
+  - `google-oauth.ts` — `chrome.identity.launchWebAuthFlow` against `GET /oauth/google/start`. PKCE S256. Returns server-issued JWT (existing `aud=mcp` shape, plus optional `google_sub` claim).
+  - `bootstrap-ticket.ts` — wraps `/api/extension-bootstrap/{issue,redeem}` (server change).
+  - `key-escrow.ts` — Argon2id KDF (via `hash-wasm`), AES-GCM-256 wrap/unwrap of Ed25519 secret using WebCrypto. Talks to `PUT/GET/DELETE /api/key-escrow`.
+- `src/types/` — `ChatAdapter`, `ChatTurn`, `Memory`, `StorageTier`, etc.
+- `tests/` — vitest unit + Playwright E2E. Adapter HAR fixtures in `tests/fixtures/`.
+
+**`ChatAdapter` interface (the framework that makes new platforms easy to add):**
+
+```ts
+export interface ChatAdapter {
+  readonly hostPattern: RegExp;            // matched against location.hostname
+  readonly platform: string;               // 'chatgpt' | 'claude' | 'gemini' | ...
+  /** Extract the current visible conversation as ordered turns. */
+  extractConversation(doc: Document): ChatTurn[];
+  /** Locate the chat input box for "insert into chat" recall. Phase 1 only ChatGPT must support; others can return null. */
+  findInputBox(doc: Document): HTMLElement | null;
+  /** Optional: return a stable per-chat id if the platform exposes one (URL slug, data attr). */
+  getChatId(doc: Document, location: Location): string | null;
+  /** Optional: detect when a new assistant turn finishes (for auto-capture mode). */
+  onNewAssistantTurn?(doc: Document, cb: (turn: ChatTurn) => void): () => void;
+}
+export type ChatTurn = { role: 'user' | 'assistant' | 'system'; content: string; ts?: string; modelHint?: string };
+```
+
+Adapter registry is a flat array exported from `src/content/adapters.ts`. Service worker selects adapter by `hostPattern` match against the active tab URL.
+
+**Modified (server, `mcp/`):**
+
+- `mcp/src/oauth.rs` — add Google OAuth provider:
+  - `GET /oauth/google/start?client_id=mnemonic-extension&redirect_uri=...&code_challenge=...&state=...` — redirects to Google consent.
+  - `GET /oauth/google/callback?code=...&state=...` — exchanges code for Google tokens, validates `id_token` (issuer = `accounts.google.com`, audience = `GOOGLE_OAUTH_CLIENT_ID`, signature via cached Google JWKS), then redirects to `redirect_uri` with our own server-issued auth code (existing `oauth/token` flow).
+  - On first link: requires extension to call `POST /oauth/google/link` with a possession-proof challenge signed by the new Ed25519 keypair, server inserts a row into `google_identity_links`.
+  - On subsequent sign-in: `POST /oauth/google/lookup` returns `{existing_pubkey, escrow_present: bool}`.
+- `mcp/src/api.rs` — new endpoints:
+  - `POST /api/extension-bootstrap/issue` (auth: server JWT) → one-time ticket.
+  - `GET /api/extension-bootstrap/redeem/:ticket` → JWT with `aud=extension`.
+  - `PUT /api/key-escrow` (auth: server JWT bound to a `google_sub`) — body `{ciphertext_b64, nonce_b64, kdf, kdf_params, pubkey_base58}`. Replaces existing blob for that `google_sub`. Server validates `pubkey_base58` matches the linked pubkey.
+  - `GET /api/key-escrow` (auth: server JWT) — returns blob + KDF params. Rate-limited: 5 fetches per 24h per `google_sub`. Counter persisted in `key_escrow_blobs` row.
+  - `DELETE /api/key-escrow` (auth: server JWT) — deletes blob (user explicit revocation).
+- `mcp/src/config.rs` — new env vars (all optional; if unset, Google login + escrow are disabled and server still boots):
+  - `GOOGLE_OAUTH_CLIENT_ID`
+  - `GOOGLE_OAUTH_CLIENT_SECRET`
+  - `GOOGLE_OAUTH_REDIRECT_URI` (default `https://mc.mnemonik.xyz/oauth/google/callback`)
+  - `KEY_ESCROW_RATE_LIMIT` (default 5, per 24h, per `google_sub`)
+- `mcp/src/main.rs` — wire Google OAuth router and key-escrow router conditionally (only if `GOOGLE_OAUTH_CLIENT_ID` set).
+- `core/src/storage/sqlite.rs` — migrations:
+  - `google_identity_links(google_sub TEXT PK, owner_pubkey TEXT NOT NULL, linked_at TEXT NOT NULL, last_seen TEXT)`. Index on `owner_pubkey`.
+  - `key_escrow_blobs(google_sub TEXT PK, ciphertext BLOB NOT NULL, nonce BLOB NOT NULL, kdf TEXT NOT NULL, kdf_params TEXT NOT NULL, pubkey_base58 TEXT NOT NULL, updated_at TEXT NOT NULL, fetch_count_24h INTEGER NOT NULL DEFAULT 0, last_fetch_at TEXT)`. Server only ever stores opaque ciphertext — secret never sent in plaintext.
+- `mcp/tests/oauth_google.rs` — mock Google JWKS server, full PKCE round-trip, link + lookup flows.
+- `mcp/tests/key_escrow.rs` — PUT/GET/DELETE, rate-limit, pubkey-binding validation.
+
+**Modified (build / repo):**
+
+- Root `package.json` — add `packages/extension` to workspaces.
+- `packages/sdk/package.json` — add `browser` export field for ESM browser bundle (already in T2 from `work/mnemonic-cli/backlog.md`).
+- `core/src/wasm/mod.rs` — verify `compress_embedding`, `decompress_embedding`, `to_canonical_cbor`, `blake3_hash`, `sign_cose_payload`, `generate_keypair`, `import_keypair_json`, `export_keypair_json` are all `#[wasm_bindgen]`-exported. Add any missing (T5 task).
+- `webapp/src/components/IdentityPanel.tsx` — add "Send to Extension" button mirroring "Send to CLI" pattern.
+- `.github/workflows/node-test.yml` — add `packages/extension` to matrix (Node 20, Bun).
+- New `.github/workflows/ext-e2e.yml` — Playwright E2E with extension loaded.
+
+**Unchanged (consumed as-is):**
+
+- `core/src/storage/traits.rs`, `mcp/src/tools.rs`, `mcp/src/payment.rs`, `mcp/src/pricing.rs`, all Arweave/Solana code, all existing OAuth (Solana wallet) flow.
+- **No new `cloud` enum variant in Rust.** "Cloud" is extension-side UX naming for hosted-`full`.
+
+## Data flow
+
+### Local-mode `signMemory` (browser-only, zero network)
+
+```
+chat capture (content script) ──┐
+selection capture ──────────────┴─→ ChatAdapter or selection.ts
+                                       │
+                                       ▼  {content, tags, source_meta}
+                                runtime/embed.ts  (transformers.js, Web Worker)
+                                       │  f32[384]
+                                       ▼
+                                runtime/compress.ts (WASM compress_embedding)
+                                       │  bytes (TurboQuant 4-bit)
+                                       ▼
+                                runtime/sign.ts
+                                       │  to_canonical_cbor → blake3 → sign_cose_payload
+                                       ▼  COSE_Sign1 envelope
+                                runtime/store/indexeddb.ts
+                                       │  put attestation
+                                       ▼
+                                popup updated via chrome.runtime.sendMessage
+```
+
+Synthetic `local:<truncated_hash>` tx ids identical to server-`local`.
+
+### Cloud-mode `signMemory`
+
+Same client-side pipeline up through COSE_Sign1 envelope. Then `sync/cloud-client.ts`:
+
+1. `POST /mcp` `mnemonic_sign_memory` (Bearer JWT) → server returns `{correlation_id, expires_in}` (existing deferred-signing flow).
+2. `POST /api/sign-callback` with `{correlation_id, cose_signed_bytes (base64), signer_pubkey (base58)}`. Server verifies, persists, anchors to Arweave + Solana.
+3. Response `{attestation_id, solana_tx, arweave_tx}`.
+4. `IndexedDbStore.put` with the same row plus real `solana_tx` / `arweave_tx`.
+5. Offline: enqueue in `pending_uploads` store; alarm-triggered retry.
+
+### Recall
+
+Always client-side cosine over IndexedDB embeddings. Cloud-tier additionally calls `mnemonic_recall` JSON-RPC and merges results, deduping by `attestation_id`.
+
+### Restore on new device
+
+```
+Install extension (fresh) ─→ first-run popup
+   │
+   ▼ user clicks "Sign in with Google"
+chrome.identity.launchWebAuthFlow → /oauth/google/start → Google consent → callback
+   │
+   ▼ server-issued JWT
+POST /oauth/google/lookup → { existing_pubkey: "H8x...", escrow_present: true }
+   │
+   ▼ popup shows "Welcome back, identity H8x... detected"
+user enters recovery passphrase
+   │
+   ▼ GET /api/key-escrow → { ciphertext, nonce, kdf, kdf_params, pubkey }
+key-escrow.ts: derive key via Argon2id(passphrase, salt) → AES-GCM-256 unwrap
+   │
+   ▼ Ed25519 secret recovered
+chrome.storage.local.set({ keypair }) — restored
+   │
+   ▼ background: sync mnemonic_recall (all) → IndexedDB cache
+ready: cloud-history visible in popup
+```
+
+Wrong passphrase: client retries decryption locally (no server roundtrip until `GET /api/key-escrow` is called again). Server-side rate-limit prevents brute force on the ciphertext fetch (5 per 24h per `google_sub`). After 5 failed client-side decrypts, popup blocks input for 24h (UX-level; server enforces fetch limit independently).
+
+## Decisions (seed for `decisions.md`)
+
+1. Extension is fully self-contained for local mode (browser-only). Cloud mode = thin client to hosted MCP-`full`.
+2. Server `StorageMode` is unchanged: still `local | full`. "Cloud" is purely UX naming in the extension.
+3. Browser embedder = `transformers.js` + `Xenova/all-MiniLM-L6-v2` (lazy-loaded, 384 dim). Vector dim MUST match server default — golden-fixture test enforces.
+4. Bundle: WXT (default) — fastest MV3 dev loop. Fallback Vite + crxjs. Final pick in T1.
+5. Google OAuth via `chrome.identity.launchWebAuthFlow` + PKCE S256. No Google client_secret in extension; server holds it. Server validates Google id_token + binds Google `sub` to Ed25519 pubkey via possession-proof.
+6. Identity: 1 Ed25519 keypair per user across CLI / webapp / extension. Cross-device = restore-on-google-signin OR existing bootstrap-ticket.
+7. Mode switching is explicit: local → cloud uploads existing attestations one-by-one (best-effort, resumable queue); cloud → local exports + disconnects. No silent dual-write.
+8. **Primary feature is AI-chat capture, not generic page capture.** Generic capture is a free fallback. Phase 1 ships adapters for ChatGPT, Claude.ai, Gemini.
+9. **Key escrow / restore via Google login** — server stores Ed25519 secret as a passphrase-encrypted blob keyed by Google `sub`. Wrap = AES-GCM-256 with key derived via Argon2id (`memory_cost=64MiB, time_cost=3, parallelism=1`, salt = 16 random bytes stored alongside ciphertext). Server only ever sees opaque ciphertext + KDF params + pubkey. Server cannot decrypt — passphrase never leaves client. Lost passphrase = lost restore (user falls back to manual keypair import). Rate limit: 5 GET fetches / 24h / `google_sub`.
+10. `ChatAdapter` interface keeps platform support extensible. Phase 1 ships 3 adapters (ChatGPT, Claude.ai, Gemini); contributions land via PRs adding new adapter modules + HAR fixtures + entry in registry.
+11. host_permissions enumerated explicitly per supported AI-chat domain (no `<all_urls>`) to ease Chrome Web Store review. Generic page-selection capture relies on `activeTab` + user gesture (popup hotkey or context-menu).
+12. Auto-capture is opt-in per domain (off by default). Privacy-first.
+
+## Testing
+
+### Unit (vitest, in `packages/extension/tests/unit/`)
+
+- `store/indexeddb.test.ts` — CRUD, search-by-tags, lineage edges, schema migration.
+- `embed/transformers.test.ts` — deterministic seed → expected vector (slack 1e-4).
+- `compress/turboquant.test.ts` — round-trip via WASM, compare against `core/` golden bytes.
+- `sign/cose.test.ts` — same plaintext + same keypair → byte-identical to server `to_canonical_cbor` + `sign_cose_payload`. Reuses `--features golden-fixtures` from `core/`.
+- `auth/key-escrow.test.ts` — wrap then unwrap → original bytes; wrong passphrase → fail; tampered ciphertext → fail.
+- `chat/chatgpt.adapter.test.ts`, `claude.adapter.test.ts`, `gemini.adapter.test.ts` — parse fixed HTML snapshot → expected `ChatTurn[]`.
+
+### Component (Playwright + Vitest browser mode)
+
+- Popup: capture, recall, verify, settings panel.
+- Onboarding: Local path; Cloud path with mocked Google + server.
+- Restore: fresh storage → mocked Google → passphrase prompt → identity restored.
+
+### E2E (Playwright with `--load-extension=dist/`)
+
+- `e2e/chatgpt-capture.spec.ts` — load HAR fixture of ChatGPT page → click "Save chat" → assert IndexedDB row.
+- `e2e/claude-capture.spec.ts` — same for Claude.ai.
+- `e2e/gemini-capture.spec.ts` — same for Gemini.
+- `e2e/recall-overlay.spec.ts` — open hotkey overlay on arbitrary page → search → copy.
+- `e2e/mode-switch.spec.ts` — Local → Cloud migration with mocked server.
+- `e2e/restore-on-second-profile.spec.ts` — install in second Chrome profile → Google → passphrase → assert keypair restored + memories synced.
+
+### Server (Rust)
+
+- `mcp/tests/oauth_google.rs` — mock Google JWKS, PKCE round-trip, link + lookup, possession-proof validation, signature-fail rejection.
+- `mcp/tests/key_escrow.rs` — PUT then GET round-trip, rate-limit (6th fetch within 24h fails), pubkey-binding mismatch rejection, DELETE, replay nonce.
+
+### CI
+
+- Existing `ci.yml` unchanged (Rust workspace).
+- Extend `node-test.yml`: matrix step for `packages/extension` (Node 20, Bun) running unit + component.
+- New `ext-e2e.yml`: Playwright with extension loaded, runs on PRs touching `packages/extension/**` or `packages/sdk/**`.
+- Bundle-size budget enforcement: fails CI if popup initial JS >50KB or total package >2MB (via `size-limit`).
+
+## Tasks (waves)
+
+Each task file in `tasks/` follows the existing pattern (`work/mnemonic-cli/tasks/3.md`): frontmatter (`status`, `depends_on`, `wave`, `skills`, `verify`, `reviewers`), description, what-to-do, TDD anchor, files (create/modify/read).
+
+- **Wave 1 (foundation, parallel):** T01 (scaffolding + WXT decision), T02 (SDK browser bundle, unblocks `work/mnemonic-cli` Phase 1.5).
+- **Wave 2 (storage + crypto pipeline, parallel after W1):** T03 (IndexedDB store), T04 (transformers.js embedder in worker), T05 (WASM bindings parity tests).
+- **Wave 3 (chat capture — primary feature):** T06 (ChatAdapter framework + registry), T07 (ChatGPT adapter + HAR fixture), T08 (Claude.ai adapter), T09 (Gemini adapter).
+- **Wave 4 (extension shell, parallel after W3):** T10 (MV3 manifest + service worker), T11 (popup UI), T12 (options page), T13 (FAB + recall overlay + hotkeys).
+- **Wave 5 (auth + cloud + escrow, sequential):** T14 (server: Google OAuth provider) → T15 (server: extension-bootstrap + key-escrow endpoints + DB migrations) → T16 (extension: Google sign-in client) → T17 (extension: key-escrow client + restore UX) → T18 (extension: cloud-tier sync via deferred signing).
+- **Wave 6 (release):** T19 (E2E suite + recorded HAR fixtures), T20 (Chrome Web Store packaging + privacy policy + listing assets).
+
+## Critical files (read-only context for implementer)
+
+- `core/src/storage/traits.rs` — `AttestationStore` trait shape to mirror in TS.
+- `core/src/storage/sqlite.rs:332+` — only existing impl; reference for IndexedDB schema.
+- `core/src/wasm/mod.rs` — verify exports cover signing pipeline + escrow primitives.
+- `mcp/src/tools.rs:380, 467` — storage-mode dispatch; unchanged but referenced.
+- `mcp/src/oauth.rs` — extend with Google provider.
+- `mcp/src/api.rs` — extend bootstrap-ticket flow + add escrow endpoints.
+- `mcp/src/config.rs:95` — env-driven config; add Google + escrow vars.
+- `webapp/src/components/IdentityPanel.tsx` — pattern for "Send to Extension" button.
+- `work/mnemonic-cli/user-spec.md`, `work/mnemonic-cli/tech-spec.md`, `work/mnemonic-cli/tasks/3.md` — format templates.
+- `work/mnemonic-cli/backlog.md` — Phase 1.5 SDK browser bundle (T02 fulfills).
+
+## Verification
+
+1. `cargo test --workspace --no-fail-fast` green; new `oauth_google.rs`, `key_escrow.rs` included.
+2. `pnpm -C packages/extension test` green (vitest unit + component).
+3. `pnpm -C packages/extension build` produces `dist/` with valid MV3 manifest; `web-ext lint dist/` clean.
+4. `pnpm -C packages/extension e2e` Playwright suite green (extension loaded, HAR fixtures replayed).
+5. Bundle size budget: popup ≤50KB initial, total ≤2MB (excl. lazy embedder model).
+6. Manual flow A (Local): install unpacked → choose Local → on `chatgpt.com` save chat → recall finds it → verify returns verified.
+7. Manual flow B (Cloud + restore): install → choose Cloud → Google sign-in → set passphrase → save chat on `claude.ai` → in webapp under same identity see attestation. Then second Chrome profile: install → Google sign-in (same account) → enter passphrase → identity restored, attestation visible. Wrong-passphrase 5 attempts → 6th blocked 24h.
+8. Server boot with `STORAGE_MODE=full` + `GOOGLE_OAUTH_CLIENT_ID` set: `GET /oauth/google/start` redirects; mock id_token tests in suite green.
+9. Privacy policy reviewed and linked from manifest + Chrome Web Store listing.

--- a/work/chrome-extension/user-spec.md
+++ b/work/chrome-extension/user-spec.md
@@ -1,0 +1,196 @@
+---
+created: 2026-05-10
+status: draft
+type: feature
+size: L
+---
+
+# User Spec: Chrome Extension `Mnemonik` (Phase 1 — AI-chat capture + Local/Cloud)
+
+## Что делаем
+
+Шипаем публичный Chrome-extension `Mnemonik` (Manifest V3, Chrome Web Store, MIT) — третий MCP-consumer после CLI и webapp. Главная функция: **захват контекста и истории из любого AI-чата в браузере** (ChatGPT, Claude.ai, Gemini, Grok, Perplexity, …) и сохранение его как verifiable memory под одной кросс-клиентской identity. Сохранённый контент далее:
+
+- доступен через `mnemonic_recall` во всех других MCP-клиентах (CLI, webapp, Cursor, Claude Desktop) под той же Ed25519 identity,
+- может быть скопирован обратно в новый чат как preloaded context,
+- подписан COSE_Sign1 локально в браузере и хранится по выбору пользователя:
+  - **Local** — IndexedDB, бесплатно, оффлайн, данные не покидают устройство;
+  - **Cloud** — managed Arweave + Solana на Mnemonik AWS-инфраструктуре, платно, синхронизация между устройствами и durable proof.
+
+Auth: **Google OAuth** как primary onboarding, и одновременно — механизм восстановления identity (Ed25519 keypair) на новом устройстве через encrypted key-escrow (passphrase-wrapped blob). Существующий Solana-wallet OAuth остаётся для power-users (CLI, headless).
+
+## Зачем
+
+**Сегодня контекст в AI-чатах эфемерен.** Пользователь работает с ChatGPT / Claude / Gemini, нагенерил полезные промпты, дискуссии, артефакты — а через сутки этого нет ни в поиске, ни в новом чате, ни в другой модели. Window-context съезжает, чат теряется в тред-листе, перенос в другой LLM = copy-paste руками.
+
+Mnemonik закрывает категорию "non-technical knowledge workers" + "vibe-coders на ChatGPT", которые:
+
+- работают преимущественно в браузерных AI-чатах, а не в IDE;
+- не поставят CLI и не запустят MCP-сервер;
+- хотят **portable cross-LLM memory** — сохранил инсайт в ChatGPT, через час подтянул его обратно в Claude или Gemini одним кликом;
+- хотят **proof-of-conversation** — durable, verifiable артефакт чата (для research, compliance, авторства).
+
+Cloud-tier — первый платный SKU с понятным value prop ("sync across devices + durable proof"). Free local-tier даёт zero-friction onboarding и сохраняет privacy-first позиционирование.
+
+## Как должно работать
+
+### Сценарий 1 — Install + first-run onboarding
+
+Пользователь устанавливает `Mnemonik` из Chrome Web Store. При первом запуске popup показывает:
+
+1. Краткий pitch (3 экрана: capture, recall, verify).
+2. Выбор tier: **Local (free)** или **Cloud (paid, sign in with Google)**. Local — кнопка "Start", без аккаунта, генерится локальный Ed25519 keypair, сохраняется в `chrome.storage.local`, печатает pubkey + DID в options. Cloud — кнопка "Sign in with Google" → `chrome.identity.launchWebAuthFlow` → выбор Google-аккаунта.
+3. Для Cloud: после Google-успеха — экран "Set recovery passphrase" (минимум 12 символов, zxcvbn-проверка ≥3). Объясняем: "passphrase нужен чтобы восстановить identity на другом устройстве; мы не можем его вспомнить за тебя; запиши в password manager". Generate keypair → wrap secret через Argon2id+AES-GCM → upload encrypted blob на сервер (`PUT /api/key-escrow`).
+4. Если Google-аккаунт уже привязан к существующей identity (server вернул `existing_pubkey`): экран "Welcome back" → запрос passphrase → fetch blob → decrypt → restore keypair в `chrome.storage.local`. Wrong passphrase: 5 попыток → 24h cooldown.
+
+### Сценарий 2 — Capture AI chat (главная функция)
+
+Пользователь открыл `chatgpt.com` (или `claude.ai`, `gemini.google.com`, `x.com/i/grok`, `perplexity.ai`, …). Extension content-script инжектит floating action button (FAB) в правый-нижний угол страницы (опционально hide-able) и пункт в context-menu "Save to Mnemonik".
+
+**Save selection** — пользователь выделил кусок ответа модели (или своего промпта), правый клик → "Save selection to Mnemonik" (или горячая клавиша `Cmd/Ctrl+Shift+M`). Popup всплывает, prefilled tags из URL (`source:chatgpt`, `model:gpt-5`, `chat:abc123`) + первая строка как title, кнопка "Sign". Подпись локально, IndexedDB save (Local) или upload (Cloud), toast "Saved · attestation 0xabc…".
+
+**Save whole conversation** — клик по FAB → "Save this chat". Content-script экстрактит всю текущую беседу через per-platform DOM-adapter, нормализует в structured markdown (JSONL of `{role, content, ts}` в payload + human-readable .md в content). Popup показывает preview + tag editor + storage-tier confirmation. Sign → Save.
+
+**Auto-capture (opt-in, options page)** — для определённого домена включить background watcher: каждый новый assistant-response в чате автоматически добавляется к "draft attestation"; в конце сессии (или по кнопке) — single sign covering the full conversation. Off по дефолту.
+
+### Сценарий 3 — Recall context back into a chat
+
+В popup или на любой странице с открытым AI-чатом: глобальная горячая клавиша `Cmd/Ctrl+Shift+R` → mini-search overlay → пользователь печатает запрос → top-5 семантически близких memories → выбирает → опции:
+
+- **Copy to clipboard** (markdown с ссылкой на attestation_id),
+- **Insert into chat input** (если adapter знает где input у текущего домена) — вставляет в поле ChatGPT/Claude/etc.,
+- **Open in popup** (полный текст + verify badge + источник).
+
+### Сценарий 4 — Verify
+
+Popup → "Verify" tab → paste attestation_id или drop файл с COSE-bundle → verified / tampered / not_found, с метаданными (signer, ts, source-platform).
+
+### Сценарий 5 — Switch storage mode
+
+Options page → "Storage" → переключатель Local/Cloud. Local→Cloud: явный prompt "upload N existing attestations to cloud?" → resumable очередь. Cloud→Local: "export and disconnect" → скачивает .zip с COSE-bundles + удаляет escrow blob по запросу.
+
+### Сценарий 6 — Restore identity on new device
+
+Установил extension на втором ноуте → Sign in with Google (тот же аккаунт) → server: `existing_pubkey: "H8x...c4v"` → popup показывает "Welcome back, identity H8x...c4v detected" → ввести recovery passphrase → fetch blob (`GET /api/key-escrow`) → Argon2id-derive key → AES-GCM-unwrap → keypair восстановлен в `chrome.storage.local` → cloud-history синхронизируется в IndexedDB. Если passphrase утерян: либо "start fresh" (новый keypair, теряется доступ к подписанной cloud-истории под старым ключом — данные читать можно, подписать новые от старого имени нельзя), либо импорт keypair-файла из webapp/CLI.
+
+### Сценарий 7 — Rotate passphrase
+
+Options → Security → "Rotate passphrase" → ввести old + new → re-encrypt blob → `PUT /api/key-escrow`.
+
+### Сценарий 8 — Programmatic / cross-client portability
+
+Та же identity (тот же pubkey) видит те же атестации в webapp, CLI (`mnemonic recall`), Claude.ai через MCP, Cursor. Ничего платформо-специфичного в payload — markdown + structured chat JSON универсальны.
+
+## Критерии приёмки
+
+**MUST для Phase 1:**
+
+- [ ] Manifest V3, проходит Chrome Web Store review (no remote code, declared permissions justified).
+- [ ] **Chat-adapter framework** + рабочие adapter'ы для ChatGPT (`chatgpt.com`), Claude.ai (`claude.ai`), Gemini (`gemini.google.com`). Grok / Perplexity — backlog if time.
+- [ ] **Save selection** работает на любом сайте (не только AI-чатах) через context-menu + горячую клавишу.
+- [ ] **Save whole conversation** работает на трёх supported платформах: экстрактится правильный turn-order, role labels, code blocks сохраняются как fenced markdown.
+- [ ] **Recall overlay** (`Cmd/Ctrl+Shift+R`) работает: top-k семантический поиск, copy/insert/open actions.
+- [ ] **Local mode** полностью оффлайн: zero network в DevTools после первого page-load. IndexedDB versioned schema. Synthetic `local:` tx ids идентичны server-`local`.
+- [ ] **Cloud mode**: Google sign-in → set passphrase → keypair generated + escrowed → save chat → server анкорит на Arweave+Solana → recall на втором устройстве после restore возвращает тот же memory.
+- [ ] **Restore flow** работает end-to-end: fresh extension install → Google sign-in (existing user) → enter passphrase → identity restored → cloud-history pulled.
+- [ ] **Wrong-passphrase rate-limit**: 5 fetches / 24h / `google_sub`, server-enforced.
+- [ ] **Bundle budget**: popup initial JS ≤50KB, total package ≤2MB (excl. lazy-loaded embedder model ~25MB, cached after first download).
+- [ ] **Full sign pipeline ≤2s** на M1 после warm WASM (warm: model loaded, WASM instantiated). Cold-start ≤8s.
+- [ ] **Accessibility**: keyboard navigation, ARIA labels, screen-reader friendly popup.
+- [ ] **Privacy policy** опубликован, явно говорит: local-mode = data stays on device, cloud-mode = encrypted-at-rest на AWS, escrow blob не E2EE для контента (только для secret key).
+- [ ] **CI**: vitest unit + Playwright E2E с загруженным extension; на supported платформах — smoke tests против записанных HAR.
+
+**Phase 1.5+ (backlog, не блокирующий):**
+
+- Auto-capture mode (per-domain watcher).
+- Grok / Perplexity / Poe / OpenRouter chat adapter'ы.
+- "Insert into chat input" для всех supported платформ (Phase 1 — только copy-to-clipboard).
+- Firefox / Safari порты.
+- WebAuthn (passkey) wrap взамен passphrase.
+- Team / shared memories.
+- E2EE attestation content (зашифровано до upload).
+- Custom embedder model selection.
+
+## Ограничения
+
+- **Chromium only Phase 1** (Chrome, Edge, Brave, Arc). Firefox/Safari — backlog.
+- **Embedder fixed**: `Xenova/all-MiniLM-L6-v2` (384 dim, ~25MB). User не выбирает модель.
+- **Adapter brittleness**: AI-chat UIs меняются часто; adapters могут сломаться, нужен update path. Версия adapters bundled с extension; auto-update через Chrome Web Store releases.
+- **No E2EE для attestation content в cloud-tier MVP**. Encrypted at rest + in transit, but server can technically read. Документировано. Phase 2 добавит client-side encryption.
+- **Recovery passphrase не recoverable**: lost passphrase = lost ability to restore on new device без manual keypair file.
+- **Auto-capture off by default** — privacy. User должен explicitly enable per domain.
+- **Cloud-tier requires online** для sign-callback; offline создаёт queue, синкается при reconnect.
+- **Identity = одна Ed25519 keypair** на user across CLI/webapp/extension. Multi-account — backlog.
+
+## Риски
+
+| Риск | Вероятность | Митигация |
+|------|-------------|-----------|
+| ChatGPT/Claude/Gemini DOM меняется → adapter ломается | Высокая | Adapter'ы изолированы за `ChatAdapter` интерфейсом; CI smoke runs против записанных HAR; bug-report кнопка в popup отправляет broken-adapter telemetry (opt-in). |
+| Chrome Web Store review reject (broad host_permissions, "captures user data") | Средняя | Минимизируем permissions: `activeTab` + специфичные host_permissions per supported domain (не `<all_urls>`); explicit user opt-in для capture; privacy policy с прямым text. |
+| WASM 442KB + 25MB embedder = slow first-sign UX | Средняя | Lazy-load model в Web Worker при первом sign; progress UI; кэш в Cache API после первого скачивания. |
+| Утерянный passphrase = поддержка-тикеты "верните мою identity" | Высокая | Жёсткий messaging при онбординге; password-manager prompt; "import keypair from webapp/CLI" как fallback. |
+| Google OAuth scope creep (запросим больше чем openid+email) | Низкая | Только `openid email profile`, никаких Drive/Gmail scopes. |
+| IndexedDB quota eviction при долгом неиспользовании | Низкая | `navigator.storage.persist()` request на onboarding; UI warning при approaching quota. |
+| Embedder vector dim ≠ серверной → recall в cross-client сценариях возвращает не то | Высокая если разъедутся | T5 валидирует round-trip против golden-fixtures из `core/`; CI gate. |
+
+## Технические решения (user-facing)
+
+- **Default tier: Local.** Cloud — opt-in через Google sign-in. Это сохраняет privacy-first messaging и снижает onboarding friction.
+- **Cloud requires Google sign-in + recovery passphrase.** Без passphrase нет escrow — но user может opt-out из escrow (тогда identity привязана к этому одному устройству, на втором нужен manual import).
+- **One identity per user** across all clients. Switching modes не меняет keypair.
+- **Adapter framework** документирован — можем принимать community contributions для новых платформ.
+- **Floating action button** опционален (hide через options или per-domain).
+- **Hotkeys customizable** (Chrome's `commands` API).
+- **Telemetry**: opt-in only (broken-adapter reports, anonymous). Default off.
+
+## Тестирование
+
+**Unit (vitest):**
+- IndexedDB store CRUD (mock IDBFactory).
+- Embedder round-trip с deterministic seed.
+- WASM signer parity vs server golden-fixtures.
+- Argon2id + AES-GCM wrap/unwrap round-trip.
+- Each chat adapter: parse фиксированный HTML snapshot → expected JSONL.
+
+**Component (Playwright):**
+- Popup: capture, recall, verify, options flows.
+- Onboarding: Google → passphrase → keypair → cloud upload (mocked server).
+- Restore: fresh storage → Google → passphrase → keypair restored.
+
+**E2E (Playwright with `--load-extension=dist/`):**
+- chat capture on ChatGPT (against recorded HAR fixture).
+- chat capture on Claude.ai.
+- chat capture on Gemini.
+- recall overlay on arbitrary page.
+- mode switch local→cloud.
+- restore on second profile.
+
+**Server (Rust, in `mcp/tests/`):**
+- `oauth_google.rs` — mock Google JWKS, full PKCE round-trip.
+- `key_escrow.rs` — PUT/GET/DELETE, rate-limit enforcement.
+
+**Security:**
+- Manual review: CSP (no `unsafe-eval`, no remote scripts).
+- `web-ext lint dist/` clean.
+- Argon2id parameters meet OWASP 2026 minimums (`memory_cost ≥ 64MiB, time_cost ≥ 3`).
+
+## Как проверить
+
+### Агент проверяет
+
+- `cargo test --workspace --no-fail-fast` зелёный (новые `oauth_google.rs`, `key_escrow.rs` в составе).
+- `pnpm -C packages/extension test` зелёный.
+- `pnpm -C packages/extension build` создаёт `dist/` с валидным MV3 manifest.
+- `web-ext lint dist/` без warnings.
+- Bundle size budget enforcement в CI (popup ≤50KB initial, total ≤2MB).
+- Round-trip COSE/CBOR test против golden-fixtures из `core/`.
+
+### Пользователь проверяет
+
+- Установка распакованного extension в Chrome → onboarding → выбор Local → save selection на любом сайте → recall находит.
+- Выбор Cloud → Google sign-in → set passphrase → save full chat в ChatGPT → в webapp под той же identity видна та же атестация.
+- На втором профиле/устройстве: install → Google sign-in → enter passphrase → identity restored → cloud-history появляется в popup.
+- Wrong passphrase 5 раз подряд → 6-я попытка блокируется на 24h.
+- Toggle "auto-capture" для chatgpt.com → каждый новый assistant-message добавляется в draft → "Finalize" → один attestation на всю беседу.
+- Recall overlay (`Cmd/Ctrl+Shift+R`) на странице Claude.ai → найти memory, скопированный из ChatGPT неделю назад.


### PR DESCRIPTION
Spec-driven workflow scaffolding for the Mnemonik Chrome extension. Primary
feature is AI-chat capture from supported platforms (ChatGPT, Claude.ai,
Gemini); generic page-selection capture is a fallback. Two user-visible
storage tiers: Local (IndexedDB, free, offline) and Cloud (managed
hosted-full on AWS, paid). Google login is the primary onboarding path and
also drives identity restore via passphrase-encrypted key escrow
(Argon2id+AES-GCM-256, server cannot decrypt).

Server-side StorageMode is unchanged (still local|full); cloud is purely UX
naming in the extension. ChatAdapter framework keeps platform support
extensible (T07-T09 ship ChatGPT/Claude/Gemini, more in backlog).

Includes 12 ratified decisions, full task waves (Wave 1-3 detailed; Wave 4-6
to follow). Branch: claude/chrome-extension-storage-modes-ukS8l.