### PR TITLE
chore(chrome-extension): mark T01-T09 done in task frontmatter

### DIFF
--- a/work/chrome-extension/tasks/01.md
+++ b/work/chrome-extension/tasks/01.md
@@ -1,12 +1,12 @@
 ---
-status: in_review
+status: done
 depends_on: []
 wave: 1
 skills: [code-writing, ratify-decisions]
 verify: [npm-build, npm-test, web-ext-lint]
 reviewers: [code-reviewer]
 teammate_name: T01-scaffold
-blocked_on: ci-verify
+merged_in: "PR#96 → dev (483ed01)"
 ---
 
 # Task 01: Scaffold `packages/extension/` + ratify Decisions D1–D12

--- a/work/chrome-extension/tasks/02.md
+++ b/work/chrome-extension/tasks/02.md
@@ -1,13 +1,12 @@
 ---
-status: in_review
+status: done
 depends_on: []
 wave: 1
 skills: [code-writing]
 verify: [npm-build, npm-test, size-limit]
 reviewers: [code-reviewer]
 teammate_name: T02-sdk-browser
-branch: claude/sdk-browser-bundle-UVNTn
-blocked_on: ci-verify
+merged_in: "PR#97 → dev (7ba41db)"
 ---
 
 # Task 02: SDK browser bundle (`@mnemonik-xyz/sdk` `dist/browser.js`)

--- a/work/chrome-extension/tasks/03.md
+++ b/work/chrome-extension/tasks/03.md
@@ -1,13 +1,12 @@
 ---
-status: in_review
+status: done
 depends_on: [01]
 wave: 2
 skills: [code-writing]
 verify: [npm-test]
 reviewers: [code-reviewer, test-reviewer]
 teammate_name: T03-indexeddb-store
-branch: claude/sdk-browser-bundle-UVNTn
-blocked_on: ci-verify
+merged_in: "PR#97 (T02 SDK bundle) → dev (7ba41db); IndexedDbStore + tests landed alongside SDK"
 ---
 
 # Task 03: `IndexedDbStore` implementing `AttestationStore` shape

--- a/work/chrome-extension/tasks/04.md
+++ b/work/chrome-extension/tasks/04.md
@@ -1,12 +1,12 @@
 ---
-status: in_review
+status: done
 depends_on: [01]
 wave: 2
 skills: [code-writing]
 verify: [pnpm-test]
 reviewers: [code-reviewer, test-reviewer]
 teammate_name: T04-embedder
-blocked_on: [fixture-recording, ci-verify]
+merged_in: "PR#102 → dev (337f3e6)"
 ---
 
 # Task 04: Browser embedder via `transformers.js` in Web Worker

--- a/work/chrome-extension/tasks/05.md
+++ b/work/chrome-extension/tasks/05.md
@@ -1,13 +1,12 @@
 ---
-status: in_review
+status: done
 depends_on: [01, 02]
 wave: 2
 skills: [code-writing, rust]
 verify: [npm-test, cargo-test]
 reviewers: [code-reviewer, security-auditor, test-reviewer]
 teammate_name: T05-wasm-parity
-branch: claude/sdk-browser-bundle-UVNTn
-blocked_on: ci-verify
+merged_in: "PR#97 (T02 SDK bundle) → dev (7ba41db); WASM bindings + golden fixtures + cose.ts landed alongside SDK"
 ---
 
 # Task 05: WASM crypto pipeline bindings + golden-fixture parity tests

--- a/work/chrome-extension/tasks/06.md
+++ b/work/chrome-extension/tasks/06.md
@@ -1,12 +1,12 @@
 ---
-status: in_review
+status: done
 depends_on: [01]
 wave: 3
 skills: [code-writing]
 verify: [pnpm-test]
 reviewers: [code-reviewer]
 teammate_name: T06-adapter-framework
-blocked_on: ci-verify
+merged_in: "PR#103 → dev (5b1322b)"
 ---
 
 # Task 06: `ChatAdapter` framework + registry + serializer

--- a/work/chrome-extension/tasks/07.md
+++ b/work/chrome-extension/tasks/07.md
@@ -1,12 +1,12 @@
 ---
-status: in_review
-blocked_on: ci-verify
+status: done
 depends_on: [06]
 wave: 3
 skills: [code-writing, dom-scraping]
 verify: [pnpm-test, manual-har-replay]
 reviewers: [code-reviewer]
 teammate_name: T07-chatgpt-adapter
+merged_in: "PR#104 → dev (908f3ba)"
 ---
 
 # Task 07: ChatGPT adapter (`chatgpt.com`)

--- a/work/chrome-extension/tasks/08.md
+++ b/work/chrome-extension/tasks/08.md
@@ -1,12 +1,12 @@
 ---
-status: in_review
+status: done
 depends_on: [06]
 wave: 3
 skills: [code-writing, dom-scraping]
 verify: [pnpm-test]
 reviewers: [code-reviewer]
 teammate_name: T08-claude-adapter
-blocked_on: ci-verify
+merged_in: "PR#106 → dev (feb69fd)"
 ---
 
 # Task 08: Claude.ai adapter (`claude.ai`)

--- a/work/chrome-extension/tasks/09.md
+++ b/work/chrome-extension/tasks/09.md
@@ -1,12 +1,12 @@
 ---
-status: in_review
-blocked_on: ci-verify
+status: done
 depends_on: [06]
 wave: 3
 skills: [code-writing, dom-scraping]
 verify: [pnpm-test]
 reviewers: [code-reviewer]
 teammate_name: T09-gemini-adapter
+merged_in: "PR#109 → dev (a3b1a0d)"
 ---
 
 # Task 09: Gemini adapter (`gemini.google.com`)


### PR DESCRIPTION
## Summary
- Sync `work/chrome-extension/tasks/{01..09}.md` frontmatter with their dev-branch merge commits
- `status: in_review` → `status: done`, clear `blocked_on: ci-verify`, add `merged_in:` pointer per task
- Unblocks Wave A (T14 — server Google OAuth) as the next ready task per `/do-feature` orchestration

## Test plan
- [x] Frontmatter-only change; no code or test touched
- [x] All nine merges verified via `gh pr view <PR#>` + `git log`

🤖 Generated with [Claude Code](https://claude.com/claude-code)