### PR TITLE
feat(extension): T04 — transformers.js Web Worker embedder

### DIFF
--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -23,6 +23,7 @@
     "lint:webext": "web-ext lint --source-dir=dist"
   },
   "dependencies": {
+    "@xenova/transformers": "^2.17.2",
     "idb": "^8.0.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"

--- a/packages/extension/src/runtime/embed/transformers-embedder.ts
+++ b/packages/extension/src/runtime/embed/transformers-embedder.ts
@@ -1,0 +1,187 @@
+// Browser-side `Embedder` impl backed by `@xenova/transformers` running in a
+// dedicated Web Worker (`./worker.ts`). The worker is lazy-spawned on the
+// first `embed` call so the popup paints instantly — model download (~25MB)
+// only happens when the user actually signs a memory.
+//
+// Cold-init has a hard 30s budget; longer than that and we surface a
+// structured `EmbedderInitTimeout` so the UI layer can show a fallback /
+// retry state instead of hanging forever.
+
+import {
+  EmbedderInitTimeout,
+  EmbedderRuntimeError,
+  type Embedder,
+  type WorkerRequest,
+  type WorkerResponse,
+} from "./types";
+
+/** Server's fastembed default — see `core/src/embed/mod.rs:20`. */
+const SERVER_DEFAULT_DIM = 384;
+const DEFAULT_MODEL_ID = "Xenova/all-MiniLM-L6-v2";
+const DEFAULT_INIT_TIMEOUT_MS = 30_000;
+
+export interface TransformersEmbedderOptions {
+  modelId?: string;
+  /** Use INT8-quantised weights (~25MB vs ~80MB fp32). Default true. */
+  quantized?: boolean;
+  initTimeoutMs?: number;
+  /** Test seam — inject a worker built from a different URL or a stub. */
+  workerFactory?: () => Worker;
+}
+
+interface PendingEmbed {
+  resolve: (v: Float32Array) => void;
+  reject: (err: Error) => void;
+}
+
+export class TransformersEmbedder implements Embedder {
+  readonly dim = SERVER_DEFAULT_DIM;
+  readonly providerName = "transformers.js";
+  readonly isOpenWeights = true;
+  readonly modelId: string;
+
+  private readonly quantized: boolean;
+  private readonly initTimeoutMs: number;
+  private readonly workerFactory: () => Worker;
+
+  private worker: Worker | null = null;
+  private readyPromise: Promise<void> | null = null;
+  private disposed = false;
+  private nextRequestId = 1;
+  private readonly pending = new Map<number, PendingEmbed>();
+
+  constructor(options: TransformersEmbedderOptions = {}) {
+    this.modelId = options.modelId ?? DEFAULT_MODEL_ID;
+    this.quantized = options.quantized ?? true;
+    this.initTimeoutMs = options.initTimeoutMs ?? DEFAULT_INIT_TIMEOUT_MS;
+    this.workerFactory =
+      options.workerFactory ??
+      (() =>
+        new Worker(new URL("./worker.ts", import.meta.url), {
+          type: "module",
+          name: "mnemonik-embedder",
+        }));
+  }
+
+  async embed(text: string): Promise<Float32Array> {
+    if (this.disposed) {
+      throw new EmbedderRuntimeError("embed called on disposed embedder");
+    }
+    if (text.length === 0) {
+      throw new EmbedderRuntimeError("embed: text must not be empty");
+    }
+    await this.ensureReady();
+    const worker = this.worker;
+    if (!worker) {
+      throw new EmbedderRuntimeError("worker missing after init");
+    }
+    const id = this.nextRequestId++;
+    return new Promise<Float32Array>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      const req: WorkerRequest = { type: "embed", id, text };
+      worker.postMessage(req);
+    });
+  }
+
+  async dispose(): Promise<void> {
+    this.disposed = true;
+    const worker = this.worker;
+    if (!worker) return;
+    try {
+      const req: WorkerRequest = { type: "dispose" };
+      worker.postMessage(req);
+    } catch {
+      // Worker may already be terminated — ignore.
+    }
+    worker.terminate();
+    this.worker = null;
+    this.readyPromise = null;
+    for (const { reject } of this.pending.values()) {
+      reject(new EmbedderRuntimeError("embedder disposed before reply"));
+    }
+    this.pending.clear();
+  }
+
+  private ensureReady(): Promise<void> {
+    if (this.readyPromise) return this.readyPromise;
+    this.readyPromise = this.spawnAndInit();
+    return this.readyPromise;
+  }
+
+  private spawnAndInit(): Promise<void> {
+    const worker = this.workerFactory();
+    this.worker = worker;
+    worker.addEventListener(
+      "message",
+      (event: MessageEvent<WorkerResponse>) => {
+        this.onWorkerMessage(event.data);
+      },
+    );
+    worker.addEventListener("error", (event: ErrorEvent) => {
+      this.failAllPending(
+        new EmbedderRuntimeError(event.message || "worker error", event.error),
+      );
+    });
+
+    return new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        cleanup();
+        const err = new EmbedderInitTimeout(this.initTimeoutMs);
+        this.failAllPending(err);
+        reject(err);
+      }, this.initTimeoutMs);
+
+      const onReady = (event: MessageEvent<WorkerResponse>) => {
+        if (event.data.type === "ready") {
+          cleanup();
+          resolve();
+        } else if (event.data.type === "error" && event.data.id === undefined) {
+          cleanup();
+          reject(new EmbedderRuntimeError(event.data.message));
+        }
+      };
+      const cleanup = () => {
+        clearTimeout(timeout);
+        worker.removeEventListener("message", onReady);
+      };
+      worker.addEventListener("message", onReady);
+
+      const req: WorkerRequest = {
+        type: "init",
+        modelId: this.modelId,
+        quantized: this.quantized,
+      };
+      worker.postMessage(req);
+    });
+  }
+
+  private onWorkerMessage(msg: WorkerResponse): void {
+    if (msg.type === "embedded") {
+      const slot = this.pending.get(msg.id);
+      if (!slot) return;
+      this.pending.delete(msg.id);
+      if (msg.vector.length !== this.dim) {
+        slot.reject(
+          new EmbedderRuntimeError(
+            `vector dim ${msg.vector.length} does not match expected ${this.dim}`,
+          ),
+        );
+        return;
+      }
+      slot.resolve(msg.vector);
+      return;
+    }
+    if (msg.type === "error" && msg.id !== undefined) {
+      const slot = this.pending.get(msg.id);
+      if (!slot) return;
+      this.pending.delete(msg.id);
+      slot.reject(new EmbedderRuntimeError(msg.message));
+    }
+    // `ready` and `progress` are handled inline / dropped here.
+  }
+
+  private failAllPending(err: Error): void {
+    for (const { reject } of this.pending.values()) reject(err);
+    this.pending.clear();
+  }
+}

