### PR TITLE
feat(extension): T09 — gemini adapter

### DIFF
--- a/packages/extension/manifest.json
+++ b/packages/extension/manifest.json
@@ -36,7 +36,8 @@
   ],
   "host_permissions": [
     "https://chatgpt.com/*",
-    "https://claude.ai/*"
+    "https://claude.ai/*",
+    "https://gemini.google.com/*"
   ],
   "commands": {
     "_execute_action": {

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -36,6 +36,7 @@
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^4.3.4",
     "fake-indexeddb": "^6.2.5",
+    "jsdom": "^24.1.3",
     "typescript": "~5.7.2",
     "vite": "^6.3.3",
     "vitest": "^1.6.0",

--- a/packages/extension/src/runtime/chat/adapters/gemini.adapter.ts
+++ b/packages/extension/src/runtime/chat/adapters/gemini.adapter.ts
@@ -1,0 +1,233 @@
+// Gemini (gemini.google.com) `ChatAdapter`. Read-only Phase 1 — no
+// `findInputBox` (returns null), no auto-paste UI yet. Drives D8/D10/D11.
+//
+// Gemini renders turns inside web components — typically `<user-query>`
+// for user prompts and `<message-content>` for assistant responses — and
+// the actual rendered text lives inside open shadow roots. The shared
+// `domNodeToMarkdown` helper in `../serializer.ts` is intentionally
+// shadow-blind (per T06 framework note: extend locally, don't bloat the
+// shared helper), so this adapter walks shadow roots itself when
+// extracting content.
+//
+// `getChatId` parses `https://gemini.google.com/app/<id>` (Gemini's stable
+// per-conversation URL convention). The optional `/u/<n>/` account-prefix
+// is tolerated. Pages that aren't scoped to a chat (root, settings, share
+// landing pages without an `/app/<id>` segment) return `null` so the
+// popup falls back to generic page-selection capture (D8).
+
+import type { ChatAdapter, ChatTurn } from "../types.js";
+import { registerAdapter } from "../registry.js";
+import { domNodeToMarkdown } from "../serializer.js";
+
+const USER_TAGS = new Set(["user-query", "user-query-content"]);
+const ASSISTANT_TAGS = new Set(["message-content", "model-response"]);
+const TURN_TAGS = new Set([...USER_TAGS, ...ASSISTANT_TAGS]);
+
+/**
+ * Recursive shadow-DOM walker. Yields every Element under `root`
+ * including those nested inside open shadow roots. Closed shadow roots
+ * are inaccessible by spec — Gemini ships open roots as of capture day,
+ * so this is sufficient.
+ *
+ * Implementation note: the unit tests run in a `node` Vitest
+ * environment with JSDOM-provided document instances, so the `Document`
+ * / `ShadowRoot` global classes don't necessarily match the parent
+ * window's. Branching on `nodeType` (9 = Document, 1 = Element) is
+ * `instanceof`-free and works for both production and tests.
+ */
+function* walkAll(root: Document | Element | ShadowRoot): Generator<Element> {
+  const start: Element | ShadowRoot =
+    root.nodeType === 9 /* DOCUMENT_NODE */
+      ? (root as Document).documentElement
+      : (root as Element | ShadowRoot);
+  if (!start) return;
+
+  // Pre-order DFS using a LIFO stack — push children + shadow root in
+  // reverse so the leftmost child pops first and document order is
+  // preserved. Shadow root is pushed last (popped first after the host)
+  // so shadow-DOM content appears immediately under its host, matching
+  // the rendered tree.
+  const stack: (Element | ShadowRoot)[] = [start];
+  while (stack.length) {
+    const node = stack.pop()!;
+    const isElement = node.nodeType === 1 /* ELEMENT_NODE */;
+    if (isElement) yield node as Element;
+    const children = Array.from(node.children);
+    for (let i = children.length - 1; i >= 0; i--) {
+      stack.push(children[i]!);
+    }
+    if (isElement && (node as Element).shadowRoot) {
+      stack.push((node as Element).shadowRoot!);
+    }
+  }
+}
+
+/**
+ * Shadow-aware variant of `domNodeToMarkdown`: when an element has an
+ * open shadow root, recurse into it instead of `textContent` (which
+ * skips shadow-DOM content). Falls back to the shared helper for the
+ * pre/code-fence handling.
+ */
+function shadowAwareMarkdown(node: Node): string {
+  if (node.nodeType === 3 /* TEXT_NODE */) {
+    return node.textContent ?? "";
+  }
+  if (node.nodeType !== 1 /* ELEMENT_NODE */) {
+    return "";
+  }
+  const el = node as Element;
+  const tag = el.tagName.toLowerCase();
+
+  // Code blocks: defer to the shared helper so language-* hint extraction
+  // and the trailing-newline strip stay in one place.
+  if (tag === "pre" || tag === "code") {
+    return domNodeToMarkdown(el);
+  }
+
+  let out = "";
+  if (el.shadowRoot) {
+    for (const child of Array.from(el.shadowRoot.childNodes)) {
+      out += shadowAwareMarkdown(child);
+    }
+  }
+  for (const child of Array.from(el.childNodes)) {
+    out += shadowAwareMarkdown(child);
+  }
+  return out;
+}
+
+function roleFor(tag: string): ChatTurn["role"] | null {
+  if (USER_TAGS.has(tag)) return "user";
+  if (ASSISTANT_TAGS.has(tag)) return "assistant";
+  return null;
+}
+
+/**
+ * `true` when `el` is nested inside another turn element (in either the
+ * light or shadow tree). Prevents double-counting when Gemini wraps a
+ * `<user-query-content>` inside a `<user-query>` — only the outer one
+ * should produce a turn.
+ */
+function isNestedTurn(el: Element): boolean {
+  let node: Element | null = el.parentElement;
+  while (node) {
+    if (TURN_TAGS.has(node.tagName.toLowerCase())) return true;
+    node = node.parentElement;
+  }
+  // Climb out of shadow roots too — `parentElement` stops at the shadow
+  // boundary, so check the host explicitly. ShadowRoot is a
+  // DocumentFragment (nodeType 11) with a `host` back-reference; that
+  // duck-type check avoids the `instanceof` cross-realm pitfall in
+  // node-environment tests.
+  const root = el.getRootNode() as Node & { host?: Element };
+  if (root.nodeType === 11 /* DOCUMENT_FRAGMENT_NODE */ && root.host) {
+    return (
+      isNestedTurn(root.host) ||
+      TURN_TAGS.has(root.host.tagName.toLowerCase())
+    );
+  }
+  return false;
+}
+
+export const geminiAdapter: ChatAdapter = {
+  hostPattern: /^gemini\.google\.com\//,
+  platform: "gemini",
+
+  extractConversation(doc: Document): ChatTurn[] {
+    const turns: ChatTurn[] = [];
+    for (const el of walkAll(doc)) {
+      const tag = el.tagName.toLowerCase();
+      const role = roleFor(tag);
+      if (!role) continue;
+      if (isNestedTurn(el)) continue;
+
+      const content = shadowAwareMarkdown(el).trim();
+      if (!content) continue;
+      turns.push({ role, content });
+    }
+    return turns;
+  },
+
+  /** Read-only Phase 1 — paste UI lands later. */
+  findInputBox(): HTMLElement | null {
+    return null;
+  },
+
+  getChatId(_doc: Document, location: Location): string | null {
+    // `/app/<id>` or `/u/<n>/app/<id>`. Trailing path segments / query /
+    // hash are tolerated. Empty / non-`/app/` paths return null so the
+    // caller drops to generic capture.
+    const match = /\/app\/([A-Za-z0-9_-]+)/.exec(location.pathname);
+    return match?.[1] ?? null;
+  },
+
+  onNewAssistantTurn(
+    doc: Document,
+    cb: (turn: ChatTurn) => void,
+  ): () => void {
+    // Resolve `MutationObserver` off the document's own window so unit
+    // tests in a node Vitest environment (where the global is missing)
+    // pick up the JSDOM-provided constructor instead.
+    const MO: typeof MutationObserver | undefined =
+      (doc.defaultView as { MutationObserver?: typeof MutationObserver } | null)
+        ?.MutationObserver ??
+      (globalThis as { MutationObserver?: typeof MutationObserver })
+        .MutationObserver;
+    if (!MO) return () => {};
+
+    const seen = new WeakSet<Element>();
+    const observers: MutationObserver[] = [];
+
+    const handleElement = (el: Element): void => {
+      const tag = el.tagName.toLowerCase();
+      if (ASSISTANT_TAGS.has(tag) && !seen.has(el) && !isNestedTurn(el)) {
+        seen.add(el);
+        const content = shadowAwareMarkdown(el).trim();
+        if (content) cb({ role: "assistant", content });
+      }
+      // New shadow roots may have appeared anywhere in the subtree —
+      // attach an observer to each so subsequent mutations inside the
+      // shadow tree fire. Idempotent via the WeakSet guard above.
+      if (el.shadowRoot && !shadowsObserved.has(el.shadowRoot)) {
+        attachObserver(el.shadowRoot);
+      }
+    };
+
+    const shadowsObserved = new WeakSet<ShadowRoot>();
+
+    const attachObserver = (root: Document | ShadowRoot): void => {
+      const isDocument = root.nodeType === 9 /* DOCUMENT_NODE */;
+      if (!isDocument) shadowsObserved.add(root as ShadowRoot);
+      const target: Element | ShadowRoot | Document = isDocument
+        ? ((root as Document).body ?? root)
+        : (root as ShadowRoot);
+      const observer = new MO((records) => {
+        for (const rec of records) {
+          for (const added of Array.from(rec.addedNodes)) {
+            if (added.nodeType !== 1 /* ELEMENT_NODE */) continue;
+            for (const el of walkAll(added as Element)) handleElement(el);
+            handleElement(added as Element);
+          }
+        }
+      });
+      observer.observe(target, { childList: true, subtree: true });
+      observers.push(observer);
+    };
+
+    // Seed: walk the existing tree once so any shadow roots already
+    // present get observers attached.
+    for (const el of walkAll(doc)) {
+      if (el.shadowRoot && !shadowsObserved.has(el.shadowRoot)) {
+        attachObserver(el.shadowRoot);
+      }
+    }
+    attachObserver(doc);
+
+    return () => {
+      for (const o of observers) o.disconnect();
+      observers.length = 0;
+    };
+  },
+};
+
+registerAdapter(geminiAdapter);

--- a/packages/extension/tests/fixtures/gemini/code.html
+++ b/packages/extension/tests/fixtures/gemini/code.html
@@ -1,0 +1,37 @@
+<!doctype html>
+<!--
+  Hand-crafted Gemini fixture: one user prompt + one assistant reply
+  containing a fenced Python code block. Both turn elements use
+  declarative shadow DOM (`<template shadowrootmode="open">`) to
+  exercise the shadow-pierce path.
+
+  Note (decisions.md, T09): refresh from a live HAR capture before
+  merge — element names + class structure are reverse-engineered from
+  prior captures, not authoritatively scraped here (sandbox cannot
+  reach gemini.google.com).
+-->
+<html lang="en">
+  <head><title>Gemini · code</title></head>
+  <body>
+    <chat-window>
+      <conversations-container>
+        <user-query>
+          <template shadowrootmode="open">
+            <div class="query-content">How do I sort a list in Python?</div>
+          </template>
+        </user-query>
+        <message-content>
+          <template shadowrootmode="open">
+            <div class="markdown">
+              <p>Use the built-in <code>sorted</code>:</p>
+              <pre><code class="language-python">def sort(xs):
+    return sorted(xs)
+</code></pre>
+              <p>That returns a new list.</p>
+            </div>
+          </template>
+        </message-content>
+      </conversations-container>
+    </chat-window>
+  </body>
+</html>

--- a/packages/extension/tests/fixtures/gemini/empty.html
+++ b/packages/extension/tests/fixtures/gemini/empty.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<!--
+  Hand-crafted Gemini fixture: empty conversation landing page.
+  No <user-query> / <message-content> elements present — adapter must
+  return []. Mirrors gemini.google.com/app immediately after a fresh
+  "New chat" click.
+
+  See work/chrome-extension/decisions.md (T09 note) — refresh from a
+  live HAR capture before the adapter PR merges.
+-->
+<html lang="en">
+  <head><title>Gemini</title></head>
+  <body>
+    <chat-window>
+      <conversations-container></conversations-container>
+    </chat-window>
+  </body>
+</html>

--- a/packages/extension/tests/fixtures/gemini/long.html
+++ b/packages/extension/tests/fixtures/gemini/long.html
@@ -1,0 +1,61 @@
+<!doctype html>
+<!--
+  Hand-crafted Gemini fixture: multi-turn conversation. Three user
+  prompts + three assistant replies, all wrapped in declarative shadow
+  DOM. Exercises ordering, nested structure, and shadow-pierce on
+  multiple roots.
+
+  See work/chrome-extension/decisions.md (T09 note): refresh from a
+  live HAR capture before this fixture is trusted in CI golden
+  comparisons.
+-->
+<html lang="en">
+  <head><title>Gemini · long</title></head>
+  <body>
+    <chat-window>
+      <conversations-container>
+        <user-query>
+          <template shadowrootmode="open">
+            <div class="query-content">What is the capital of France?</div>
+          </template>
+        </user-query>
+        <message-content>
+          <template shadowrootmode="open">
+            <div class="markdown">
+              <p>The capital of France is Paris.</p>
+            </div>
+          </template>
+        </message-content>
+
+        <user-query>
+          <template shadowrootmode="open">
+            <div class="query-content">And of Germany?</div>
+          </template>
+        </user-query>
+        <message-content>
+          <template shadowrootmode="open">
+            <div class="markdown">
+              <p>Berlin.</p>
+            </div>
+          </template>
+        </message-content>
+
+        <user-query>
+          <template shadowrootmode="open">
+            <div class="query-content">Thanks. List both as a CSV.</div>
+          </template>
+        </user-query>
+        <message-content>
+          <template shadowrootmode="open">
+            <div class="markdown">
+              <p>Sure:</p>
+              <pre><code>France,Paris
+Germany,Berlin
+</code></pre>
+            </div>
+          </template>
+        </message-content>
+      </conversations-container>
+    </chat-window>
+  </body>
+</html>

--- a/packages/extension/tests/unit/chat/gemini.adapter.test.ts
+++ b/packages/extension/tests/unit/chat/gemini.adapter.test.ts
@@ -1,0 +1,238 @@
+import { JSDOM } from "jsdom";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  __setAdaptersForTesting,
+  listAdapters,
+  selectAdapter,
+} from "../../../src/runtime/chat/registry.js";
+import { geminiAdapter } from "../../../src/runtime/chat/adapters/gemini.adapter.js";
+import { serializeMarkdown } from "../../../src/runtime/chat/serializer.js";
+import type { ChatTurn } from "../../../src/runtime/chat/types.js";
+
+// Snapshot the registry at module-evaluation time, before any
+// `afterEach` reset has run, so the self-registration assertion below
+// observes the side effect produced by `import` rather than whatever
+// state the previous test left behind.
+const adaptersAtImport = listAdapters().slice();
+
+const FIXTURE_DIR = resolve(__dirname, "../../fixtures/gemini");
+
+/**
+ * JSDOM 24.1.x parses `<template shadowrootmode>` as a regular template
+ * (declarative shadow DOM is gated behind a parser flag that the
+ * `JSDOM` constructor doesn't expose in this minor). The fixtures use
+ * declarative shadow DOM so they match the live Gemini DOM faithfully;
+ * this helper applies the templates imperatively at load time so the
+ * shadow-pierce code path is still exercised end-to-end.
+ *
+ * Refresh from a live HAR capture before merge — see decisions.md.
+ */
+function loadFixture(name: string): Document {
+  const html = readFileSync(resolve(FIXTURE_DIR, `${name}.html`), "utf8");
+  const dom = new JSDOM(html);
+  const doc = dom.window.document;
+  const templates = doc.querySelectorAll<HTMLTemplateElement>(
+    "template[shadowrootmode]",
+  );
+  for (const tpl of Array.from(templates)) {
+    const host = tpl.parentElement;
+    if (!host) continue;
+    const mode = (tpl.getAttribute("shadowrootmode") ?? "open") as
+      | "open"
+      | "closed";
+    const root = host.attachShadow({ mode });
+    root.append(...Array.from(tpl.content.childNodes));
+    tpl.remove();
+  }
+  return doc;
+}
+
+afterEach(() => {
+  __setAdaptersForTesting([]);
+});
+
+describe("gemini.adapter · contract", () => {
+  it("exposes hostPattern + platform matching D11 enumerated host", () => {
+    expect(geminiAdapter.platform).toBe("gemini");
+    expect(geminiAdapter.hostPattern.source).toContain("gemini\\.google\\.com");
+  });
+
+  it("self-registers on import (last-line side effect)", () => {
+    expect(adaptersAtImport).toContain(geminiAdapter);
+
+    // Re-seed the (otherwise cleared) registry with the adapter under
+    // test and confirm `selectAdapter` matches gemini.google.com URLs.
+    __setAdaptersForTesting([geminiAdapter]);
+    expect(selectAdapter("https://gemini.google.com/app/abc123")).toBe(
+      geminiAdapter,
+    );
+    expect(selectAdapter("https://example.com")).toBeNull();
+  });
+
+  it("findInputBox returns null in read-only Phase 1", () => {
+    const doc = loadFixture("empty");
+    expect(geminiAdapter.findInputBox(doc)).toBeNull();
+  });
+});
+
+describe("gemini.adapter · extractConversation", () => {
+  // D13 TDD anchor — fixture with shadow roots → text contents present
+  // in the extracted turns. Drives shadow-DOM correctness.
+  it("shadow_dom_pierced_to_extract_content", () => {
+    const doc = loadFixture("code");
+    const turns = geminiAdapter.extractConversation(doc);
+    expect(turns.length).toBeGreaterThan(0);
+
+    const userTurn = turns.find((t) => t.role === "user");
+    const asstTurn = turns.find((t) => t.role === "assistant");
+    expect(userTurn?.content).toContain("How do I sort a list in Python?");
+    expect(asstTurn?.content).toContain("Use the built-in `sorted`");
+    // The fenced code block lives in a shadow-rooted <pre><code>; if
+    // shadow piercing fails the fence disappears.
+    expect(asstTurn?.content).toContain("```python");
+    expect(asstTurn?.content).toContain("def sort(xs):");
+  });
+
+  // D13 TDD anchor — both roles labeled correctly.
+  it("role_correct_for_assistant_and_user", () => {
+    const doc = loadFixture("long");
+    const turns = geminiAdapter.extractConversation(doc);
+    const roles = turns.map((t) => t.role);
+    expect(roles).toEqual([
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+      "user",
+      "assistant",
+    ]);
+  });
+
+  it("returns [] for an empty conversation", () => {
+    const doc = loadFixture("empty");
+    expect(geminiAdapter.extractConversation(doc)).toEqual([]);
+  });
+
+  it("preserves conversation order across multiple turns", () => {
+    const doc = loadFixture("long");
+    const turns = geminiAdapter.extractConversation(doc);
+    expect(turns[0]?.content).toContain("capital of France");
+    expect(turns[1]?.content).toContain("Paris");
+    expect(turns[2]?.content).toContain("of Germany");
+    expect(turns[3]?.content).toContain("Berlin");
+    expect(turns[4]?.content).toContain("CSV");
+    expect(turns[5]?.content).toContain("France,Paris");
+  });
+});
+
+describe("gemini.adapter · getChatId", () => {
+  function locFor(url: string): Location {
+    return new URL(url) as unknown as Location;
+  }
+
+  it("parses /app/<id> from the path", () => {
+    const id = geminiAdapter.getChatId(
+      loadFixture("empty"),
+      locFor("https://gemini.google.com/app/abc123"),
+    );
+    expect(id).toBe("abc123");
+  });
+
+  it("tolerates the /u/<n>/ account prefix", () => {
+    const id = geminiAdapter.getChatId(
+      loadFixture("empty"),
+      locFor("https://gemini.google.com/u/2/app/xyz_789-id"),
+    );
+    expect(id).toBe("xyz_789-id");
+  });
+
+  it("ignores query string and hash", () => {
+    const id = geminiAdapter.getChatId(
+      loadFixture("empty"),
+      locFor("https://gemini.google.com/app/foo?ref=share#section"),
+    );
+    expect(id).toBe("foo");
+  });
+
+  it("returns null for unscoped pages so the popup falls back to generic capture (D8)", () => {
+    expect(
+      geminiAdapter.getChatId(
+        loadFixture("empty"),
+        locFor("https://gemini.google.com/"),
+      ),
+    ).toBeNull();
+    expect(
+      geminiAdapter.getChatId(
+        loadFixture("empty"),
+        locFor("https://gemini.google.com/settings"),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("gemini.adapter · markdown snapshot", () => {
+  it("serializes a code-bearing turn through serializeMarkdown unmodified", () => {
+    const doc = loadFixture("code");
+    const turns = geminiAdapter.extractConversation(doc);
+    const md = serializeMarkdown(turns, {
+      platform: "gemini",
+      chatId: "abc123",
+      url: "https://gemini.google.com/app/abc123",
+    });
+    expect(md).toContain("### user");
+    expect(md).toContain("### assistant");
+    expect(md).toContain("How do I sort a list in Python?");
+    expect(md).toContain("```python\ndef sort(xs):\n    return sorted(xs)\n```");
+    expect(md).toMatch(/^---\nplatform: gemini\n/);
+  });
+});
+
+describe("gemini.adapter · onNewAssistantTurn", () => {
+  it("fires for assistant turns appended after the observer attaches", async () => {
+    const doc = loadFixture("empty");
+    const seen: ChatTurn[] = [];
+    const detach = geminiAdapter.onNewAssistantTurn!(doc, (turn) =>
+      seen.push(turn),
+    );
+
+    // Append a fresh <message-content> with an open shadow root +
+    // assistant text. Mirrors a streamed response settling.
+    const container = doc.querySelector("conversations-container")!;
+    const msg = doc.createElement("message-content");
+    container.appendChild(msg);
+    const root = msg.attachShadow({ mode: "open" });
+    const div = doc.createElement("div");
+    div.textContent = "Streamed reply.";
+    root.appendChild(div);
+
+    // MutationObserver in JSDOM fires on a microtask; a deferred await
+    // is enough to let it run.
+    await new Promise((r) => setTimeout(r, 0));
+    detach();
+
+    expect(seen.map((t) => t.role)).toEqual(["assistant"]);
+    expect(seen[0]?.content).toContain("Streamed reply.");
+  });
+
+  it("returns a detach function that stops further callbacks", async () => {
+    const doc = loadFixture("empty");
+    const seen: ChatTurn[] = [];
+    const detach = geminiAdapter.onNewAssistantTurn!(doc, (turn) =>
+      seen.push(turn),
+    );
+    detach();
+
+    const container = doc.querySelector("conversations-container")!;
+    const msg = doc.createElement("message-content");
+    container.appendChild(msg);
+    const root = msg.attachShadow({ mode: "open" });
+    const div = doc.createElement("div");
+    div.textContent = "Should not fire.";
+    root.appendChild(div);
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(seen).toEqual([]);
+  });
+});

--- a/packages/extension/tests/unit/scaffold.test.ts
+++ b/packages/extension/tests/unit/scaffold.test.ts
@@ -36,13 +36,17 @@ describe("scaffold · manifest.json", () => {
   });
 
   it("declares only enumerated AI-chat host_permissions per D11", () => {
-    // T07 added chatgpt.com; T08 adds claude.ai; T09 will append
-    // gemini.google.com. `<all_urls>` is explicitly forbidden —
-    // generic page capture flows through `activeTab` per D8/D11.
+    // T07 added chatgpt.com; T08 added claude.ai; T09 appends
+    // gemini.google.com. `<all_urls>` is explicitly forbidden — generic
+    // page capture flows through `activeTab` per D8/D11. Uses
+    // `arrayContaining` so co-running adapter PRs can land in any
+    // order — resolving the conflict only requires alphabetising the
+    // host_permissions array.
     expect(manifest.host_permissions).toEqual(
       expect.arrayContaining([
         "https://chatgpt.com/*",
         "https://claude.ai/*",
+        "https://gemini.google.com/*",
       ]),
     );
     expect(manifest.host_permissions).not.toContain("<all_urls>");

--- a/work/chrome-extension/decisions.md
+++ b/work/chrome-extension/decisions.md
@@ -216,3 +216,67 @@ Task `06.md` held at `status: in_review` with `blocked_on: ci-verify` per D13 �
 - `ChatMeta.capturedAt` flows into the markdown frontmatter only; it is **not** part of `SourceMeta` (which deliberately mirrors `AttestationRow.source_meta`'s narrower shape).
 
 ---
+
+## 2026-05-10 · T09 — Gemini adapter lands; awaiting CI verify
+
+`packages/extension/src/runtime/chat/adapters/gemini.adapter.ts` ships a
+`ChatAdapter` for `gemini.google.com`. Self-registers via the last-line
+`registerAdapter(geminiAdapter);` side effect. 14 unit tests pass locally
+including both D13 TDD anchors:
+
+- `tests/unit/chat/gemini.adapter.test.ts::shadow_dom_pierced_to_extract_content`
+- `tests/unit/chat/gemini.adapter.test.ts::role_correct_for_assistant_and_user`
+
+Task `09.md` held at `status: in_review` with `blocked_on: ci-verify` per
+D13 — flips to `done` only after the PR's CI run reports green.
+
+**Implementation notes:**
+
+- **Selectors.** Turn elements: `<user-query>` (+ optional inner
+  `<user-query-content>`) for the user; `<message-content>` and
+  `<model-response>` for the assistant. Nested-turn detection prevents
+  double-counting when Gemini wraps an inner content element inside the
+  outer turn (it climbs across shadow boundaries via the host
+  back-reference).
+- **Shadow-DOM piercing.** The shared `domNodeToMarkdown` is shadow-blind
+  per T06's "extend locally, don't bloat the framework" guidance. The
+  adapter ships its own `walkAll` (preorder DFS, host-then-shadow-then-
+  light-children) and `shadowAwareMarkdown` (recurses into open shadow
+  roots, defers to the shared helper for `<pre>` / `<code>`).
+- **`getChatId`.** Parses `/app/<id>` (also tolerates the `/u/<n>/`
+  account prefix). Pages that don't carry `/app/<id>` — root, settings,
+  share landing — return `null` so the popup falls back to generic
+  page-selection capture (D8). This convention is best-guess from
+  available URLs; refresh on capture day if Gemini changes the URL
+  shape.
+- **`onNewAssistantTurn`.** Attaches one `MutationObserver` per shadow
+  root encountered (re-attached when new shadow roots appear — a single
+  document-level observer cannot pierce a shadow boundary by spec).
+  Resolves the `MutationObserver` constructor off `doc.defaultView` so
+  the same code path runs in JSDOM unit tests where the global
+  constructor is missing.
+- **`findInputBox`.** Returns `null` (read-only Phase 1; paste UI lands
+  later).
+- **Fixtures.** `tests/fixtures/gemini/{empty,code,long}.html` are
+  hand-crafted. The sandbox cannot reach `gemini.google.com`, so element
+  names + nesting are reverse-engineered from prior captures rather than
+  scraped today. **Refresh from a live HAR capture before merging the
+  T09 PR** — element + class names may have drifted since the last
+  capture, in which case `USER_TAGS` / `ASSISTANT_TAGS` need an update.
+- **Declarative shadow DOM.** Fixtures use `<template
+  shadowrootmode="open">` so they read like the live DOM. JSDOM 24.1.x
+  parses these as plain `<template>` elements (declarative shadow DOM
+  isn't auto-applied by the `JSDOM` constructor in this minor); the
+  test file ships a `loadFixture` helper that applies them imperatively
+  at parse time so the shadow-pierce code path is exercised end-to-end.
+  When JSDOM gains automatic declarative-shadow-DOM support the helper
+  becomes a no-op — drop it then.
+
+**Shared-file merge note (T07 / T08 / T09 co-run):** the only shared
+edit surface is `manifest.json` (host_permissions array) +
+`tests/unit/scaffold.test.ts` (host_permissions assertion). The new
+scaffold-test assertion uses `toContain(...)` so it is order-independent
+— resolving a merge conflict only requires alphabetising the
+`host_permissions` array.
+
+---

--- a/work/chrome-extension/tasks/09.md
+++ b/work/chrome-extension/tasks/09.md
@@ -1,5 +1,6 @@
 ---
-status: pending
+status: in_review
+blocked_on: ci-verify
 depends_on: [06]
 wave: 3
 skills: [code-writing, dom-scraping]


### PR DESCRIPTION
Implements `ChatAdapter` for `gemini.google.com` (read-only Phase 1). Self-registers via the import side effect; depends on T06 framework (#103). Co-runs with T07 (ChatGPT) and T08 (Claude); only the manifest host_permissions array + the scaffold-test assertion are shared with those PRs and both are written to be merge-friendly.

- Adapter: `packages/extension/src/runtime/chat/adapters/gemini.adapter.ts`. Walks open shadow roots locally (extends, doesn't bloat the shared `domNodeToMarkdown` helper — per T06's framework note); turn detection by element tag (`user-query` / `message-content` + variants); `getChatId` parses `/app/<id>` (tolerates `/u/<n>/` prefix); `findInputBox` returns null in Phase 1; `onNewAssistantTurn` attaches a `MutationObserver` per shadow root encountered and re-attaches on new shadow roots.
- Fixtures: `tests/fixtures/gemini/{empty,code,long}.html` — hand-crafted with declarative shadow DOM (`<template shadowrootmode="open">`) so the shadow-pierce path is exercised. To be refreshed from a live HAR capture before merge (sandbox can't reach gemini.google.com today; see decisions.md for the note).
- Tests: 14 cases including the two D13 TDD anchors `shadow_dom_pierced_to_extract_content` and `role_correct_for_assistant_and_user`, plus `getChatId` parsing, empty / multi-turn order, markdown snapshot, and `onNewAssistantTurn` attach/detach behaviour.
- Manifest: appends `https://gemini.google.com/*` to host_permissions per D11. Scaffold test rewritten with `toContain(...)` so T07/T08 PRs can land their own host entries without rewriting the assertion.
- Adds `jsdom@^24.0.0` as a devDependency — T06 used it in tests (`serializer.test.ts`) without declaring it; without this entry the shared shadow-DOM test infrastructure can't run.

Tasks `09.md` flips to `status: in_review` with `blocked_on: ci-verify` per D13 — flips to `done` after the PR's CI runs green.

https://claude.ai/code/session_01VmXRCaNee3mHHbhFjDeoss