### PR TITLE
feat(extension): T07 — chatgpt adapter

### DIFF
--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -34,7 +34,9 @@
     "clipboardWrite",
     "alarms"
   ],
-  "host_permissions": [],
+  "host_permissions": [
+    "https://chatgpt.com/*"
+  ],
   "commands": {
     "_execute_action": {
       "suggested_key": {

--- a/packages/extension/src/runtime/chat/adapters/chatgpt.adapter.ts
+++ b/packages/extension/src/runtime/chat/adapters/chatgpt.adapter.ts
@@ -1,0 +1,170 @@
+// ChatGPT (`chatgpt.com`) adapter — plugs into `runtime/chat/registry.ts`
+// per the framework laid down in T06. DOM selectors target the 2026 layout:
+// per-turn `[data-message-author-role]` nodes, a streaming-state
+// `data-stream` attribute on the assistant turn while tokens are still
+// arriving, and `textarea[data-id="root"]` for the prompt input. Verify
+// the selectors on capture day — the live ChatGPT DOM is not stable.
+
+import { registerAdapter } from "../registry.js";
+import {
+  domNodeToMarkdown,
+} from "../serializer.js";
+import type { ChatAdapter, ChatTurn } from "../types.js";
+
+/** Path segment after `/c/` is the stable chat id (typically a UUID). */
+const CHAT_ID_PATH = /^\/c\/([^/?#]+)/;
+
+/** Streaming-state attribute on the assistant turn while tokens stream in. */
+const STREAM_ATTR = "data-stream";
+
+function inferRole(value: string | null): ChatTurn["role"] | null {
+  if (value === "user" || value === "assistant" || value === "system") {
+    return value;
+  }
+  // ChatGPT also surfaces `tool` / `function` roles internally; fold them
+  // under `system` so the conversation still serialises rather than
+  // dropping context. Adapters MAY choose differently — generic fold is
+  // the conservative choice for cross-platform recall.
+  return value ? "system" : null;
+}
+
+export const chatgptAdapter: ChatAdapter = {
+  hostPattern: /^chatgpt\.com\//,
+  platform: "chatgpt",
+
+  extractConversation(doc: Document): ChatTurn[] {
+    const nodes = doc.querySelectorAll<HTMLElement>(
+      "[data-message-author-role]",
+    );
+    const turns: ChatTurn[] = [];
+    for (const node of Array.from(nodes)) {
+      const role = inferRole(node.getAttribute("data-message-author-role"));
+      if (!role) continue;
+      const content = domNodeToMarkdown(node).trim();
+      if (!content) continue;
+      turns.push({ role, content });
+    }
+    return turns;
+  },
+
+  findInputBox(doc: Document): HTMLElement | null {
+    // Primary selector — current 2026 ChatGPT prompt textarea.
+    const textarea = doc.querySelector<HTMLTextAreaElement>(
+      'textarea[data-id="root"]',
+    );
+    if (textarea) return textarea;
+    // Fallback: contenteditable composer used during A/B rollouts.
+    return doc.querySelector<HTMLElement>(
+      '[contenteditable="true"][data-id="root"]',
+    );
+  },
+
+  getChatId(_doc: Document, location: Location): string | null {
+    const match = CHAT_ID_PATH.exec(location.pathname);
+    return match?.[1] ?? null;
+  },
+
+  onNewAssistantTurn(
+    doc: Document,
+    cb: (turn: ChatTurn) => void,
+  ): () => void {
+    // Track which assistant turns we've already announced + which were
+    // observed mid-stream. An emit fires when a `[data-stream]` turn
+    // loses that attribute (streaming finished) OR a fresh assistant
+    // turn appears already-settled (snapshot replay).
+    const announced = new WeakSet<Element>();
+    const wasStreaming = new WeakSet<Element>();
+
+    const emit = (turn: Element): void => {
+      if (announced.has(turn)) return;
+      announced.add(turn);
+      const role = inferRole(turn.getAttribute("data-message-author-role"));
+      if (role !== "assistant") return;
+      const content = domNodeToMarkdown(turn).trim();
+      if (!content) return;
+      cb({ role, content });
+    };
+
+    const visit = (turn: Element): void => {
+      if (turn.getAttribute("data-message-author-role") !== "assistant") {
+        return;
+      }
+      if (turn.hasAttribute(STREAM_ATTR)) {
+        wasStreaming.add(turn);
+        return;
+      }
+      // No stream attribute now — emit if we previously saw it streaming
+      // (transition) or if it appeared settled from the start.
+      emit(turn);
+    };
+
+    // Seed with any assistant turns already in the DOM at subscription time.
+    for (const turn of Array.from(
+      doc.querySelectorAll<HTMLElement>(
+        '[data-message-author-role="assistant"]',
+      ),
+    )) {
+      visit(turn);
+    }
+
+    // Pull `MutationObserver` from the document's own window so the
+    // adapter works under both real browser globals and a JSDOM-backed
+    // unit test environment (where Node's globalThis lacks the API).
+    const view = doc.defaultView ??
+      (typeof globalThis !== "undefined" ? globalThis : undefined);
+    const Observer =
+      view && (view as { MutationObserver?: typeof MutationObserver })
+        .MutationObserver;
+    if (!Observer) return () => {};
+
+    const observer = new Observer((records) => {
+      for (const record of records) {
+        if (record.type === "childList") {
+          for (const added of Array.from(record.addedNodes)) {
+            if (added.nodeType !== 1 /* ELEMENT_NODE */) continue;
+            const el = added as Element;
+            if (el.matches?.("[data-message-author-role]")) {
+              visit(el);
+            }
+            for (const inner of Array.from(
+              el.querySelectorAll?.(
+                '[data-message-author-role="assistant"]',
+              ) ?? [],
+            )) {
+              visit(inner);
+            }
+          }
+        } else if (
+          record.type === "attributes" &&
+          record.attributeName === STREAM_ATTR
+        ) {
+          const target = record.target as Element;
+          if (
+            target.getAttribute("data-message-author-role") === "assistant" &&
+            !target.hasAttribute(STREAM_ATTR) &&
+            wasStreaming.has(target)
+          ) {
+            emit(target);
+          }
+        }
+      }
+    });
+
+    const root = doc.body ?? doc.documentElement;
+    if (root) {
+      observer.observe(root, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: [STREAM_ATTR],
+      });
+    }
+
+    return () => observer.disconnect();
+  },
+};
+
+// Self-register on import. Bootstrap modules (popup, content script,
+// service worker) opt in to ChatGPT support by importing this module
+// (or `runtime/chat/adapters/index.ts`).
+registerAdapter(chatgptAdapter);

--- a/packages/extension/src/runtime/chat/adapters/index.ts
+++ b/packages/extension/src/runtime/chat/adapters/index.ts
@@ -1,0 +1,7 @@
+// Adapter bootstrap. Importing this module registers every concrete
+// `ChatAdapter` with the registry as an import side-effect. T07 wires
+// ChatGPT; T08/T09 will add `./claude.adapter.js` and
+// `./gemini.adapter.js` lines below — keep registrations alphabetical
+// so concurrent feature branches edit different lines and merge cleanly.
+
+import "./chatgpt.adapter.js";

--- a/packages/extension/tests/fixtures/chatgpt/code.html
+++ b/packages/extension/tests/fixtures/chatgpt/code.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<!--
+  ChatGPT multi-turn-with-code fixture (hand-crafted, not a live capture —
+  sandbox cannot reach chatgpt.com). Mirrors the 2026 DOM described in T07:
+  - per-turn `[data-message-author-role]` nodes alternating user/assistant
+  - assistant code blocks rendered as `<pre><code class="language-X">`
+  - prompt `<textarea data-id="root">` at the bottom
+  Two languages (Python + Rust) drive `extracts_code_block_with_language`
+  and adjacent serializer round-trip checks. Refresh from a live capture
+  before merge once a human can verify.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>ChatGPT — code blocks</title>
+  </head>
+  <body>
+    <main>
+      <article data-message-author-role="user" data-message-id="u1">
+        <div class="prose">
+          <p>How do I sort a list in Python?</p>
+        </div>
+      </article>
+      <article data-message-author-role="assistant" data-message-id="a1">
+        <div class="prose">
+          <p>Use the built-in <code>sorted</code>:</p>
+          <pre><code class="language-python">def sort_list(xs):
+    return sorted(xs)</code></pre>
+          <p>That returns a new list.</p>
+        </div>
+      </article>
+      <article data-message-author-role="user" data-message-id="u2">
+        <div class="prose">
+          <p>And in Rust?</p>
+        </div>
+      </article>
+      <article data-message-author-role="assistant" data-message-id="a2">
+        <div class="prose">
+          <p>Sort in place with <code>Vec::sort</code>:</p>
+          <pre><code class="language-rust">fn main() {
+    let mut xs = vec![3, 1, 2];
+    xs.sort();
+    println!("{:?}", xs);
+}</code></pre>
+        </div>
+      </article>
+      <form>
+        <textarea data-id="root" placeholder="Message ChatGPT"></textarea>
+      </form>
+    </main>
+  </body>
+</html>

--- a/packages/extension/tests/fixtures/chatgpt/empty.html
+++ b/packages/extension/tests/fixtures/chatgpt/empty.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<!--
+  ChatGPT empty-chat fixture (hand-crafted, not a live capture — sandbox
+  cannot reach chatgpt.com). Mirrors the 2026 DOM described in T07:
+  - no `[data-message-author-role]` nodes (fresh chat)
+  - prompt textarea with `data-id="root"`
+  Refresh from a live capture before merge once a human can verify.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>ChatGPT</title>
+  </head>
+  <body>
+    <main>
+      <div id="thread"></div>
+      <form>
+        <textarea data-id="root" placeholder="Message ChatGPT"></textarea>
+      </form>
+    </main>
+  </body>
+</html>

--- a/packages/extension/tests/fixtures/chatgpt/long.html
+++ b/packages/extension/tests/fixtures/chatgpt/long.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<!--
+  ChatGPT long-thread fixture (hand-crafted, not a live capture — sandbox
+  cannot reach chatgpt.com). Mirrors the 2026 DOM described in T07:
+  - many alternating turns to exercise multi-turn ordering + scrolling
+  - one assistant turn carries `data-stream` to mimic a still-streaming
+    response (drives `onNewAssistantTurn` settle detection)
+  - one short code block to keep markdown serialization realistic
+  Refresh from a live capture before merge once a human can verify.
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>ChatGPT — long thread</title>
+  </head>
+  <body>
+    <main>
+      <article data-message-author-role="system" data-message-id="s0">
+        <div class="prose">You are a helpful assistant.</div>
+      </article>
+      <article data-message-author-role="user" data-message-id="u1">
+        <div class="prose"><p>What's 2 + 2?</p></div>
+      </article>
+      <article data-message-author-role="assistant" data-message-id="a1">
+        <div class="prose"><p>4.</p></div>
+      </article>
+      <article data-message-author-role="user" data-message-id="u2">
+        <div class="prose"><p>And 3 + 5?</p></div>
+      </article>
+      <article data-message-author-role="assistant" data-message-id="a2">
+        <div class="prose"><p>8.</p></div>
+      </article>
+      <article data-message-author-role="user" data-message-id="u3">
+        <div class="prose"><p>Show me a one-liner echo in bash.</p></div>
+      </article>
+      <article data-message-author-role="assistant" data-message-id="a3">
+        <div class="prose">
+          <p>Sure:</p>
+          <pre><code class="language-bash">echo "hello"</code></pre>
+        </div>
+      </article>
+      <article data-message-author-role="user" data-message-id="u4">
+        <div class="prose"><p>And a long answer please.</p></div>
+      </article>
+      <article
+        data-message-author-role="assistant"
+        data-message-id="a4"
+        data-stream="true"
+      >
+        <div class="prose"><p>Working on it…</p></div>
+      </article>
+      <form>
+        <textarea data-id="root" placeholder="Message ChatGPT"></textarea>
+      </form>
+    </main>
+  </body>
+</html>

--- a/packages/extension/tests/unit/chat/chatgpt.adapter.test.ts
+++ b/packages/extension/tests/unit/chat/chatgpt.adapter.test.ts
@@ -1,0 +1,253 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { JSDOM } from "jsdom";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { chatgptAdapter } from "../../../src/runtime/chat/adapters/chatgpt.adapter.js";
+import {
+  __setAdaptersForTesting,
+  selectAdapter,
+} from "../../../src/runtime/chat/registry.js";
+import { serializeMarkdown } from "../../../src/runtime/chat/serializer.js";
+import type { ChatTurn } from "../../../src/runtime/chat/types.js";
+
+// `chatgpt.adapter.ts` self-registers via `registerAdapter` on import,
+// so wipe the registry between tests to keep `selectAdapter` cases
+// deterministic. Other tests that depend on a stable adapter list use
+// `__setAdaptersForTesting` directly.
+afterEach(() => {
+  __setAdaptersForTesting([]);
+});
+
+const FIXTURE_DIR = resolve(__dirname, "../../fixtures/chatgpt");
+function loadFixture(name: "empty" | "code" | "long"): Document {
+  const html = readFileSync(resolve(FIXTURE_DIR, `${name}.html`), "utf8");
+  return new JSDOM(html).window.document;
+}
+function loadFixtureWithLocation(
+  name: "empty" | "code" | "long",
+  url: string,
+): { doc: Document; location: Location } {
+  const html = readFileSync(resolve(FIXTURE_DIR, `${name}.html`), "utf8");
+  const dom = new JSDOM(html, { url });
+  return { doc: dom.window.document, location: dom.window.location };
+}
+
+describe("chatgpt adapter · contract", () => {
+  it("declares hostPattern and platform identifying chatgpt.com", () => {
+    expect(chatgptAdapter.platform).toBe("chatgpt");
+    expect(chatgptAdapter.hostPattern.test("chatgpt.com/")).toBe(true);
+    expect(chatgptAdapter.hostPattern.test("chatgpt.com/c/abc")).toBe(true);
+    expect(chatgptAdapter.hostPattern.test("claude.ai/chat/abc")).toBe(false);
+  });
+
+  it("self-registers so selectAdapter resolves chatgpt.com URLs to it", () => {
+    // Importing the adapter module triggers registerAdapter as a side
+    // effect — the popup / content script bootstrap relies on this.
+    // (The afterEach wipe means we re-seed manually here.)
+    __setAdaptersForTesting([chatgptAdapter]);
+    expect(selectAdapter("https://chatgpt.com/c/abc123")).toBe(chatgptAdapter);
+    expect(selectAdapter("https://example.com/")).toBeNull();
+  });
+});
+
+describe("chatgpt adapter · extractConversation", () => {
+  // T07 D13 anchor — code block with a `language-*` hint must round-trip
+  // through `domNodeToMarkdown` as a fenced ```python block. Drives D8
+  // code-fidelity guarantee.
+  it("extracts_code_block_with_language", () => {
+    const doc = loadFixture("code");
+    const turns = chatgptAdapter.extractConversation(doc);
+
+    const assistant = turns.find(
+      (t) => t.role === "assistant" && t.content.includes("sorted"),
+    );
+    expect(assistant).toBeDefined();
+    expect(assistant?.content).toContain("```python\ndef sort_list(xs):\n    return sorted(xs)\n```");
+
+    const rust = turns.find(
+      (t) => t.role === "assistant" && t.content.includes("Vec::sort"),
+    );
+    expect(rust?.content).toMatch(/```rust\nfn main\(\) \{/);
+  });
+
+  // T07 D13 anchor — role attribute must be the source of truth so a
+  // captured chat reconstructs faithfully.
+  it("role_inferred_from_data_attr", () => {
+    const doc = loadFixture("code");
+    const turns = chatgptAdapter.extractConversation(doc);
+    const roles = turns.map((t) => t.role);
+    // code.html alternates user/assistant/user/assistant.
+    expect(roles).toEqual(["user", "assistant", "user", "assistant"]);
+  });
+
+  it("preserves multi-turn order and folds non-standard roles into system", () => {
+    const doc = loadFixture("long");
+    const turns = chatgptAdapter.extractConversation(doc);
+    // First turn is system, then alternating user/assistant. The trailing
+    // streaming `Working on it…` turn still emits content in extraction
+    // (the streaming gate is for `onNewAssistantTurn`, not for snapshot
+    // capture).
+    expect(turns[0]?.role).toBe("system");
+    expect(turns[1]?.role).toBe("user");
+    expect(turns[2]?.role).toBe("assistant");
+    expect(turns.at(-1)?.role).toBe("assistant");
+    expect(turns.at(-1)?.content).toContain("Working on it");
+  });
+
+  it("returns an empty list for a fresh empty chat", () => {
+    const doc = loadFixture("empty");
+    expect(chatgptAdapter.extractConversation(doc)).toEqual([]);
+  });
+
+  it("serializeMarkdown over extracted turns keeps fenced code blocks intact", () => {
+    const doc = loadFixture("code");
+    const turns = chatgptAdapter.extractConversation(doc);
+    const md = serializeMarkdown(turns, {
+      platform: "chatgpt",
+      chatId: "abc123",
+    });
+    expect(md).toContain("```python\ndef sort_list(xs):\n    return sorted(xs)\n```");
+    expect(md).toMatch(/```rust\nfn main\(\) \{[\s\S]+\}\n```/);
+    // Role headings emitted in the order extracted.
+    const userIdx = md.indexOf("### user");
+    const asstIdx = md.indexOf("### assistant");
+    expect(userIdx).toBeGreaterThan(-1);
+    expect(asstIdx).toBeGreaterThan(userIdx);
+  });
+});
+
+describe("chatgpt adapter · findInputBox", () => {
+  // T07 D13 anchor — recall paste-into-chat needs a non-null element on
+  // chat pages. Landing-style DOM (no textarea) should return null so
+  // the popup can fall back to a clipboard copy.
+  it("findInputBox_returns_textarea", () => {
+    const chatDoc = loadFixture("empty");
+    const found = chatgptAdapter.findInputBox(chatDoc);
+    expect(found).not.toBeNull();
+    expect(found?.tagName.toLowerCase()).toBe("textarea");
+    expect(found?.getAttribute("data-id")).toBe("root");
+
+    // A document without the prompt textarea (e.g. a logged-out landing
+    // page) returns null.
+    const empty = new JSDOM("<!doctype html><body></body>").window.document;
+    expect(chatgptAdapter.findInputBox(empty)).toBeNull();
+  });
+});
+
+describe("chatgpt adapter · getChatId", () => {
+  it("parses the uuid out of a /c/<id> path", () => {
+    const { doc, location } = loadFixtureWithLocation(
+      "code",
+      "https://chatgpt.com/c/abc123-uuid-xyz",
+    );
+    expect(chatgptAdapter.getChatId(doc, location)).toBe("abc123-uuid-xyz");
+  });
+
+  it("returns null on the landing page (no /c/ segment)", () => {
+    const { doc, location } = loadFixtureWithLocation(
+      "empty",
+      "https://chatgpt.com/",
+    );
+    expect(chatgptAdapter.getChatId(doc, location)).toBeNull();
+  });
+
+  it("strips query string and hash from the chat id", () => {
+    const { doc, location } = loadFixtureWithLocation(
+      "code",
+      "https://chatgpt.com/c/xyz-789?ref=foo#anchor",
+    );
+    expect(chatgptAdapter.getChatId(doc, location)).toBe("xyz-789");
+  });
+});
+
+describe("chatgpt adapter · onNewAssistantTurn", () => {
+  it("fires once when a streaming assistant turn loses data-stream", () => {
+    const dom = new JSDOM(
+      `<!doctype html><body>
+        <div id="thread">
+          <article
+            data-message-author-role="assistant"
+            data-message-id="a1"
+            data-stream="true"
+          ><div class="prose"><p>partial…</p></div></article>
+        </div>
+      </body>`,
+      { url: "https://chatgpt.com/c/abc" },
+    );
+    const doc = dom.window.document;
+    const turns: ChatTurn[] = [];
+    const off = chatgptAdapter.onNewAssistantTurn!(doc, (t) => turns.push(t));
+
+    // No emit yet — the turn is mid-stream.
+    expect(turns).toEqual([]);
+
+    // Mutate content + drop `data-stream` to simulate stream completion.
+    const turn = doc.querySelector<HTMLElement>(
+      '[data-message-author-role="assistant"]',
+    )!;
+    const prose = turn.querySelector("p")!;
+    prose.textContent = "all done";
+    turn.removeAttribute("data-stream");
+
+    // MutationObserver flushes microtasks — wait one tick.
+    return new Promise<void>((r) => {
+      setTimeout(() => {
+        expect(turns).toHaveLength(1);
+        expect(turns[0]?.role).toBe("assistant");
+        expect(turns[0]?.content).toContain("all done");
+        off();
+        r();
+      }, 0);
+    });
+  });
+
+  it("emits when a new already-settled assistant turn is appended", () => {
+    const dom = new JSDOM(
+      `<!doctype html><body><div id="thread"></div></body>`,
+      { url: "https://chatgpt.com/c/abc" },
+    );
+    const doc = dom.window.document;
+    const turns: ChatTurn[] = [];
+    const off = chatgptAdapter.onNewAssistantTurn!(doc, (t) => turns.push(t));
+
+    const thread = doc.getElementById("thread")!;
+    const settled = doc.createElement("article");
+    settled.setAttribute("data-message-author-role", "assistant");
+    settled.innerHTML = `<div class="prose"><p>fresh reply</p></div>`;
+    thread.appendChild(settled);
+
+    return new Promise<void>((r) => {
+      setTimeout(() => {
+        expect(turns).toHaveLength(1);
+        expect(turns[0]?.content).toContain("fresh reply");
+        off();
+        r();
+      }, 0);
+    });
+  });
+
+  it("returned disposer detaches the observer (no further emits)", () => {
+    const dom = new JSDOM(
+      `<!doctype html><body><div id="thread"></div></body>`,
+      { url: "https://chatgpt.com/c/abc" },
+    );
+    const doc = dom.window.document;
+    const turns: ChatTurn[] = [];
+    const off = chatgptAdapter.onNewAssistantTurn!(doc, (t) => turns.push(t));
+    off();
+
+    const thread = doc.getElementById("thread")!;
+    const settled = doc.createElement("article");
+    settled.setAttribute("data-message-author-role", "assistant");
+    settled.textContent = "should be ignored";
+    thread.appendChild(settled);
+
+    return new Promise<void>((r) => {
+      setTimeout(() => {
+        expect(turns).toEqual([]);
+        r();
+      }, 0);
+    });
+  });
+});

--- a/packages/extension/tests/unit/scaffold.test.ts
+++ b/packages/extension/tests/unit/scaffold.test.ts
@@ -35,9 +35,17 @@ describe("scaffold · manifest.json", () => {
     );
   });
 
-  it("starts with empty host_permissions per D11", () => {
-    // Domain-specific entries land in T07–T09 as adapters arrive.
-    expect(manifest.host_permissions).toEqual([]);
+  it("declares only enumerated AI-chat host_permissions per D11", () => {
+    // T07 adds chatgpt.com; T08/T09 will append claude.ai and
+    // gemini.google.com. `<all_urls>` is explicitly forbidden — generic
+    // page capture flows through `activeTab` per D8/D11.
+    expect(manifest.host_permissions).toEqual(
+      expect.arrayContaining(["https://chatgpt.com/*"]),
+    );
+    expect(manifest.host_permissions).not.toContain("<all_urls>");
+    for (const entry of manifest.host_permissions) {
+      expect(entry).toMatch(/^https:\/\/[a-z0-9.-]+\/\*$/);
+    }
   });
 
   it("registers popup, options, and a service-worker entry point", () => {

--- a/work/chrome-extension/decisions.md
+++ b/work/chrome-extension/decisions.md
@@ -153,6 +153,27 @@ A task that is functionally complete but missing tests stays at `status: in_revi
 
 ---
 
+## 2026-05-10 · T07 — ChatGPT adapter lands; awaiting CI verify
+
+`packages/extension/src/runtime/chat/adapters/chatgpt.adapter.ts` implements the `ChatAdapter` contract for `chatgpt.com`. 14 unit tests pass locally including all three D13-binding TDD anchors:
+
+- `tests/unit/chat/chatgpt.adapter.test.ts::extracts_code_block_with_language`
+- `tests/unit/chat/chatgpt.adapter.test.ts::role_inferred_from_data_attr`
+- `tests/unit/chat/chatgpt.adapter.test.ts::findInputBox_returns_textarea`
+
+Plus: `getChatId` parsing (uuid path + null on landing + query/hash strip), multi-turn ordering with non-standard role fold-into-system, JSDOM-backed `MutationObserver` settle detection (streaming-attribute drop and fresh-settled-turn append), markdown serialization snapshot. Manifest `host_permissions` adds `https://chatgpt.com/*` (T08/T09 will append `claude.ai` and `gemini.google.com` per D11). Scaffold test updated to assert the enumerated entry instead of the empty-array invariant from T01.
+
+Task `07.md` held at `status: in_review` with `blocked_on: ci-verify` per D13 — flips to `done` only after the PR's CI run reports green.
+
+**Notes for T08/T09 implementers:**
+
+- `registry.ts` now exports `registerAdapter(adapter)` — concrete adapters call it once at module load. `__setAdaptersForTesting` is unchanged (test-only).
+- `runtime/chat/adapters/index.ts` is a barrel: each adapter file is imported here for its registration side-effect. Add `import "./claude.adapter.js"` / `import "./gemini.adapter.js"` on a fresh line, alphabetical order, so concurrent feature branches edit different lines and merge cleanly.
+- The MutationObserver in the auto-capture hook pulls its constructor from `doc.defaultView.MutationObserver` — Node's `globalThis` doesn't expose it, but JSDOM's window does, so unit tests don't need `environment: jsdom` set globally in vitest.
+- **Sandbox caveat:** the three fixtures in `tests/fixtures/chatgpt/` are hand-crafted to match the documented 2026 selectors (`[data-message-author-role]`, `pre > code.language-*`, `textarea[data-id="root"]`, `data-stream` while streaming) — the sandbox cannot reach `chatgpt.com`. A human must refresh them from a live capture before merge if the live DOM has drifted.
+
+---
+
 ## 2026-05-10 · T06 — adapter framework lands; awaiting CI verify
 
 `packages/extension/src/runtime/chat/{types,registry,serializer}.ts` shipped, registry array intentionally empty per D10 (concrete adapters land T07–T09). 20 unit tests pass locally including both D13-binding TDD anchors:

--- a/work/chrome-extension/tasks/07.md
+++ b/work/chrome-extension/tasks/07.md
@@ -1,5 +1,6 @@
 ---
-status: pending
+status: in_review
+blocked_on: ci-verify
 depends_on: [06]
 wave: 3
 skills: [code-writing, dom-scraping]


### PR DESCRIPTION
## Summary

Implements [`work/chrome-extension/tasks/07.md`](../blob/claude/extension-t07-chatgpt-adapter-Yf3gN/work/chrome-extension/tasks/07.md) — the ChatGPT (`chatgpt.com`) `ChatAdapter` against the T06 framework (now merged via PR #103). Rebased onto `dev` after #103 landed; the diff is now T07-only (598 additions / 5 deletions).

- **`runtime/chat/adapters/chatgpt.adapter.ts`** — `hostPattern = /^chatgpt\.com\//`, `platform = "chatgpt"`. `extractConversation` walks `[data-message-author-role]` nodes (role from the attribute, content via `domNodeToMarkdown` so `<pre><code class="language-X">` survives as fenced ```` ```X ```` blocks). `getChatId` parses `/c/<uuid>` from `location.pathname` and strips query/hash. `findInputBox` returns `textarea[data-id="root"]` (with a contenteditable fallback for ChatGPT A/B rollouts). `onNewAssistantTurn` runs a `MutationObserver` that fires when an assistant turn loses `data-stream` (streaming finished) or when a fresh already-settled turn appears.
- **`runtime/chat/adapters/index.ts`** — barrel that imports `./chatgpt.adapter.js` for its registration side-effect (`registerAdapter` already shipped in T06). T08/T09 will append `./claude.adapter.js` / `./gemini.adapter.js` on fresh, alphabetically-ordered lines so concurrent feature branches edit different lines and merge cleanly.
- **`manifest.json`** — `host_permissions` adds `https://chatgpt.com/*` per D11 (no `<all_urls>`). T08/T09 will append `claude.ai` and `gemini.google.com`.
- **`tests/unit/scaffold.test.ts`** — replaces the T01 "starts empty" assertion with an enumerated-entries assertion that requires `https://chatgpt.com/*`, forbids `<all_urls>`, and validates each entry against the `https://<host>/*` shape.

## TDD anchors (D13)

All three task-spec anchors implemented and passing locally:

- `tests/unit/chat/chatgpt.adapter.test.ts::extracts_code_block_with_language` — Python + Rust fenced blocks survive a round-trip through `domNodeToMarkdown` with the right language hints.
- `tests/unit/chat/chatgpt.adapter.test.ts::role_inferred_from_data_attr` — the four-turn `code.html` fixture emits exactly `[user, assistant, user, assistant]`.
- `tests/unit/chat/chatgpt.adapter.test.ts::findInputBox_returns_textarea` — non-null `textarea[data-id="root"]` on a chat page, null on a logged-out landing-style document.

Plus 11 supporting tests covering chat-id parsing (uuid path + null on landing + query/hash strip), the contract surface (`hostPattern` / `platform` / self-registration into `selectAdapter`), multi-turn ordering with non-standard roles folded into `system`, an empty-fixture short-circuit, a `serializeMarkdown` snapshot over extracted turns (fences + role headings), and JSDOM-backed `MutationObserver` behaviour (streaming-attribute drop, fresh-settled append, disposer detaches).

```
Test Files  4 passed (4)
     Tests  43 passed (43)   # chat + scaffold; 14 new from T07
```

Full extension suite is 60/68 locally; the two failing files (`tests/unit/embed/transformers.test.ts` HF network and `tests/unit/sign/cose.test.ts` WASM loader) are pre-existing on `dev` and called out in the task brief.

## Sandbox caveat

The CI sandbox cannot reach `chatgpt.com`, so `tests/fixtures/chatgpt/{empty,code,long}.html` are hand-crafted against the documented 2026 selectors (`[data-message-author-role]`, `pre > code.language-*`, `textarea[data-id="root"]`, `data-stream` while streaming). A human should refresh them from a live DevTools capture before merge if the live DOM has drifted; the workaround is recorded in `decisions.md` under the T07 entry.

## Test plan

- [x] `npx vitest run tests/unit/chat` — 37/37 green locally (registry now 9 tests with T06's `registerAdapter` cases)
- [x] `npx vitest run tests/unit/scaffold.test.ts` — 6/6 green locally (updated `host_permissions` assertion)
- [x] `npx tsc -b --noEmit` — clean (no new errors)
- [x] Rebased onto `dev` after PR #103 merged; `mergeable_state` is `clean`.
- [x] Task `07.md` held at `status: in_review` with `blocked_on: ci-verify` per D13 — flips to `done` only after this PR's CI is green.
- [ ] CI (Node Test workflow runs `packages/extension` tests on `bun-latest`)
- [ ] Human refresh of `tests/fixtures/chatgpt/*.html` from a live ChatGPT capture

https://claude.ai/code/session_01Q6KTvLh3itRQUuGNzDvVFz