--- a/packages/extension/src/runtime/embed/types.ts
+++ b/packages/extension/src/runtime/embed/types.ts
@@ -1,0 +1,67 @@
+// Browser-side embedder contract. Mirrors `core/src/embed/mod.rs::Embedder`
+// (Send/Sync stripped — JS is single-threaded per realm). Concrete impls live
+// alongside this file: `transformers-embedder.ts` (production, all-MiniLM-L6-v2
+// in a Web Worker) and a mock used in tests.
+//
+// `dim` MUST equal the server's embedding dimension (384, fastembed default at
+// `mcp/src/config.rs` + `core/src/embed/mod.rs:20`). Drift breaks the
+// golden-fixture parity test in T05 and silently corrupts cosine recall across
+// server / extension memories.
+
+export interface Embedder {
+  /** Vector dimension. 384 for the project default. */
+  readonly dim: number;
+  /** Canonical model id stored in on-chain anchors. Third parties use this
+   *  to re-embed and verify. e.g. `"Xenova/all-MiniLM-L6-v2"`. */
+  readonly modelId: string;
+  /** Provider tag for logs / telemetry. e.g. `"transformers.js"`. */
+  readonly providerName: string;
+  /** True when the model weights are publicly downloadable — only open
+   *  weights produce externally verifiable attestations. */
+  readonly isOpenWeights: boolean;
+
+  /** Embed a single piece of text. Resolves to a length-`dim` Float32Array,
+   *  L2-normalized (matches fastembed / sentence-transformers default). */
+  embed(text: string): Promise<Float32Array>;
+
+  /** Release any underlying resources (workers, model buffers). Calling
+   *  `embed` after `dispose` is a programmer error. */
+  dispose(): Promise<void>;
+}
+
+/** Structured error surfaced when the worker fails to initialise within the
+ *  cold-start budget. Callers can branch on `code` to decide whether to
+ *  retry, surface a UI banner, or fall back to server-side embedding. */
+export class EmbedderInitTimeout extends Error {
+  readonly code = "embedder_init_timeout" as const;
+  constructor(public readonly timeoutMs: number) {
+    super(`Embedder cold-init exceeded ${timeoutMs}ms`);
+    this.name = "EmbedderInitTimeout";
+  }
+}
+
+/** Structured error for runtime embedding failures (worker crashed, model
+ *  download blocked by CSP, etc). */
+export class EmbedderRuntimeError extends Error {
+  readonly code = "embedder_runtime_error" as const;
+  constructor(message: string, public readonly cause?: unknown) {
+    super(message);
+    this.name = "EmbedderRuntimeError";
+  }
+}
+
+// ── Worker wire protocol ────────────────────────────────────────────────────
+// Messages sent across the `postMessage` boundary. Kept narrow on purpose:
+// only `embed` requests after `init`, plus a `dispose` cleanup. Progress
+// events are advisory (download bar in the popup) and may be dropped.
+
+export type WorkerRequest =
+  | { type: "init"; modelId: string; quantized: boolean }
+  | { type: "embed"; id: number; text: string }
+  | { type: "dispose" };
+
+export type WorkerResponse =
+  | { type: "ready" }
+  | { type: "progress"; status: string; file?: string; progress?: number }
+  | { type: "embedded"; id: number; vector: Float32Array }
+  | { type: "error"; id?: number; message: string };

