### PR TITLE
feat(webapp): add Telegram announcements channel link

### DIFF
--- a/webapp/src/components/SiteFooter.tsx
+++ b/webapp/src/components/SiteFooter.tsx
@@ -70,7 +70,10 @@ export default function SiteFooter() {
             Discord
           </FooterLink>
           <FooterLink external href={EXTERNAL_LINKS.telegram}>
-            Telegram
+            Telegram · community
+          </FooterLink>
+          <FooterLink external href={EXTERNAL_LINKS.telegramAnnouncements}>
+            Telegram · announcements
           </FooterLink>
         </FooterColumn>
       </div>

--- a/webapp/src/lib/links.ts
+++ b/webapp/src/lib/links.ts
@@ -18,6 +18,7 @@ export const EXTERNAL_LINKS = {
     "https://www.researchgate.net/publication/404381758_Sublinear_Verifiable_Recall_An_Inverted-File_Cascade_for_Compressed_Embedding_Retrieval_in_the_Mnemonic_Protocol",
   discord: "https://discord.gg/ws6wruJj",
   telegram: "https://t.me/mnemonikprotocol",
+  telegramAnnouncements: "https://t.me/mnemonik_xyz_announcements",
   issues: "https://github.com/mnemonik-xyz/monorepo/issues",
 } as const;
 


### PR DESCRIPTION
Adds the announcements-only Telegram channel (`@mnemonik_xyz_announcements`) next to the existing community channel in the footer's Talk column.