--- a/packages/extension/src/runtime/embed/worker.ts
+++ b/packages/extension/src/runtime/embed/worker.ts
@@ -1,0 +1,118 @@
+/// <reference lib="webworker" />
+// Dedicated Web Worker that hosts `@xenova/transformers` and runs the
+// feature-extraction pipeline off the popup thread. The pipeline is
+// lazy-initialised on the first `init` message — model bytes (~25MB ONNX) are
+// downloaded once and cached by `transformers.js` via the browser's Cache API
+// (`env.useBrowserCache = true`, default).
+//
+// Wire protocol is in `./types.ts`. Keep this file dependency-free at module
+// scope so the bundler emits a small synchronous worker entry; the heavy
+// transformers import is dynamic and only happens when the popup actually
+// signs a memory.
+
+import type { WorkerRequest, WorkerResponse } from "./types";
+
+type FeatureExtractionPipeline = (
+  texts: string | string[],
+  opts: { pooling: "mean" | "none"; normalize: boolean },
+) => Promise<{ data: Float32Array | number[]; dims: number[] }>;
+
+let pipelinePromise: Promise<FeatureExtractionPipeline> | null = null;
+
+function post(msg: WorkerResponse, transfer?: Transferable[]): void {
+  // `self` in a module worker is `DedicatedWorkerGlobalScope` — postMessage
+  // exists. The cast keeps the file compilable under `lib: ["WebWorker"]`
+  // without dragging in `dom` lib types.
+  const scope = self as unknown as DedicatedWorkerGlobalScope;
+  if (transfer && transfer.length > 0) {
+    scope.postMessage(msg, transfer);
+  } else {
+    scope.postMessage(msg);
+  }
+}
+
+async function loadPipeline(
+  modelId: string,
+  quantized: boolean,
+): Promise<FeatureExtractionPipeline> {
+  if (pipelinePromise) return pipelinePromise;
+  pipelinePromise = (async () => {
+    const transformers = await import("@xenova/transformers");
+    // Cache model artefacts in the browser Cache API across sessions; this
+    // is the default but we set it explicitly so a future env override can
+    // be reasoned about from one place.
+    transformers.env.useBrowserCache = true;
+    transformers.env.allowLocalModels = false;
+    const pipe = await transformers.pipeline("feature-extraction", modelId, {
+      quantized,
+      progress_callback: (info: {
+        status: string;
+        file?: string;
+        progress?: number;
+      }) => {
+        post({
+          type: "progress",
+          status: info.status,
+          ...(info.file !== undefined ? { file: info.file } : {}),
+          ...(info.progress !== undefined ? { progress: info.progress } : {}),
+        });
+      },
+    });
+    return pipe as unknown as FeatureExtractionPipeline;
+  })();
+  return pipelinePromise;
+}
+
+async function handleEmbed(id: number, text: string): Promise<void> {
+  if (!pipelinePromise) {
+    post({
+      type: "error",
+      id,
+      message: "embed received before init",
+    });
+    return;
+  }
+  try {
+    const pipe = await pipelinePromise;
+    // `pooling: "mean"` averages token embeddings into one sentence vector;
+    // `normalize: true` L2-normalizes — both match sentence-transformers /
+    // fastembed defaults so vectors round-trip with the server's recall.
+    const out = await pipe(text, { pooling: "mean", normalize: true });
+    const vector =
+      out.data instanceof Float32Array ? out.data : new Float32Array(out.data);
+    // Transfer the underlying buffer to avoid a copy across the boundary.
+    post({ type: "embedded", id, vector }, [vector.buffer]);
+  } catch (err) {
+    post({
+      type: "error",
+      id,
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+self.addEventListener("message", (event: MessageEvent<WorkerRequest>) => {
+  const msg = event.data;
+  switch (msg.type) {
+    case "init": {
+      loadPipeline(msg.modelId, msg.quantized).then(
+        () => post({ type: "ready" }),
+        (err: unknown) =>
+          post({
+            type: "error",
+            message: err instanceof Error ? err.message : String(err),
+          }),
+      );
+      return;
+    }
+    case "embed": {
+      void handleEmbed(msg.id, msg.text);
+      return;
+    }
+    case "dispose": {
+      pipelinePromise = null;
+      (self as unknown as DedicatedWorkerGlobalScope).close();
+      return;
+    }
+  }
+});

--- a/packages/extension/tests/fixtures/embed/seed-vector.json
+++ b/packages/extension/tests/fixtures/embed/seed-vector.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "Recorded reference vector for the deterministic-seed parity test in tests/unit/embed/transformers.test.ts. Drives D3 cross-client recall reproducibility. Regenerate with: MNEMONIK_RECORD_EMBED_FIXTURE=1 npm run -w @mnemonik-xyz/extension test -- transformers (the test will write the captured values back into this file when the env var is set, otherwise it compares).",
+  "model_id": "Xenova/all-MiniLM-L6-v2",
+  "quantized": true,
+  "input": "hello mnemonik",
+  "dim": 384,
+  "first_eight_dims": null,
+  "l2_norm": null,
+  "recorded_at": null
+}

--- a/packages/extension/tests/unit/embed/transformers.test.ts
+++ b/packages/extension/tests/unit/embed/transformers.test.ts
@@ -1,0 +1,346 @@
+// T04 unit tests + TDD anchors for the browser embedder.
+//
+// Two anchors are binding per D13:
+//
+//   1. `dim_matches_server_default_384` — `embedder.dim === 384`. Drives D3
+//      vector-dim parity with the server (`core/src/embed/mod.rs:20`).
+//   2. `deterministic_seed_matches_fixture` — running the all-MiniLM-L6-v2
+//      pipeline on "hello mnemonik" produces a Float32Array with L2 norm
+//      ≈ 1.0 and first-8-dims matching `tests/fixtures/embed/seed-vector.json`
+//      within 1e-3. Drives reproducibility for cross-client recall.
+//
+// The wrapper class spawns a real `Worker`, which doesn't exist in Vitest's
+// node env. We therefore split the surface:
+//
+//   - Class-level tests inject a fake `workerFactory` so we exercise the
+//     spawn / message / dispose lifecycle without `transformers.js`.
+//   - Pipeline-level tests load `@xenova/transformers` directly in node
+//     (it ships with `onnxruntime-node`) and assert the *output* matches
+//     the recorded fixture. This is the same canonical vector the worker
+//     produces in the browser — both call `pipeline("feature-extraction",
+//     "Xenova/all-MiniLM-L6-v2", { quantized: true })` with the same
+//     pooling/normalize defaults.
+
+import { describe, it, expect, vi } from "vitest";
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { TransformersEmbedder } from "../../../src/runtime/embed/transformers-embedder.js";
+import {
+  EmbedderInitTimeout,
+  EmbedderRuntimeError,
+  type WorkerRequest,
+  type WorkerResponse,
+} from "../../../src/runtime/embed/types.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = path.resolve(
+  __dirname,
+  "../../fixtures/embed/seed-vector.json",
+);
+
+interface SeedFixture {
+  _comment?: string;
+  model_id: string;
+  quantized: boolean;
+  input: string;
+  dim: number;
+  first_eight_dims: number[] | null;
+  l2_norm: number | null;
+  recorded_at: string | null;
+}
+
+// ── Fake worker plumbing ────────────────────────────────────────────────────
+// Implements just enough of the `Worker` shape for the wrapper to drive its
+// lifecycle. The handler decides what to reply for each request.
+
+type Reply = WorkerResponse | WorkerResponse[];
+
+interface FakeWorkerOptions {
+  /** If true, never reply to `init` — used to exercise the timeout path. */
+  silentInit?: boolean;
+  /** Per-request reply, called for each `embed`. */
+  onEmbed?: (req: Extract<WorkerRequest, { type: "embed" }>) => Reply;
+}
+
+class FakeWorker {
+  terminated = false;
+  postMessages: WorkerRequest[] = [];
+  private readonly listeners = {
+    message: new Set<(e: MessageEvent<WorkerResponse>) => void>(),
+    error: new Set<(e: ErrorEvent) => void>(),
+  };
+  constructor(private readonly opts: FakeWorkerOptions = {}) {}
+
+  addEventListener(
+    type: "message" | "error",
+    cb: ((e: MessageEvent<WorkerResponse>) => void) &
+      ((e: ErrorEvent) => void),
+  ): void {
+    if (type === "message") this.listeners.message.add(cb);
+    else this.listeners.error.add(cb);
+  }
+  removeEventListener(
+    type: "message" | "error",
+    cb: ((e: MessageEvent<WorkerResponse>) => void) &
+      ((e: ErrorEvent) => void),
+  ): void {
+    if (type === "message") this.listeners.message.delete(cb);
+    else this.listeners.error.delete(cb);
+  }
+
+  postMessage(msg: WorkerRequest): void {
+    this.postMessages.push(msg);
+    if (msg.type === "init") {
+      if (!this.opts.silentInit) {
+        queueMicrotask(() => this.emit({ type: "ready" }));
+      }
+      return;
+    }
+    if (msg.type === "embed" && this.opts.onEmbed) {
+      const reply = this.opts.onEmbed(msg);
+      const replies = Array.isArray(reply) ? reply : [reply];
+      queueMicrotask(() => {
+        for (const r of replies) this.emit(r);
+      });
+    }
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  private emit(msg: WorkerResponse): void {
+    const event = { data: msg } as MessageEvent<WorkerResponse>;
+    for (const cb of this.listeners.message) cb(event);
+  }
+}
+
+// ── Class-level lifecycle tests ─────────────────────────────────────────────
+
+describe("TransformersEmbedder · contract", () => {
+  it("dim_matches_server_default_384 — exposes 384-dim per D3 parity", () => {
+    const embedder = new TransformersEmbedder({
+      workerFactory: () => new FakeWorker() as unknown as Worker,
+    });
+    expect(embedder.dim).toBe(384);
+    expect(embedder.modelId).toBe("Xenova/all-MiniLM-L6-v2");
+    expect(embedder.providerName).toBe("transformers.js");
+    expect(embedder.isOpenWeights).toBe(true);
+  });
+
+  it("lazy-spawns the worker only on the first embed call", async () => {
+    const factory = vi.fn(() => new FakeWorker() as unknown as Worker);
+    const embedder = new TransformersEmbedder({ workerFactory: factory });
+    expect(factory).not.toHaveBeenCalled();
+
+    const fake = new FakeWorker({
+      onEmbed: (req) => ({
+        type: "embedded",
+        id: req.id,
+        vector: new Float32Array(384),
+      }),
+    });
+    factory.mockImplementationOnce(() => fake as unknown as Worker);
+
+    await embedder.embed("hello mnemonik");
+    expect(factory).toHaveBeenCalledTimes(1);
+
+    await embedder.embed("again");
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("two embed calls return vectors of the configured dim", async () => {
+    const fake = new FakeWorker({
+      onEmbed: (req) => {
+        const v = new Float32Array(384);
+        // Deterministic-from-id payload — the wrapper just propagates bytes.
+        v[0] = req.id;
+        return { type: "embedded", id: req.id, vector: v };
+      },
+    });
+    const embedder = new TransformersEmbedder({
+      workerFactory: () => fake as unknown as Worker,
+    });
+    const a = await embedder.embed("hello");
+    const b = await embedder.embed("hello");
+    expect(a.length).toBe(384);
+    expect(b.length).toBe(384);
+  });
+
+  it("rejects with EmbedderInitTimeout when worker stays silent past budget", async () => {
+    const fake = new FakeWorker({ silentInit: true });
+    const embedder = new TransformersEmbedder({
+      workerFactory: () => fake as unknown as Worker,
+      initTimeoutMs: 25,
+    });
+    await expect(embedder.embed("hello")).rejects.toBeInstanceOf(
+      EmbedderInitTimeout,
+    );
+  });
+
+  it("rejects when worker reports a vector dim mismatch", async () => {
+    const fake = new FakeWorker({
+      onEmbed: (req) => ({
+        type: "embedded",
+        id: req.id,
+        vector: new Float32Array(128),
+      }),
+    });
+    const embedder = new TransformersEmbedder({
+      workerFactory: () => fake as unknown as Worker,
+    });
+    await expect(embedder.embed("hello")).rejects.toBeInstanceOf(
+      EmbedderRuntimeError,
+    );
+  });
+
+  it("propagates worker-side errors back through the embed promise", async () => {
+    const fake = new FakeWorker({
+      onEmbed: (req) => ({
+        type: "error",
+        id: req.id,
+        message: "model download blocked",
+      }),
+    });
+    const embedder = new TransformersEmbedder({
+      workerFactory: () => fake as unknown as Worker,
+    });
+    await expect(embedder.embed("hello")).rejects.toThrow(
+      /model download blocked/,
+    );
+  });
+
+  it("dispose_terminates_worker_cleanly", async () => {
+    const fake = new FakeWorker({
+      onEmbed: (req) => ({
+        type: "embedded",
+        id: req.id,
+        vector: new Float32Array(384),
+      }),
+    });
+    const embedder = new TransformersEmbedder({
+      workerFactory: () => fake as unknown as Worker,
+    });
+    await embedder.embed("hello");
+    expect(fake.terminated).toBe(false);
+
+    await embedder.dispose();
+    expect(fake.terminated).toBe(true);
+    expect(fake.postMessages.at(-1)).toEqual({ type: "dispose" });
+
+    await expect(embedder.embed("again")).rejects.toBeInstanceOf(
+      EmbedderRuntimeError,
+    );
+  });
+});
+
+// ── Pipeline-level fixture parity ───────────────────────────────────────────
+// Loads `@xenova/transformers` directly in node to capture / verify the
+// canonical vector. Running the same pipeline in the worker produces the
+// same bytes (same model file, same tokenizer, same `pooling: "mean"` +
+// `normalize: true` flags). When the dependency isn't installed locally
+// the test is skipped with an explicit reason; in CI the dep is always
+// installed and the assertion runs.
+
+async function tryLoadTransformers(): Promise<typeof import("@xenova/transformers") | null> {
+  try {
+    return (await import("@xenova/transformers")) as typeof import(
+      "@xenova/transformers"
+    );
+  } catch {
+    return null;
+  }
+}
+
+const pipelineDescribe =
+  process.env.MNEMONIK_SKIP_PIPELINE_TESTS === "1" ? describe.skip : describe;
+
+pipelineDescribe("transformers.js pipeline · fixture parity", () => {
+  it("deterministic_seed_matches_fixture — first 8 dims of L2-normalised vector for 'hello mnemonik'", async () => {
+    const transformers = await tryLoadTransformers();
+    if (!transformers) {
+      // Surface the skip explicitly so CI can spot dependency drift.
+      console.warn(
+        "[transformers.test] @xenova/transformers not installed; skipping pipeline parity test.",
+      );
+      return;
+    }
+    const fixture = JSON.parse(
+      readFileSync(FIXTURE_PATH, "utf8"),
+    ) as SeedFixture;
+    expect(fixture.model_id).toBe("Xenova/all-MiniLM-L6-v2");
+    expect(fixture.dim).toBe(384);
+
+    transformers.env.useBrowserCache = false;
+    transformers.env.allowLocalModels = false;
+    const pipe = await transformers.pipeline(
+      "feature-extraction",
+      fixture.model_id,
+      { quantized: fixture.quantized },
+    );
+    const out = (await pipe(fixture.input, {
+      pooling: "mean",
+      normalize: true,
+    })) as { data: Float32Array | number[]; dims: number[] };
+    const vector =
+      out.data instanceof Float32Array
+        ? out.data
+        : new Float32Array(out.data);
+
+    expect(vector.length).toBe(fixture.dim);
+    const norm = Math.sqrt(vector.reduce((s, x) => s + x * x, 0));
+    expect(norm).toBeCloseTo(1.0, 3);
+
+    const firstEight = Array.from(vector.slice(0, 8));
+
+    if (
+      !fixture.first_eight_dims ||
+      process.env.MNEMONIK_RECORD_EMBED_FIXTURE === "1"
+    ) {
+      const updated: SeedFixture = {
+        ...fixture,
+        first_eight_dims: firstEight,
+        l2_norm: norm,
+        recorded_at: new Date().toISOString(),
+      };
+      writeFileSync(FIXTURE_PATH, JSON.stringify(updated, null, 2) + "\n");
+      console.warn(
+        "[transformers.test] recorded fixture; commit tests/fixtures/embed/seed-vector.json to lock parity.",
+      );
+      return;
+    }
+
+    for (let i = 0; i < 8; i++) {
+      expect(firstEight[i]).toBeCloseTo(fixture.first_eight_dims[i]!, 3);
+    }
+    if (fixture.l2_norm !== null) {
+      expect(norm).toBeCloseTo(fixture.l2_norm, 3);
+    }
+  }, 120_000);
+
+  it("two consecutive calls produce identical vectors", async () => {
+    const transformers = await tryLoadTransformers();
+    if (!transformers) return;
+    const pipe = await transformers.pipeline(
+      "feature-extraction",
+      "Xenova/all-MiniLM-L6-v2",
+      { quantized: true },
+    );
+    const a = (await pipe("hello mnemonik", {
+      pooling: "mean",
+      normalize: true,
+    })) as { data: Float32Array | number[] };
+    const b = (await pipe("hello mnemonik", {
+      pooling: "mean",
+      normalize: true,
+    })) as { data: Float32Array | number[] };
+    const va = a.data instanceof Float32Array ? a.data : new Float32Array(a.data);
+    const vb = b.data instanceof Float32Array ? b.data : new Float32Array(b.data);
+    expect(vb.length).toBe(va.length);
+    for (let i = 0; i < va.length; i++) {
+      expect(vb[i]).toBe(va[i]);
+    }
+  }, 120_000);
+});

--- a/work/chrome-extension/tasks/04.md
+++ b/work/chrome-extension/tasks/04.md
@@ -1,11 +1,12 @@
 ---
-status: pending
+status: in_review
 depends_on: [01]
 wave: 2
 skills: [code-writing]
 verify: [pnpm-test]
 reviewers: [code-reviewer, test-reviewer]
 teammate_name: T04-embedder
+blocked_on: [fixture-recording, ci-verify]
 ---
 
 # Task 04: Browser embedder via `transformers.js` in Web Worker


### PR DESCRIPTION
## Summary

T04 from `work/chrome-extension/tasks/04.md` — implements the browser-side `Embedder` for the extension using `@xenova/transformers` and `Xenova/all-MiniLM-L6-v2` (384-dim, INT8 quantised) in a dedicated Web Worker. Lazy-spawned on the first `embed` call; model bytes (~25MB ONNX) cached via the browser's Cache API across sessions.

Vector dim 384 matches the server default at `core/src/embed/mod.rs:20` — drift breaks cross-client recall (D3).

## Files

- `packages/extension/src/runtime/embed/types.ts` — `Embedder` interface mirroring `core/src/embed/mod.rs::Embedder`, structured error classes (`EmbedderInitTimeout`, `EmbedderRuntimeError`), and the `WorkerRequest`/`WorkerResponse` wire protocol.
- `packages/extension/src/runtime/embed/worker.ts` — module worker; lazy-imports transformers, runs `pipeline("feature-extraction", "Xenova/all-MiniLM-L6-v2", { quantized: true })` with `pooling: "mean"` + `normalize: true` (matches fastembed / sentence-transformers defaults), posts vectors back via transferable buffers, `env.useBrowserCache = true`.
- `packages/extension/src/runtime/embed/transformers-embedder.ts` — wrapper class. Lazy-spawns the worker, multiplexes embed requests by id, enforces dim parity on every reply, propagates structured errors, exposes a `workerFactory` test seam. 30s cold-init budget surfaces `EmbedderInitTimeout`.
- `packages/extension/tests/unit/embed/transformers.test.ts` — TDD anchors per **D13**:
  - `dim_matches_server_default_384` (pure-unit, no model load)
  - `deterministic_seed_matches_fixture` (loads transformers in node, asserts L2 norm ≈ 1.0 and first-8-dims within 1e-3 of recorded fixture)
  - Plus lifecycle tests via injected fake worker: lazy-spawn, `dispose` termination, init timeout, dim mismatch rejection, error propagation.
- `packages/extension/tests/fixtures/embed/seed-vector.json` — fixture skeleton. First run with `MNEMONIK_RECORD_EMBED_FIXTURE=1` records the canonical vector for `"hello mnemonik"` and locks it.
- `packages/extension/package.json` — adds `@xenova/transformers ^2.17.2`.
- `work/chrome-extension/tasks/04.md` — `status: in_review`, `blocked_on: [fixture-recording, ci-verify]` per D13.

Manifest unchanged: model download goes over `connect-src` (CORS-OK on huggingface.co); the WASM CSP `wasm-unsafe-eval` lands with shell wiring in T10.

## D13 status

`tasks/04.md` is `in_review`, **not** `done`. Per D13 the TDD-anchor tests + `pnpm-test` must pass in CI on this PR before the task can be marked done. The `deterministic_seed_matches_fixture` fixture is committed empty — it self-records on the first run with values intact within a single CI invocation, but locking real cross-run regression coverage requires running once with `MNEMONIK_RECORD_EMBED_FIXTURE=1` and committing the captured vector.

## Test plan

- [ ] CI runs `cargo test --workspace` (Rust untouched — should pass clean)
- [ ] `npm install` resolves the new `@xenova/transformers` runtime dep
- [ ] `npm run -w @mnemonik-xyz/extension test` passes — class-level lifecycle tests (fake worker) green; pipeline parity test self-records and passes
- [ ] `npm run -w @mnemonik-xyz/extension lint` (`tsc -b --noEmit`) clean
- [ ] `npm run -w @mnemonik-xyz/extension lint:webext` clean
- [ ] Locally: run with `MNEMONIK_RECORD_EMBED_FIXTURE=1` once, commit `tests/fixtures/embed/seed-vector.json` with the recorded first-8-dims to lock parity

## Notes

- Targeted at `dev` (not `main`) — same integration-buffer rationale as #96 / #97.
- Open question for review (raised in chat): whether to migrate `@xenova/transformers` → `@huggingface/transformers` v3 for WebGPU support in a follow-up. **Model stays `all-MiniLM-L6-v2`** regardless, since server parity is non-negotiable.

https://claude.ai/code/session_01PC2ymfi7PffTvfA7fwNC5f

---
_Generated by [Claude Code](https://claude.ai/code/session_01PC2ymfi7PffTvfA7fwNC5f)_