### PR TITLE
feat(extension): T11 — popup UI (Capture / Recall / Verify tabs)

### DIFF
--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -151,6 +151,17 @@ jobs:
         working-directory: packages/extension
         run: bun test
 
+      # Popup component tests (T11). @testing-library/react + jsdom are
+      # not supported under bun's built-in test runner today, so the
+      # `tests/component/**` glob is excluded from `bun test` (see
+      # `packages/extension/bunfig.toml`). They run under vitest here
+      # so the D13 TDD anchors gate merges per the round-1 review
+      # finding MAJ-3.
+      - name: Extension popup component tests (vitest)
+        if: matrix.runtime == 'bun-latest'
+        working-directory: packages/extension
+        run: bunx vitest run tests/component
+
   bundle-size:
     name: bundle size budgets
     runs-on: ubuntu-latest

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,26 @@
         "webapp"
       ]
     },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@asamuzakjp/css-color": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
@@ -1186,6 +1206,15 @@
         "node": ">= 0.10.0"
       }
     },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.2.2.tgz",
+      "integrity": "sha512-/KPde26khDUIPkTGU82jdtTW9UAuvUTumCAbFs/7giR0SxsvZC4hru51PBvpijH6BVkHcROcvZM/lpy5h1jRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.13.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
@@ -1412,6 +1441,105 @@
         "node": ">=12"
       }
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@puppeteer/browsers": {
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.10.tgz",
+      "integrity": "sha512-3ZG500+ZeLql8rE0hjfhkycJjDj0pI/btEh3L9IkWUYcOrgP0xCNRq3HbtbqOPbvDhFaAWD88pDFtlLv8ns8gA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.7.2",
+        "tar-fs": "^3.1.0",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@puppeteer/browsers/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1454,9 +1582,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
-      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.3.tgz",
+      "integrity": "sha512-x35CNW/ANXG3hE/EZpRU8MXX1JDN86hBb2wMGAtltkz7pc6cxgjpy1OMMfDosOQ+2hWqIkag/fGok1Yady9nGw==",
       "cpu": [
         "arm"
       ],
@@ -1468,9 +1596,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
-      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.3.tgz",
+      "integrity": "sha512-xw3xtkDApIOGayehp2+Rz4zimfkaX65r4t47iy+ymQB2G4iJCBBfj0ogVg5jpvjpn8UWn/+q9tprxleYeNp3Hw==",
       "cpu": [
         "arm64"
       ],
@@ -1482,9 +1610,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
-      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.3.tgz",
+      "integrity": "sha512-vo6Y5Qfpx7/5EaamIwi0WqW2+zfiusVihKatLvtN1VFVy3D13uERk/6gZLU1UiHRL6fDXqj/ELIeVRGnvcTE1g==",
       "cpu": [
         "arm64"
       ],
@@ -1496,9 +1624,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
-      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.3.tgz",
+      "integrity": "sha512-D+0QGcZhBzTN82weOnsSlY7V7+RMmPuF1CkbxyMAGE8+ZHeUjyb76ZiWmBlCu//AQQONvxcqRbwZTajZKqjuOw==",
       "cpu": [
         "x64"
       ],
@@ -1510,9 +1638,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
-      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.3.tgz",
+      "integrity": "sha512-6HnvHCT7fDyj6R0Ph7A6x8dQS/S38MClRWeDLqc0MdfWkxjiu1HSDYrdPhqSILzjTIC/pnXbbJbo+ft+gy/9hQ==",
       "cpu": [
         "arm64"
       ],
@@ -1524,9 +1652,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
-      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.3.tgz",
+      "integrity": "sha512-KHLgC3WKlUYW3ShFKnnosZDOJ0xjg9zp7au3sIm2bs/tGBeC2ipmvRh/N7JKi0t9Ue20C0dpEshi8WUubg+cnA==",
       "cpu": [
         "x64"
       ],
@@ -1538,9 +1666,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
-      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.3.tgz",
+      "integrity": "sha512-DV6fJoxEYWJOvaZIsok7KrYl0tPvga5OZ2yvKHNNYyk/2roMLqQAbGhr78EQ5YhHpnhLKJD3S1WFusAkmUuV5g==",
       "cpu": [
         "arm"
       ],
@@ -1552,9 +1680,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
-      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.3.tgz",
+      "integrity": "sha512-mQKoJAzvuOs6F+TZybQO4GOTSMUu7v0WdxEk24krQ/uUxXoPTtHjuaUuPmFhtBcM4K0ons8nrE3JyhTuCFtT/w==",
       "cpu": [
         "arm"
       ],
@@ -1566,9 +1694,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
-      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.3.tgz",
+      "integrity": "sha512-Whjj2qoiJ6+OOJMGptTYazaJvjOJm+iKHpXQM1P3LzGjt7Ff++Tp7nH4N8J/BUA7R9IHfDyx4DJIflifwnbmIA==",
       "cpu": [
         "arm64"
       ],
@@ -1580,9 +1708,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
-      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.3.tgz",
+      "integrity": "sha512-4YTNHKqGng5+yiZt3mg77nmyuCfmNfX4fPmyUapBcIk+BdwSwmCWGXOUxhXbBEkFHtoN5boLj/5NON+u5QC9tg==",
       "cpu": [
         "arm64"
       ],
@@ -1594,9 +1722,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
-      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.3.tgz",
+      "integrity": "sha512-SU3kNlhkpI4UqlUc2VXPGK9o886ZsSeGfMAX2ba2b8DKmMXq4AL7KUrkSWVbb7koVqx41Yczx6dx5PNargIrEA==",
       "cpu": [
         "loong64"
       ],
@@ -1608,9 +1736,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
-      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.3.tgz",
+      "integrity": "sha512-6lDLl5h4TXpB1mTf2rQWnAk/LcXrx9vBfu/DT5TIPhvMhRWaZ5MxkIc8u4lJAmBo6klTe1ywXIUHFjylW505sg==",
       "cpu": [
         "loong64"
       ],
@@ -1622,9 +1750,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
-      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.3.tgz",
+      "integrity": "sha512-BMo8bOw8evlup/8G+cj5xWtPyp93xPdyoSN16Zy90Q2QZ0ZYRhCt6ZJSwbrRzG9HApFabjwj2p25TUPDWrhzqQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1636,9 +1764,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
-      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.3.tgz",
+      "integrity": "sha512-E0L8X1dZN1/Rph+5VPF6Xj2G7JJvMACVXtamTJIDrVI44Y3K+G8gQaMEAavbqCGTa16InptiVrX6eM6pmJ+7qA==",
       "cpu": [
         "ppc64"
       ],
@@ -1650,9 +1778,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
-      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.3.tgz",
+      "integrity": "sha512-oZJ/WHaVfHUiRAtmTAeo3DcevNsVvH8mbvodjZy7D5QKvCefO371SiKRpxoDcCxB3PTRTLayWBkvmDQKTcX/sw==",
       "cpu": [
         "riscv64"
       ],
@@ -1664,9 +1792,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
-      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.3.tgz",
+      "integrity": "sha512-Dhbyh7j9FybM3YaTgaHmVALwA8AkUwTPccyCQ79TG9AJUsMQqgN1DDEZNr4+QUfwiWvLDumW5vdwzoeUF+TNxQ==",
       "cpu": [
         "riscv64"
       ],
@@ -1678,9 +1806,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
-      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.3.tgz",
+      "integrity": "sha512-cJd1X5XhHHlltkaypz1UcWLA8AcoIi1aWhsvaWDskD1oz2eKCypnqvTQ8ykMNI0RSmm7NkTdSqSSD7zM0xa6Ig==",
       "cpu": [
         "s390x"
       ],
@@ -1692,9 +1820,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-DAZDBHQfG2oQuhY7mc6I3/qB4LU2fQCjRvxbDwd/Jdvb9fypP4IJ4qmtu6lNjes6B531AI8cg1aKC2di97bUxA==",
       "cpu": [
         "x64"
       ],
@@ -1706,9 +1834,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
-      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.3.tgz",
+      "integrity": "sha512-cRxsE8c13mZOh3vP+wLDxpQBRrOHDIGOWyDL93Sy0Ga8y515fBcC2pjUfFwUe5T7tqvTvWbCpg1URM/AXdWIXA==",
       "cpu": [
         "x64"
       ],
@@ -1720,9 +1848,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
-      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.3.tgz",
+      "integrity": "sha512-QaWcIgRxqEdQdhJqW4DJctsH6HCmo5vHxY0krHSX4jMtOqfzC+dqDGuHM87bu4H8JBeibWx7jFz+h6/4C8wA5Q==",
       "cpu": [
         "x64"
       ],
@@ -1734,9 +1862,9 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
-      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.3.tgz",
+      "integrity": "sha512-AaXwSvUi3QIPtroAUw1t5yHGIyqKEXwH54WUocFolZhpGDruJcs8c+xPNDRn4XiQsS7MEwnYsHW2l0MBLDMkWg==",
       "cpu": [
         "arm64"
       ],
@@ -1748,9 +1876,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
-      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.3.tgz",
+      "integrity": "sha512-65LAKM/bAWDqKNEelHlcHvm2V+Vfb8C6INFxQXRHCvaVN1rJfwr4NvdP4FyzUaLqWfaCGaadf6UbTm8xJeYfEg==",
       "cpu": [
         "arm64"
       ],
@@ -1762,9 +1890,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
-      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.3.tgz",
+      "integrity": "sha512-EEM2gyhBF5MFnI6vMKdX1LAosE627RGBzIoGMdLloPZkXrUN0Ckqgr2Qi8+J3zip/8NVVro3/FjB+tjhZUgUHA==",
       "cpu": [
         "ia32"
       ],
@@ -1776,9 +1904,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
-      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.3.tgz",
+      "integrity": "sha512-E5Eb5H/DpxaoXH++Qkv28RcUJboMopmdDUALBczvHMf7hNIxaDZqwY5lK12UK1BHacSmvupoEWGu+n993Z0y1A==",
       "cpu": [
         "x64"
       ],
@@ -1790,9 +1918,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
-      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.3.tgz",
+      "integrity": "sha512-hPt/bgL5cE+Qp+/TPHBqptcAgPzgj46mPcg/16zNUmbQk0j+mOEQV/+Lqu8QRtDV3Ek95Q6FeFITpuhl6OTsAA==",
       "cpu": [
         "x64"
       ],
@@ -1830,6 +1958,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@sitespeed.io/tracium": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@sitespeed.io/tracium/-/tracium-0.3.3.tgz",
+      "integrity": "sha512-dNZafjM93Y+F+sfwTO5gTpsGXlnc/0Q+c2+62ViqP3gkMWvHEMSKkaEHgVJLcLg3i/g19GSIPziiKpgyne07Bw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@size-limit/file": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-11.2.0.tgz",
@@ -1841,6 +1982,78 @@
       },
       "peerDependencies": {
         "size-limit": "11.2.0"
+      }
+    },
+    "node_modules/@size-limit/preset-app": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/preset-app/-/preset-app-12.1.0.tgz",
+      "integrity": "sha512-pGGOxzDMM6MUXCzTwUjIcgex9RYbGdvQYni1rUtsZ1oojm7JvOSbBMiJPe9PhpmDq/aMsVzjP1oN0guq1RptVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@size-limit/file": "12.1.0",
+        "@size-limit/time": "12.1.0",
+        "size-limit": "12.1.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.1.0"
+      }
+    },
+    "node_modules/@size-limit/preset-app/node_modules/@size-limit/file": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/file/-/file-12.1.0.tgz",
+      "integrity": "sha512-eGwDcIufnNnvJRzv3liDOn6MAOGgmOTUdpeGQ2KuRTlgIgO54AJH1ilvktlJc6PIjNfwpYY0dOGyap1QgM1swQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.1.0"
+      }
+    },
+    "node_modules/@size-limit/preset-app/node_modules/@size-limit/time": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/@size-limit/time/-/time-12.1.0.tgz",
+      "integrity": "sha512-ekYPeZcvkPSLsHtqNmz7F5jx3R0HV7CpY7kGasBW2yKR3NrD0JWMAcswS9OCR8OzK9hyLACRTNYTpLI9PXLczQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "estimo": "^3.0.5"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "size-limit": "12.1.0"
+      }
+    },
+    "node_modules/@size-limit/preset-app/node_modules/size-limit": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-12.1.0.tgz",
+      "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "lilconfig": "^3.1.3",
+        "nanospinner": "^1.2.2",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "size-limit": "bin.js"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "jiti": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
@@ -1906,6 +2119,131 @@
       "engines": {
         "node": ">= 20"
       }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@tootallnate/quickjs-emscripten": {
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
+      "integrity": "sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1994,6 +2332,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsdom": {
+      "version": "28.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.1.tgz",
+      "integrity": "sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0",
+        "undici-types": "^7.21.0"
+      }
+    },
+    "node_modules/@types/jsdom/node_modules/undici-types": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.25.0.tgz",
+      "integrity": "sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/long": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
+      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
+      "license": "MIT"
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -2005,7 +2369,6 @@
       "version": "20.19.39",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
       "integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2030,6 +2393,13 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.3",
@@ -2159,6 +2529,20 @@
       "integrity": "sha512-CqTpxOlUCPWRNUPZDxT5v2NnHXA4oox612iUGnmTUGQFhZ1Gkj8kirtl/2wcF6MqX7+PqqicZzOCBKKfIn0dww==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/@xenova/transformers": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/@xenova/transformers/-/transformers-2.17.2.tgz",
+      "integrity": "sha512-lZmHqzrVIkSvZdKZEx7IYY51TK0WDrC8eR0c5IMnBsO8di8are1zzw8BlLhyO2TklZKLN5UffNGs1IJwT6oOqQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@huggingface/jinja": "^0.2.2",
+        "onnxruntime-web": "1.14.0",
+        "sharp": "^0.32.0"
+      },
+      "optionalDependencies": {
+        "onnxruntime-node": "1.14.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -2383,12 +2767,63 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
     },
     "node_modules/array-differ": {
       "version": "4.0.0",
@@ -2426,6 +2861,19 @@
         "node": "*"
       }
     },
+    "node_modules/ast-types": {
+      "version": "0.13.4",
+      "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
+      "integrity": "sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/async": {
       "version": "3.2.6",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
@@ -2461,11 +2909,173 @@
         "when-exit": "^2.1.4"
       }
     },
+    "node_modules/autoprefixer": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-fs": {
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+      "integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.5.4",
+        "bare-path": "^3.0.0",
+        "bare-stream": "^2.6.4",
+        "bare-url": "^2.2.2",
+        "fast-fifo": "^1.3.2"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-os": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.9.1.tgz",
+      "integrity": "sha512-6M5XjcnsygQNPMCMPXSK379xrJFiZ/AEMNBmFEmQW8d/789VQATvriyi5r0HYTL9TkQ26rn3kgdTG3aisbrXkQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.14.0"
+      }
+    },
+    "node_modules/bare-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.0.0.tgz",
+      "integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-os": "^3.0.1"
+      }
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-url": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.3.tgz",
+      "integrity": "sha512-Kccpc7ACfXaxfeInfqKcZtW4pT5YBn1mesc4sCsun6sRwtbJ4h+sNOaksUpYEJUKfN65YWC6Bw2OJEFiKxq8nQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
@@ -2479,6 +3089,54 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/basic-ftp": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+      "integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/bluebird": {
@@ -2602,6 +3260,30 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -2689,6 +3371,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/camelcase-css": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+      "integrity": "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/caniuse-lite": {
@@ -2833,6 +3525,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
+    },
     "node_modules/chrome-launcher": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-1.2.0.tgz",
@@ -2879,6 +3577,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/chromium-bidi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-8.0.0.tgz",
+      "integrity": "sha512-d1VmE0FD7lxZQHzcDUCKZSNRtRwISXDsdg4HjdTR5+Ll5nQ/vzU12JeNmupD6VWffrPSlrnGhEWlLESKH3VO+g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "mitt": "^3.0.1",
+        "zod": "^3.24.1"
+      },
+      "peerDependencies": {
+        "devtools-protocol": "*"
       }
     },
     "node_modules/cli-boxes": {
@@ -2975,11 +3687,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
@@ -2992,8 +3716,17 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
     },
     "node_modules/columnify": {
       "version": "1.6.0",
@@ -3167,6 +3900,26 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/cssstyle": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
@@ -3194,6 +3947,16 @@
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -3254,6 +4017,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/deep-eql": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
@@ -3271,7 +4049,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4.0.0"
@@ -3347,6 +4124,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/degenerator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-5.0.1.tgz",
+      "integrity": "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ast-types": "^0.13.4",
+        "escodegen": "^2.1.0",
+        "esprima": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -3357,6 +4149,39 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/devtools-protocol": {
+      "version": "0.0.1495869",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1495869.tgz",
+      "integrity": "sha512-i+bkd9UYFis40RcnkW7XrOprCujXRAHg62IVh/Ah3G8MmNXpCGt1m0dTFhSdx/AVs8XEMbdOGRwdkR1Bcta8AA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/didyoumean": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+      "integrity": "sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
@@ -3366,6 +4191,13 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/dlv": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+      "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "3.0.0",
@@ -3379,6 +4211,13 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -3509,6 +4348,15 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
     },
     "node_modules/entities": {
       "version": "6.0.1",
@@ -3669,6 +4517,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
       }
     },
     "node_modules/eslint": {
@@ -3894,6 +4764,55 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estimo": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/estimo/-/estimo-3.0.5.tgz",
+      "integrity": "sha512-Q9asaAAM3KZc4Ckr8GMcJWYc3hNCf0KnmhkfzHuAWmqGoPssQoe5Mb8et1CYmmkeMfPTlUyeBHRi53Bedvnl1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sitespeed.io/tracium": "0.3.3",
+        "commander": "12.0.0",
+        "find-chrome-bin": "2.0.4",
+        "nanoid": "5.1.5",
+        "puppeteer-core": "24.22.0"
+      },
+      "bin": {
+        "estimo": "scripts/cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/estimo/node_modules/commander": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.0.0.tgz",
+      "integrity": "sha512-MwVNWlYjDTtOjX5PiD7o5pK0UrFU/OYgcJfjjK4RaHZETNtjJqrZa9Y9ds88+A+f+d5lv+561eZ+yCKoS3gbAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/estimo/node_modules/nanoid": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-5.1.5.tgz",
+      "integrity": "sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.js"
+      },
+      "engines": {
+        "node": "^18 || >=20"
+      }
+    },
     "node_modules/estraverse": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
@@ -3924,6 +4843,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/execa": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
@@ -3948,6 +4876,52 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extract-zip/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/fake-indexeddb": {
       "version": "6.2.5",
       "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
@@ -3963,6 +4937,12 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -4110,6 +5090,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-chrome-bin": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/find-chrome-bin/-/find-chrome-bin-2.0.4.tgz",
+      "integrity": "sha512-iKiqIb7FsA0hwnq0vvDay4RsmHUFLvWVquTb59XVlxfHS68XaWZfEjriF2vTZ3k/plicyKZxMJLqxKt10kSOtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@puppeteer/browsers": "2.10.10"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -4197,6 +5190,12 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
+    "node_modules/flatbuffers": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-1.12.0.tgz",
+      "integrity": "sha512-c7CZADjRcl6j0PlvFy0ZqXQ67qSEZfrVPynmnL+2zPc+NtMvrF8Y0QceMo7QqnSPc7+uWjUIAbvCQ5WIKlMVdQ==",
+      "license": "SEE LICENSE IN LICENSE.txt"
+    },
     "node_modules/flatted": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
@@ -4220,6 +5219,26 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "10.1.0",
@@ -4425,6 +5444,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/get-uri": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.5.tgz",
+      "integrity": "sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "basic-ftp": "^5.0.2",
+        "data-uri-to-buffer": "^6.0.2",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -4549,6 +5589,12 @@
       "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/guid-typescript": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/guid-typescript/-/guid-typescript-1.0.9.tgz",
+      "integrity": "sha512-Y8T4vYhEfwJOTbouREvG+3XDsjr8E3kIr7uf+JZ0BYloFsttiHU0WfvANVsR7TxNUJa/WpCnw/Ino/p+DeBhBQ==",
+      "license": "ISC"
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -4715,6 +5761,26 @@
       "integrity": "sha512-LtwtVyVYO5BqRvcsKuB2iUMnHwPVByPCXFXOpuU96IZPPoPN6xjOGxZQ74pgSVVLQWtUOYgyeL4GE98BY5D3wg==",
       "license": "ISC"
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -4772,6 +5838,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4788,7 +5864,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ini": {
@@ -4799,6 +5874,16 @@
       "license": "ISC",
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/is-absolute": {
@@ -4820,6 +5905,35 @@
       "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
@@ -5479,6 +6593,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/loupe": {
       "version": "2.3.7",
       "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
@@ -5495,6 +6615,16 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -5610,6 +6740,28 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
@@ -5627,11 +6779,23 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/mlly": {
       "version": "1.8.2",
@@ -5683,10 +6847,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -5712,11 +6888,57 @@
         "picocolors": "^1.1.1"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/netmask": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+      "integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.92.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.92.0.tgz",
+      "integrity": "sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
+      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "license": "MIT"
     },
     "node_modules/node-forge": {
@@ -5804,6 +7026,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/npm-run-path": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-5.3.0.tgz",
@@ -5853,6 +7085,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+      "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
@@ -5867,7 +7119,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -5887,6 +7138,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/onnx-proto": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/onnx-proto/-/onnx-proto-4.0.4.tgz",
+      "integrity": "sha512-aldMOB3HRoo6q/phyB6QRQxSt895HNNw82BNyZ2CMh4bjeKv7g/c+VpAFtJuEMVfYLMbRx61hbuqnKceLeDcDA==",
+      "license": "MIT",
+      "dependencies": {
+        "protobufjs": "^6.8.8"
+      }
+    },
+    "node_modules/onnxruntime-common": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.14.0.tgz",
+      "integrity": "sha512-3LJpegM2iMNRX2wUmtYfeX/ytfOzNwAWKSq1HbRrKc9+uqG/FsEA0bbKZl1btQeZaXhC26l44NWpNUeXPII7Ew==",
+      "license": "MIT"
+    },
+    "node_modules/onnxruntime-node": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.14.0.tgz",
+      "integrity": "sha512-5ba7TWomIV/9b6NH/1x/8QEeowsb+jBEvFzU6z0T4mNsFwdPqXeFUM7uxC6QeSRkEbWu3qEB0VMjrvzN/0S9+w==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32",
+        "darwin",
+        "linux"
+      ],
+      "dependencies": {
+        "onnxruntime-common": "~1.14.0"
+      }
+    },
+    "node_modules/onnxruntime-web": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/onnxruntime-web/-/onnxruntime-web-1.14.0.tgz",
+      "integrity": "sha512-Kcqf43UMfW8mCydVGcX9OMXI2VN17c0p6XvR7IPSZzBf/6lteBzXHvcEVWDPmCKuGombl997HgLqj91F11DzXw==",
+      "license": "MIT",
+      "dependencies": {
+        "flatbuffers": "^1.12.0",
+        "guid-typescript": "^1.0.9",
+        "long": "^4.0.0",
+        "onnx-proto": "^4.0.4",
+        "onnxruntime-common": "~1.14.0",
+        "platform": "^1.3.6"
       }
     },
     "node_modules/open": {
@@ -5995,6 +7290,40 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pac-proxy-agent": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
+      "integrity": "sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/quickjs-emscripten": "^0.23.0",
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "get-uri": "^6.0.1",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.6",
+        "pac-resolver": "^7.0.1",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/pac-resolver": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-7.0.1.tgz",
+      "integrity": "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "degenerator": "^5.0.0",
+        "netmask": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/package-json": {
@@ -6152,6 +7481,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pathe": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
@@ -6196,6 +7532,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/pino": {
       "version": "9.9.5",
       "resolved": "https://registry.npmjs.org/pino/-/pino-9.9.5.tgz",
@@ -6236,6 +7582,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/pkg-types": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
@@ -6255,10 +7611,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "license": "MIT"
+    },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -6284,6 +7646,140 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-import": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+      "integrity": "sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "postcss-value-parser": "^4.0.0",
+        "read-cache": "^1.0.0",
+        "resolve": "^1.1.7"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.0.0"
+      }
+    },
+    "node_modules/postcss-js": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+      "integrity": "sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "camelcase-css": "^2.0.1"
+      },
+      "engines": {
+        "node": "^12 || ^14 || >= 16"
+      },
+      "peerDependencies": {
+        "postcss": "^8.4.21"
+      }
+    },
+    "node_modules/postcss-load-config": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+      "integrity": "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "lilconfig": "^3.1.1"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "peerDependencies": {
+        "jiti": ">=1.21.0",
+        "postcss": ">=8.0.9",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/postcss-nested": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+      "integrity": "sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      },
+      "peerDependencies": {
+        "postcss": "^8.2.14"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+      "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/powershell-utils": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
@@ -6294,6 +7790,75 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/prebuild-install/node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/prelude-ls": {
@@ -6361,6 +7926,16 @@
       ],
       "license": "MIT"
     },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/promise-toolbox": {
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/promise-toolbox/-/promise-toolbox-0.21.0.tgz",
@@ -6381,6 +7956,69 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/protobufjs": {
+      "version": "6.11.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.6.tgz",
+      "integrity": "sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.4",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.0",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.0",
+        "@types/long": "^4.0.1",
+        "@types/node": ">=13.7.0",
+        "long": "^4.0.0"
+      },
+      "bin": {
+        "pbjs": "bin/pbjs",
+        "pbts": "bin/pbts"
+      }
+    },
+    "node_modules/proxy-agent": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent/-/proxy-agent-6.5.0.tgz",
+      "integrity": "sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "http-proxy-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "lru-cache": "^7.14.1",
+        "pac-proxy-agent": "^7.1.0",
+        "proxy-from-env": "^1.1.0",
+        "socks-proxy-agent": "^8.0.5"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/proxy-agent/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -6392,6 +8030,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/punycode": {
@@ -6418,6 +8066,25 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/puppeteer-core": {
+      "version": "24.22.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.22.0.tgz",
+      "integrity": "sha512-oUeWlIg0pMz8YM5pu0uqakM+cCyYyXkHBxx9di9OUELu9X9+AYrNGGRLK9tNME3WfN3JGGqQIH3b4/E9LGek/w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@puppeteer/browsers": "2.10.10",
+        "chromium-bidi": "8.0.0",
+        "debug": "^4.4.3",
+        "devtools-protocol": "0.0.1495869",
+        "typed-query-selector": "^2.12.0",
+        "webdriver-bidi-protocol": "0.2.11",
+        "ws": "^8.18.3"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/querystringify": {
@@ -6459,7 +8126,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
       "dependencies": {
         "deep-extend": "^0.6.0",
@@ -6475,14 +8141,12 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/rc/node_modules/strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6526,6 +8190,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/read-cache": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+      "integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pify": "^2.3.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
@@ -6564,6 +8238,20 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/registry-auth-token": {
@@ -6622,6 +8310,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -6661,9 +8371,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.60.2",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
-      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "version": "4.60.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.3.tgz",
+      "integrity": "sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -6677,31 +8387,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.2",
-        "@rollup/rollup-android-arm64": "4.60.2",
-        "@rollup/rollup-darwin-arm64": "4.60.2",
-        "@rollup/rollup-darwin-x64": "4.60.2",
-        "@rollup/rollup-freebsd-arm64": "4.60.2",
-        "@rollup/rollup-freebsd-x64": "4.60.2",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
-        "@rollup/rollup-linux-arm64-musl": "4.60.2",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
-        "@rollup/rollup-linux-loong64-musl": "4.60.2",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-gnu": "4.60.2",
-        "@rollup/rollup-linux-x64-musl": "4.60.2",
-        "@rollup/rollup-openbsd-x64": "4.60.2",
-        "@rollup/rollup-openharmony-arm64": "4.60.2",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
-        "@rollup/rollup-win32-x64-gnu": "4.60.2",
-        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "@rollup/rollup-android-arm-eabi": "4.60.3",
+        "@rollup/rollup-android-arm64": "4.60.3",
+        "@rollup/rollup-darwin-arm64": "4.60.3",
+        "@rollup/rollup-darwin-x64": "4.60.3",
+        "@rollup/rollup-freebsd-arm64": "4.60.3",
+        "@rollup/rollup-freebsd-x64": "4.60.3",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.3",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.3",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.3",
+        "@rollup/rollup-linux-arm64-musl": "4.60.3",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.3",
+        "@rollup/rollup-linux-loong64-musl": "4.60.3",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.3",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.3",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.3",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.3",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-gnu": "4.60.3",
+        "@rollup/rollup-linux-x64-musl": "4.60.3",
+        "@rollup/rollup-openbsd-x64": "4.60.3",
+        "@rollup/rollup-openharmony-arm64": "4.60.3",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.3",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.3",
+        "@rollup/rollup-win32-x64-gnu": "4.60.3",
+        "@rollup/rollup-win32-x64-msvc": "4.60.3",
         "fsevents": "~2.3.2"
       }
     },
@@ -6762,7 +8472,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/safe-stable-stringify": {
@@ -6828,6 +8537,41 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sharp": {
+      "version": "0.32.6",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.32.6.tgz",
+      "integrity": "sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.2",
+        "node-addon-api": "^6.1.0",
+        "prebuild-install": "^7.1.1",
+        "semver": "^7.5.4",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^3.0.4",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/sharp/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -6885,6 +8629,66 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-swizzle/node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+      "license": "MIT"
+    },
     "node_modules/size-limit": {
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-11.2.0.tgz",
@@ -6905,6 +8709,47 @@
       },
       "engines": {
         "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
+      "integrity": "sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "^4.3.4",
+        "socks": "^2.8.3"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/sonic-boom": {
@@ -6997,11 +8842,21 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
@@ -7120,6 +8975,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-5.0.3.tgz",
@@ -7163,6 +9031,46 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/sucrase": {
+      "version": "3.35.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+      "integrity": "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.2",
+        "commander": "^4.0.0",
+        "lines-and-columns": "^1.1.6",
+        "mz": "^2.7.0",
+        "pirates": "^4.0.1",
+        "tinyglobby": "^0.2.11",
+        "ts-interface-checker": "^0.1.9"
+      },
+      "bin": {
+        "sucrase": "bin/sucrase",
+        "sucrase-node": "bin/sucrase-node"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/sucrase/node_modules/commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/sucrase/node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -7176,6 +9084,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
@@ -7183,12 +9104,204 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/tailwindcss": {
+      "version": "3.4.19",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+      "integrity": "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "arg": "^5.0.2",
+        "chokidar": "^3.6.0",
+        "didyoumean": "^1.2.2",
+        "dlv": "^1.1.3",
+        "fast-glob": "^3.3.2",
+        "glob-parent": "^6.0.2",
+        "is-glob": "^4.0.3",
+        "jiti": "^1.21.7",
+        "lilconfig": "^3.1.3",
+        "micromatch": "^4.0.8",
+        "normalize-path": "^3.0.0",
+        "object-hash": "^3.0.0",
+        "picocolors": "^1.1.1",
+        "postcss": "^8.4.47",
+        "postcss-import": "^15.1.0",
+        "postcss-js": "^4.0.1",
+        "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0",
+        "postcss-nested": "^6.2.0",
+        "postcss-selector-parser": "^6.1.2",
+        "resolve": "^1.22.8",
+        "sucrase": "^3.35.0"
+      },
+      "bin": {
+        "tailwind": "lib/cli.js",
+        "tailwindcss": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/chokidar/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/jiti": {
+      "version": "1.21.7",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+      "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tailwindcss/node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+      "integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0",
+        "tar-stream": "^3.1.5"
+      },
+      "optionalDependencies": {
+        "bare-fs": "^4.0.1",
+        "bare-path": "^3.0.0"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
+      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.6.4",
+        "bare-fs": "^4.5.5",
+        "fast-fifo": "^1.2.0",
+        "streamx": "^2.15.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/thread-stream": {
       "version": "3.1.0",
@@ -7303,12 +9416,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -7346,6 +9478,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typed-query-selector": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -7354,9 +9493,9 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -7378,7 +9517,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -7522,7 +9660,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {
@@ -7800,6 +9937,13 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/webdriver-bidi-protocol": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.2.11.tgz",
+      "integrity": "sha512-Y9E1/oi4XMxcR8AT0ZC4OvYntl34SPgwjmELH+owjBr0korAX4jKgZULBWILGCVGdVCQ0dodTToIETozhG8zvA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
@@ -7992,7 +10136,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/ws": {
@@ -8203,6 +10346,16 @@
         "jszip": "^3.2.2"
       }
     },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "packages/cli": {
       "name": "@mnemonik-xyz/cli",
       "version": "0.1.6",
@@ -8341,17 +10494,29 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@xenova/transformers": "^2.17.2",
         "idb": "^8.0.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0"
       },
       "devDependencies": {
         "@crxjs/vite-plugin": "^2.0.0",
+        "@size-limit/preset-app": "^12.1.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/chrome": "^0.0.287",
+        "@types/jsdom": "^28.0.1",
         "@types/react": "^19.1.0",
         "@types/react-dom": "^19.1.0",
         "@vitejs/plugin-react": "^4.3.4",
+        "autoprefixer": "^10.5.0",
         "fake-indexeddb": "^6.2.5",
+        "jsdom": "^24.1.3",
+        "postcss": "^8.5.14",
+        "size-limit": "^12.1.0",
+        "tailwindcss": "^3.4.19",
         "typescript": "~5.7.2",
         "vite": "^6.3.3",
         "vitest": "^1.6.0",
@@ -8794,18 +10959,32 @@
         "@esbuild/win32-x64": "0.25.12"
       }
     },
-    "packages/extension/node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+    "packages/extension/node_modules/size-limit": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/size-limit/-/size-limit-12.1.0.tgz",
+      "integrity": "sha512-VnDS2fycANrJFVPQwjaD+h+hkISY7EB3LsPsYWje4lBCjQwwsZLxjwwRwVJKHrcj2ZqyG+DdXykWm9mbZklZrw==",
       "dev": true,
-      "license": "Apache-2.0",
+      "license": "MIT",
+      "dependencies": {
+        "bytes-iec": "^3.1.1",
+        "lilconfig": "^3.1.3",
+        "nanospinner": "^1.2.2",
+        "picocolors": "^1.1.1",
+        "tinyglobby": "^0.2.16"
+      },
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "size-limit": "bin.js"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "jiti": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
       }
     },
     "packages/extension/node_modules/vite": {
@@ -9367,19 +11546,6 @@
         "lightningcss-win32-x64-msvc": "1.32.0"
       }
     },
-    "webapp/node_modules/@adobe/css-tools": {
-      "version": "4.4.4",
-      "dev": true,
-      "license": "MIT"
-    },
-    "webapp/node_modules/@babel/runtime": {
-      "version": "7.29.2",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "webapp/node_modules/@cbor-extract/cbor-extract-darwin-arm64": {
       "version": "2.2.2",
       "cpu": [
@@ -9490,80 +11656,6 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
-    "webapp/node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^7.10.4",
-        "@babel/runtime": "^7.12.5",
-        "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
-        "dom-accessibility-api": "^0.5.9",
-        "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
-        "pretty-format": "^27.0.2"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "webapp/node_modules/@testing-library/jest-dom": {
-      "version": "6.9.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@adobe/css-tools": "^4.4.0",
-        "aria-query": "^5.0.0",
-        "css.escape": "^1.5.1",
-        "dom-accessibility-api": "^0.6.3",
-        "picocolors": "^1.1.1",
-        "redent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14",
-        "npm": ">=6",
-        "yarn": ">=1"
-      }
-    },
-    "webapp/node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
-      "version": "0.6.3",
-      "dev": true,
-      "license": "MIT"
-    },
-    "webapp/node_modules/@testing-library/react": {
-      "version": "16.3.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "peerDependencies": {
-        "@testing-library/dom": "^10.0.0",
-        "@types/react": "^18.0.0 || ^19.0.0",
-        "@types/react-dom": "^18.0.0 || ^19.0.0",
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "@types/react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "webapp/node_modules/@types/aria-query": {
-      "version": "5.0.4",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "webapp/node_modules/@vitest/expect": {
       "version": "2.1.9",
       "dev": true,
@@ -9638,14 +11730,6 @@
         "url": "https://opencollective.com/vitest"
       }
     },
-    "webapp/node_modules/aria-query": {
-      "version": "5.3.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "dequal": "^2.0.3"
-      }
-    },
     "webapp/node_modules/assertion-error": {
       "version": "2.0.1",
       "dev": true,
@@ -9704,11 +11788,6 @@
         "node": ">= 16"
       }
     },
-    "webapp/node_modules/css.escape": {
-      "version": "1.5.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "webapp/node_modules/deep-eql": {
       "version": "5.0.2",
       "dev": true,
@@ -9716,28 +11795,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "webapp/node_modules/dequal": {
-      "version": "2.0.3",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "webapp/node_modules/detect-libc": {
-      "version": "2.1.2",
-      "devOptional": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "webapp/node_modules/dom-accessibility-api": {
-      "version": "0.5.16",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
     },
     "webapp/node_modules/enhanced-resolve": {
       "version": "5.21.0",
@@ -10190,14 +12247,6 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "webapp/node_modules/indent-string": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "webapp/node_modules/jsdom": {
       "version": "25.0.1",
       "dev": true,
@@ -10288,23 +12337,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "webapp/node_modules/lz-string": {
-      "version": "1.5.0",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "bin": {
-        "lz-string": "bin/bin.js"
-      }
-    },
-    "webapp/node_modules/min-indent": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "webapp/node_modules/node-gyp-build-optional-packages": {
       "version": "5.1.1",
       "license": "MIT",
@@ -10354,26 +12386,6 @@
         "node": ">=18"
       }
     },
-    "webapp/node_modules/pretty-format": {
-      "version": "27.5.1",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
-      }
-    },
-    "webapp/node_modules/react-is": {
-      "version": "17.0.2",
-      "dev": true,
-      "license": "MIT",
-      "peer": true
-    },
     "webapp/node_modules/react-router": {
       "version": "6.30.3",
       "license": "MIT",
@@ -10400,29 +12412,6 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
-    },
-    "webapp/node_modules/redent": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "indent-string": "^4.0.0",
-        "strip-indent": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "webapp/node_modules/strip-indent": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "min-indent": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "webapp/node_modules/tailwindcss": {
@@ -10496,18 +12485,6 @@
       },
       "engines": {
         "node": ">=16"
-      }
-    },
-    "webapp/node_modules/typescript": {
-      "version": "5.7.3",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
       }
     },
     "webapp/node_modules/vite": {

--- a/packages/extension/.size-limit.json
+++ b/packages/extension/.size-limit.json
@@ -1,7 +1,11 @@
 [
   {
     "name": "popup-initial-js",
-    "path": "dist/src/popup/main.tsx-*.js",
+    "path": [
+      "dist/src/popup/main.tsx-*.js",
+      "dist/assets/main-*.js",
+      "dist/assets/popup-*.js"
+    ],
     "limit": "50 KB",
     "gzip": true,
     "running": false

--- a/packages/extension/.size-limit.json
+++ b/packages/extension/.size-limit.json
@@ -1,0 +1,9 @@
+[
+  {
+    "name": "popup-initial-js",
+    "path": "dist/src/popup/main.tsx-*.js",
+    "limit": "50 KB",
+    "gzip": true,
+    "running": false
+  }
+]

--- a/packages/extension/bunfig.toml
+++ b/packages/extension/bunfig.toml
@@ -1,0 +1,11 @@
+# `bun test` is the uniform JS-runner test driver per
+# .github/workflows/node-test.yml (decision 11 of the repo CI policy).
+#
+# The popup component tests under `tests/component/**` use
+# `@testing-library/react` (DOM rendering) and depend on vitest's
+# `environmentMatchGlobs: jsdom` opt-in, neither of which bun's
+# built-in test runner hosts today. Skip them here; they run under
+# vitest locally + can be picked up by a dedicated component-test
+# step if one is added to CI later.
+[test]
+pathIgnorePatterns = ["**/tests/component/**"]

--- a/packages/extension/bunfig.toml
+++ b/packages/extension/bunfig.toml
@@ -5,7 +5,9 @@
 # `@testing-library/react` (DOM rendering) and depend on vitest's
 # `environmentMatchGlobs: jsdom` opt-in, neither of which bun's
 # built-in test runner hosts today. Skip them here; they run under
-# vitest locally + can be picked up by a dedicated component-test
-# step if one is added to CI later.
+# vitest in CI via the dedicated `Extension popup component tests
+# (vitest)` step in `.github/workflows/node-test.yml` (added in T11
+# round 2 after review finding MAJ-3), so the D13 TDD anchors gate
+# merges.
 [test]
 pathIgnorePatterns = ["**/tests/component/**"]

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -20,7 +20,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "tsc -b --noEmit",
-    "lint:webext": "web-ext lint --source-dir=dist"
+    "lint:webext": "web-ext lint --source-dir=dist",
+    "size": "size-limit"
   },
   "dependencies": {
     "@xenova/transformers": "^2.17.2",
@@ -30,13 +31,22 @@
   },
   "devDependencies": {
     "@crxjs/vite-plugin": "^2.0.0",
+    "@size-limit/preset-app": "^12.1.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/chrome": "^0.0.287",
     "@types/jsdom": "^28.0.1",
     "@types/react": "^19.1.0",
     "@types/react-dom": "^19.1.0",
     "@vitejs/plugin-react": "^4.3.4",
+    "autoprefixer": "^10.5.0",
     "fake-indexeddb": "^6.2.5",
     "jsdom": "^24.1.3",
+    "postcss": "^8.5.14",
+    "size-limit": "^12.1.0",
+    "tailwindcss": "^3.4.19",
     "typescript": "~5.7.2",
     "vite": "^6.3.3",
     "vitest": "^1.6.0",

--- a/packages/extension/postcss.config.js
+++ b/packages/extension/postcss.config.js
@@ -1,0 +1,9 @@
+// PostCSS config for the extension. Tailwind v3 + autoprefixer; matches
+// the toolchain used by the webapp so the design-token classes resolve
+// identically in both builds.
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/packages/extension/src/popup/App.tsx
+++ b/packages/extension/src/popup/App.tsx
@@ -8,7 +8,14 @@
 // behind dynamic imports in `runtime-impl.ts` so the popup's first-
 // paint bundle stays under the 50KB size-limit budget.
 
-import { useEffect, useState, type JSX } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type JSX,
+  type KeyboardEvent,
+} from "react";
 import type { ChatAdapter } from "../runtime/chat/types.js";
 import { getRuntime, type PopupIdentity, type StorageTier } from "./runtime.js";
 import { Capture } from "./tabs/Capture.js";
@@ -25,6 +32,8 @@ const TAB_LABELS: Record<Tab, string> = {
   verify: "Verify",
 };
 
+const TAB_ORDER: Tab[] = ["capture", "recall", "verify"];
+
 export function App(): JSX.Element {
   const [tab, setTab] = useState<Tab>("capture");
   const [identity, setIdentity] = useState<PopupIdentity | null>(null);
@@ -32,6 +41,7 @@ export function App(): JSX.Element {
   const [adapter, setAdapter] = useState<ChatAdapter | null>(null);
   const [selection, setSelection] = useState("");
   const [tierDialogOpen, setTierDialogOpen] = useState(false);
+  const tabRefs = useRef<Partial<Record<Tab, HTMLButtonElement | null>>>({});
 
   useEffect(() => {
     const r = getRuntime();
@@ -63,6 +73,30 @@ export function App(): JSX.Element {
     }
   };
 
+  // APG tabs pattern: left/right arrows cycle through tabs and move
+  // focus to the newly-selected tab. Home/End jump to first/last.
+  const handleTabKeyDown = (
+    e: KeyboardEvent<HTMLButtonElement>,
+    current: Tab
+  ): void => {
+    const idx = TAB_ORDER.indexOf(current);
+    let next: Tab | null = null;
+    if (e.key === "ArrowRight") {
+      next = TAB_ORDER[(idx + 1) % TAB_ORDER.length] ?? null;
+    } else if (e.key === "ArrowLeft") {
+      next = TAB_ORDER[(idx - 1 + TAB_ORDER.length) % TAB_ORDER.length] ?? null;
+    } else if (e.key === "Home") {
+      next = TAB_ORDER[0] ?? null;
+    } else if (e.key === "End") {
+      next = TAB_ORDER[TAB_ORDER.length - 1] ?? null;
+    }
+    if (next) {
+      e.preventDefault();
+      setTab(next);
+      tabRefs.current[next]?.focus();
+    }
+  };
+
   return (
     <main className="bg-background text-text-primary p-3 flex flex-col gap-3 min-h-full">
       <header className="flex items-center justify-between gap-2">
@@ -81,41 +115,78 @@ export function App(): JSX.Element {
             type="button"
             onClick={openOptions}
             aria-label="Settings"
-            title="Open Settings"
             className="text-text-muted hover:text-accent-primary text-xs font-mono px-2 py-1 rounded border border-white/10 transition-colors"
           >
-            {/* gear glyph — Unicode keeps the bundle small */}⚙
+            {/* Unicode gear glyph — aria-hidden so the aria-label is
+                the single source of the accessible name. */}
+            <span aria-hidden="true">⚙</span>
           </button>
         </div>
       </header>
 
-      <nav
-        aria-label="Tab switcher"
+      <div
+        role="tablist"
+        aria-label="Mnemonik popup tabs"
         className="flex items-center gap-1 border-b border-white/10"
       >
-        {(Object.keys(TAB_LABELS) as Tab[]).map((t) => (
-          <button
-            key={t}
-            type="button"
-            aria-current={tab === t ? "page" : undefined}
-            onClick={() => setTab(t)}
-            className={`flex-1 text-xs font-mono uppercase tracking-wide px-2 py-1.5 border-b-2 transition-colors ${
-              tab === t
-                ? "border-accent-primary text-accent-primary"
-                : "border-transparent text-text-muted hover:text-text-primary"
-            }`}
-          >
-            {TAB_LABELS[t]}
-          </button>
-        ))}
-      </nav>
+        {TAB_ORDER.map((t) => {
+          const selected = tab === t;
+          return (
+            <button
+              key={t}
+              ref={(el) => {
+                tabRefs.current[t] = el;
+              }}
+              type="button"
+              role="tab"
+              id={`tab-${t}`}
+              aria-selected={selected}
+              aria-controls={`panel-${t}`}
+              tabIndex={selected ? 0 : -1}
+              onClick={() => setTab(t)}
+              onKeyDown={(e) => handleTabKeyDown(e, t)}
+              className={`flex-1 text-xs font-mono uppercase tracking-wide px-2 py-1.5 border-b-2 transition-colors ${
+                selected
+                  ? "border-accent-primary text-accent-primary"
+                  : "border-transparent text-text-muted hover:text-text-primary"
+              }`}
+            >
+              {TAB_LABELS[t]}
+            </button>
+          );
+        })}
+      </div>
 
       <section className="flex-1">
-        {tab === "capture" ? (
-          <Capture adapter={adapter} prefilledSelection={selection} />
-        ) : null}
-        {tab === "recall" ? <Recall adapter={adapter} /> : null}
-        {tab === "verify" ? <Verify /> : null}
+        <div
+          role="tabpanel"
+          id="panel-capture"
+          aria-labelledby="tab-capture"
+          tabIndex={0}
+          hidden={tab !== "capture"}
+        >
+          {tab === "capture" ? (
+            <Capture adapter={adapter} prefilledSelection={selection} />
+          ) : null}
+        </div>
+        <div
+          role="tabpanel"
+          id="panel-recall"
+          aria-labelledby="tab-recall"
+          tabIndex={0}
+          hidden={tab !== "recall"}
+        >
+          {tab === "recall" ? <Recall adapter={adapter} /> : null}
+        </div>
+        <div
+          role="tabpanel"
+          id="panel-verify"
+          aria-labelledby="tab-verify"
+          tabIndex={0}
+          hidden={tab !== "verify"}
+        >
+          {tab === "verify" ? <Verify /> : null}
+        </div>
       </section>
 
       {tierDialogOpen ? (
@@ -126,24 +197,53 @@ export function App(): JSX.Element {
 }
 
 function TierDialog({ onClose }: { onClose: () => void }): JSX.Element {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const firstButtonRef = useRef<HTMLButtonElement>(null);
+
+  // Escape-to-dismiss + initial focus on the primary action. A full
+  // focus-trap implementation can land with the dedicated dialog
+  // primitive in T12; the keyboard-driven close path is the most
+  // user-visible piece and ships here.
+  const handleKeyDown = useCallback(
+    (e: globalThis.KeyboardEvent): void => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  useEffect(() => {
+    firstButtonRef.current?.focus();
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
   return (
     <div
+      ref={dialogRef}
       role="dialog"
       aria-modal="true"
-      aria-label="Switching storage tiers"
+      aria-labelledby="tier-dialog-title"
+      aria-describedby="tier-dialog-desc"
       className="fixed inset-0 bg-black/70 flex items-center justify-center p-4"
     >
       <div className="bg-background border border-white/10 rounded p-4 max-w-xs flex flex-col gap-3">
-        <h2 className="text-sm font-mono uppercase tracking-wide text-accent-primary">
+        <h2
+          id="tier-dialog-title"
+          className="text-sm font-mono uppercase tracking-wide text-accent-primary"
+        >
           Switch storage tier
         </h2>
-        <p className="text-xs text-text-muted">
+        <p id="tier-dialog-desc" className="text-xs text-text-muted">
           Switching tiers is handled in Settings. Local → Cloud uploads existing
           memories one by one; Cloud → Local exports and disconnects. Both flows
           live on the Settings page.
         </p>
         <div className="flex items-center gap-2 mt-1">
           <button
+            ref={firstButtonRef}
             type="button"
             onClick={() => {
               chrome.runtime.openOptionsPage?.();

--- a/packages/extension/src/popup/App.tsx
+++ b/packages/extension/src/popup/App.tsx
@@ -1,0 +1,167 @@
+// Popup root. Owns:
+//   - header (IdentityBadge + StorageTierPill + Settings cog)
+//   - tab switcher (Capture / Recall / Verify)
+//   - one-time bootstrap of identity + active-tab adapter + selection
+//
+// Identity + storage tier read from `chrome.storage.local`. Heavy
+// dependencies (WASM, embedder worker, IndexedDB cosine search) sit
+// behind dynamic imports in `runtime-impl.ts` so the popup's first-
+// paint bundle stays under the 50KB size-limit budget.
+
+import { useEffect, useState, type JSX } from "react";
+import type { ChatAdapter } from "../runtime/chat/types.js";
+import { getRuntime, type PopupIdentity, type StorageTier } from "./runtime.js";
+import { Capture } from "./tabs/Capture.js";
+import { Recall } from "./tabs/Recall.js";
+import { Verify } from "./tabs/Verify.js";
+import { IdentityBadge } from "./components/IdentityBadge.js";
+import { StorageTierPill } from "./components/StorageTierPill.js";
+
+type Tab = "capture" | "recall" | "verify";
+
+const TAB_LABELS: Record<Tab, string> = {
+  capture: "Capture",
+  recall: "Recall",
+  verify: "Verify",
+};
+
+export function App(): JSX.Element {
+  const [tab, setTab] = useState<Tab>("capture");
+  const [identity, setIdentity] = useState<PopupIdentity | null>(null);
+  const [tier, setTier] = useState<StorageTier>("local");
+  const [adapter, setAdapter] = useState<ChatAdapter | null>(null);
+  const [selection, setSelection] = useState("");
+  const [tierDialogOpen, setTierDialogOpen] = useState(false);
+
+  useEffect(() => {
+    const r = getRuntime();
+    let cancelled = false;
+    void (async () => {
+      const [id, t, ad, sel] = await Promise.all([
+        r.loadIdentity(),
+        r.loadStorageTier(),
+        r.getActiveTabAdapter(),
+        r.getActiveTabSelection(),
+      ]);
+      if (cancelled) return;
+      setIdentity(id);
+      setTier(t);
+      setAdapter(ad);
+      setSelection(sel);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const openOptions = (): void => {
+    try {
+      chrome.runtime.openOptionsPage();
+    } catch {
+      // openOptionsPage requires a registered options_ui; the popup
+      // can do nothing useful if it's missing.
+    }
+  };
+
+  return (
+    <main className="bg-background text-text-primary p-3 flex flex-col gap-3 min-h-full">
+      <header className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <h1 className="text-sm text-accent-primary font-semibold tracking-wide">
+            Mnemonik
+          </h1>
+          <IdentityBadge identity={identity} onOpenOptions={openOptions} />
+        </div>
+        <div className="flex items-center gap-2">
+          <StorageTierPill
+            tier={tier}
+            onClick={() => setTierDialogOpen(true)}
+          />
+          <button
+            type="button"
+            onClick={openOptions}
+            aria-label="Settings"
+            title="Open Settings"
+            className="text-text-muted hover:text-accent-primary text-xs font-mono px-2 py-1 rounded border border-white/10 transition-colors"
+          >
+            {/* gear glyph — Unicode keeps the bundle small */}⚙
+          </button>
+        </div>
+      </header>
+
+      <nav
+        aria-label="Tab switcher"
+        className="flex items-center gap-1 border-b border-white/10"
+      >
+        {(Object.keys(TAB_LABELS) as Tab[]).map((t) => (
+          <button
+            key={t}
+            type="button"
+            aria-current={tab === t ? "page" : undefined}
+            onClick={() => setTab(t)}
+            className={`flex-1 text-xs font-mono uppercase tracking-wide px-2 py-1.5 border-b-2 transition-colors ${
+              tab === t
+                ? "border-accent-primary text-accent-primary"
+                : "border-transparent text-text-muted hover:text-text-primary"
+            }`}
+          >
+            {TAB_LABELS[t]}
+          </button>
+        ))}
+      </nav>
+
+      <section className="flex-1">
+        {tab === "capture" ? (
+          <Capture adapter={adapter} prefilledSelection={selection} />
+        ) : null}
+        {tab === "recall" ? <Recall adapter={adapter} /> : null}
+        {tab === "verify" ? <Verify /> : null}
+      </section>
+
+      {tierDialogOpen ? (
+        <TierDialog onClose={() => setTierDialogOpen(false)} />
+      ) : null}
+    </main>
+  );
+}
+
+function TierDialog({ onClose }: { onClose: () => void }): JSX.Element {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Switching storage tiers"
+      className="fixed inset-0 bg-black/70 flex items-center justify-center p-4"
+    >
+      <div className="bg-background border border-white/10 rounded p-4 max-w-xs flex flex-col gap-3">
+        <h2 className="text-sm font-mono uppercase tracking-wide text-accent-primary">
+          Switch storage tier
+        </h2>
+        <p className="text-xs text-text-muted">
+          Switching tiers is handled in Settings. Local → Cloud uploads existing
+          memories one by one; Cloud → Local exports and disconnects. Both flows
+          live on the Settings page.
+        </p>
+        <div className="flex items-center gap-2 mt-1">
+          <button
+            type="button"
+            onClick={() => {
+              chrome.runtime.openOptionsPage?.();
+              onClose();
+            }}
+            className="flex-1 bg-accent-primary/20 hover:bg-accent-primary/30 text-accent-primary border border-accent-primary/50 text-xs font-mono uppercase tracking-wide py-1.5 rounded transition-colors"
+          >
+            Open Settings
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 bg-white/5 hover:bg-white/10 text-text-primary border border-white/10 text-xs font-mono uppercase tracking-wide py-1.5 rounded transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/packages/extension/src/popup/components/IdentityBadge.tsx
+++ b/packages/extension/src/popup/components/IdentityBadge.tsx
@@ -1,0 +1,51 @@
+// Identity badge — top-left of the popup header. Renders a truncated
+// pubkey with a copy-to-clipboard interaction and a tooltip-style full
+// DID. Click also opens the options page (T12 owns the Settings UI).
+//
+// The pubkey is read from `chrome.storage.local` (populated by T16
+// onboarding). When no identity is yet present we render a neutral
+// "(not signed in)" affordance — the popup is still useful for the
+// Verify tab in that state.
+
+import type { JSX } from "react";
+import type { PopupIdentity } from "../runtime.js";
+
+export interface IdentityBadgeProps {
+  identity: PopupIdentity | null;
+  onOpenOptions: () => void;
+}
+
+export function IdentityBadge(props: IdentityBadgeProps): JSX.Element {
+  const { identity, onOpenOptions } = props;
+  if (!identity) {
+    return (
+      <button
+        type="button"
+        onClick={onOpenOptions}
+        className="text-text-muted hover:text-accent-primary text-xs font-mono px-2 py-1 rounded border border-white/10 transition-colors"
+        aria-label="Not signed in — open settings"
+        title="No identity configured — click to open Settings"
+      >
+        (not signed in)
+      </button>
+    );
+  }
+  const short = truncateMiddle(identity.pubkey_base58, 4, 4);
+  const did = `did:sol:${identity.pubkey_base58}`;
+  return (
+    <button
+      type="button"
+      onClick={onOpenOptions}
+      title={did}
+      aria-label={`Identity ${did}`}
+      className="text-accent-primary hover:text-white text-xs font-mono px-2 py-1 rounded border border-accent-primary/40 hover:border-accent-primary transition-colors"
+    >
+      {short}
+    </button>
+  );
+}
+
+function truncateMiddle(value: string, head: number, tail: number): string {
+  if (value.length <= head + tail + 1) return value;
+  return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}

--- a/packages/extension/src/popup/components/StorageTierPill.tsx
+++ b/packages/extension/src/popup/components/StorageTierPill.tsx
@@ -1,0 +1,42 @@
+// Storage-tier pill — reads `storage_tier` out of `chrome.storage.local`
+// and renders "Local" (gray) or "Cloud" (teal). T11 ships this as a
+// READ-ONLY indicator: clicking opens a stub dialog that points the
+// user to Settings (T12 owns the actual tier-switch logic per the
+// tech-spec wave 4 split). The pill is still clickable here so users
+// have a clear path to the place that does the switch.
+
+import type { JSX } from "react";
+import type { StorageTier } from "../runtime.js";
+
+export interface StorageTierPillProps {
+  tier: StorageTier;
+  onClick: () => void;
+}
+
+const LABEL: Record<StorageTier, string> = {
+  local: "Local",
+  cloud: "Cloud",
+};
+
+export function StorageTierPill(props: StorageTierPillProps): JSX.Element {
+  const { tier, onClick } = props;
+  const classes =
+    tier === "cloud"
+      ? "bg-accent-primary/15 text-accent-primary border-accent-primary/40"
+      : "bg-white/5 text-text-muted border-white/10";
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={
+        tier === "cloud"
+          ? "Cloud tier — synced to Mnemonik infra. Click to manage."
+          : "Local tier — stored only in this browser. Click to manage."
+      }
+      aria-label={`Storage tier: ${LABEL[tier]}`}
+      className={`text-[10px] uppercase tracking-wide font-mono px-2 py-1 rounded-full border transition-colors hover:brightness-125 ${classes}`}
+    >
+      {LABEL[tier]}
+    </button>
+  );
+}

--- a/packages/extension/src/popup/components/Toast.tsx
+++ b/packages/extension/src/popup/components/Toast.tsx
@@ -1,8 +1,10 @@
 // Tiny toast component for transient success / error feedback. Pure
-// presentational — the parent owns `show` state and timing so unit
-// tests can drive the visible state directly without fake timers.
+// presentational by default — the parent owns `show` state. When
+// `onDismiss` is supplied the toast self-clears after 4 seconds and
+// listens for the Escape key as a keyboard-driven close path
+// (round-2 UX-major #3).
 
-import type { JSX } from "react";
+import { useCallback, useEffect, type JSX } from "react";
 
 export type ToastKind = "success" | "error" | "info";
 
@@ -13,6 +15,18 @@ export interface ToastProps {
    *  the right of the message. The popup uses this for the `attestation_id`
    *  echo after a successful Sign. */
   copyValue?: string;
+  /**
+   * Called when the user dismisses the toast (Escape key or close
+   * button) or when the auto-clear timer fires (default 4 seconds).
+   * When omitted the toast stays put — useful for test fixtures that
+   * drive visibility directly.
+   */
+  onDismiss?: () => void;
+  /**
+   * Auto-clear delay in milliseconds. Defaults to 4000. Set to 0 to
+   * disable auto-clear (the Escape key + close button still work).
+   */
+  autoClearMs?: number;
 }
 
 const STYLES: Record<ToastKind, string> = {
@@ -22,7 +36,29 @@ const STYLES: Record<ToastKind, string> = {
 };
 
 export function Toast(props: ToastProps): JSX.Element {
-  const { message, kind = "info", copyValue } = props;
+  const { message, kind = "info", copyValue, onDismiss, autoClearMs } = props;
+
+  const handleKeyDown = useCallback(
+    (e: globalThis.KeyboardEvent): void => {
+      if (e.key === "Escape" && onDismiss) {
+        e.preventDefault();
+        onDismiss();
+      }
+    },
+    [onDismiss]
+  );
+
+  useEffect(() => {
+    if (!onDismiss) return;
+    document.addEventListener("keydown", handleKeyDown);
+    const delay = autoClearMs ?? 4000;
+    const timer = delay > 0 ? window.setTimeout(onDismiss, delay) : null;
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, [onDismiss, autoClearMs, handleKeyDown]);
+
   return (
     <div
       role="status"
@@ -30,20 +66,32 @@ export function Toast(props: ToastProps): JSX.Element {
       className={`flex items-center justify-between gap-2 text-xs px-3 py-2 rounded border ${STYLES[kind]}`}
     >
       <span className="font-mono break-all">{message}</span>
-      {copyValue ? (
-        <button
-          type="button"
-          onClick={() => {
-            // navigator.clipboard is allow-listed by the
-            // `clipboardWrite` manifest permission.
-            void navigator.clipboard?.writeText(copyValue);
-          }}
-          aria-label="Copy"
-          className="text-[10px] uppercase tracking-wide font-mono px-2 py-0.5 rounded border border-current opacity-80 hover:opacity-100"
-        >
-          copy
-        </button>
-      ) : null}
+      <div className="flex items-center gap-1">
+        {copyValue ? (
+          <button
+            type="button"
+            onClick={() => {
+              // navigator.clipboard is allow-listed by the
+              // `clipboardWrite` manifest permission.
+              void navigator.clipboard?.writeText(copyValue);
+            }}
+            aria-label="Copy"
+            className="text-[10px] uppercase tracking-wide font-mono px-2 py-0.5 rounded border border-current opacity-80 hover:opacity-100"
+          >
+            copy
+          </button>
+        ) : null}
+        {onDismiss ? (
+          <button
+            type="button"
+            onClick={onDismiss}
+            aria-label="Dismiss"
+            className="text-[10px] uppercase tracking-wide font-mono px-2 py-0.5 rounded border border-current opacity-80 hover:opacity-100"
+          >
+            ×
+          </button>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/packages/extension/src/popup/components/Toast.tsx
+++ b/packages/extension/src/popup/components/Toast.tsx
@@ -1,0 +1,49 @@
+// Tiny toast component for transient success / error feedback. Pure
+// presentational — the parent owns `show` state and timing so unit
+// tests can drive the visible state directly without fake timers.
+
+import type { JSX } from "react";
+
+export type ToastKind = "success" | "error" | "info";
+
+export interface ToastProps {
+  message: string;
+  kind?: ToastKind;
+  /** Optional copy-target — when set, renders a small "Copy" button to
+   *  the right of the message. The popup uses this for the `attestation_id`
+   *  echo after a successful Sign. */
+  copyValue?: string;
+}
+
+const STYLES: Record<ToastKind, string> = {
+  success: "bg-success/20 text-success border-success/40",
+  error: "bg-error/20 text-error border-error/40",
+  info: "bg-white/10 text-text-muted border-white/20",
+};
+
+export function Toast(props: ToastProps): JSX.Element {
+  const { message, kind = "info", copyValue } = props;
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`flex items-center justify-between gap-2 text-xs px-3 py-2 rounded border ${STYLES[kind]}`}
+    >
+      <span className="font-mono break-all">{message}</span>
+      {copyValue ? (
+        <button
+          type="button"
+          onClick={() => {
+            // navigator.clipboard is allow-listed by the
+            // `clipboardWrite` manifest permission.
+            void navigator.clipboard?.writeText(copyValue);
+          }}
+          aria-label="Copy"
+          className="text-[10px] uppercase tracking-wide font-mono px-2 py-0.5 rounded border border-current opacity-80 hover:opacity-100"
+        >
+          copy
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/extension/src/popup/embedder-bridge.ts
+++ b/packages/extension/src/popup/embedder-bridge.ts
@@ -1,0 +1,45 @@
+// Thin wrapper around the T04 transformers.js Web Worker. Kept in the
+// popup folder (not `runtime/`) because the popup is the only consumer
+// today and we want this entire module — plus the worker bootstrap —
+// to land behind a dynamic import so the popup's first-paint bundle
+// stays under the 50KB size-limit budget.
+
+import type { Embedder } from "../runtime/embed/types.js";
+
+let cachedEmbedder: Embedder | null = null;
+let cachedPromise: Promise<Embedder> | null = null;
+
+/**
+ * Resolve the singleton embedder. Constructed lazily on first call
+ * (popup cold-open never triggers this). Subsequent calls return the
+ * same instance — the underlying Web Worker is heavyweight (~25MB
+ * model download) and recreating it would burn the model cache.
+ */
+async function getEmbedder(): Promise<Embedder> {
+  if (cachedEmbedder) return cachedEmbedder;
+  if (cachedPromise) return cachedPromise;
+  cachedPromise = (async () => {
+    const { TransformersEmbedder } = await import(
+      "../runtime/embed/transformers-embedder.js"
+    );
+    const e = new TransformersEmbedder();
+    cachedEmbedder = e;
+    return e;
+  })();
+  return cachedPromise;
+}
+
+/** Embed `text` to a length-`dim` Float32Array. Forwards to the worker
+ *  embedder; popup callers await this from inside the Recall / Capture
+ *  flows. */
+export async function embedText(text: string): Promise<Float32Array> {
+  const e = await getEmbedder();
+  return e.embed(text);
+}
+
+/** @internal — test seam. Tests inject a deterministic embedder so the
+ *  popup's recall path can run without spinning up the real worker. */
+export function __setEmbedderForTesting(e: Embedder | null): void {
+  cachedEmbedder = e;
+  cachedPromise = e ? Promise.resolve(e) : null;
+}

--- a/packages/extension/src/popup/main.tsx
+++ b/packages/extension/src/popup/main.tsx
@@ -1,11 +1,12 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { Popup } from "./Popup";
+import { App } from "./App.js";
+import "./styles.css";
 
 const container = document.getElementById("root");
 if (!container) throw new Error("popup root element missing");
 createRoot(container).render(
   <StrictMode>
-    <Popup />
-  </StrictMode>,
+    <App />
+  </StrictMode>
 );

--- a/packages/extension/src/popup/runtime-impl.ts
+++ b/packages/extension/src/popup/runtime-impl.ts
@@ -1,0 +1,194 @@
+// Heavy-path runtime. Pulled in via dynamic import from `runtime.ts`
+// so the popup's first-paint bundle does not include the WASM glue,
+// the IndexedDB store, or the embedder worker. Each tab pays the cost
+// for the action it triggers (sign / recall / verify) and nothing more.
+
+import { IndexedDbStore } from "../runtime/store/indexeddb.js";
+import type { AttestationRow, SearchResult } from "../runtime/store/types.js";
+import type {
+  SignMemoryArgs,
+  SignMemoryResult,
+  VerifyArgs,
+  VerifyOutcome,
+} from "./runtime.js";
+
+let store: IndexedDbStore | null = null;
+
+function getStore(): IndexedDbStore {
+  if (!store) {
+    store = new IndexedDbStore();
+  }
+  return store;
+}
+
+/**
+ * Subset of the popup runtime that lives behind the dynamic-import
+ * boundary. Only the three heavyweight methods are exposed here; the
+ * lightweight readers (identity / storage tier / active tab) are
+ * handled directly in `runtime.ts` to avoid pulling WASM into the
+ * popup's first-paint bundle.
+ */
+export interface RuntimePipeline {
+  signMemory(args: SignMemoryArgs): Promise<SignMemoryResult>;
+  recall(query: string, limit: number): Promise<SearchResult[]>;
+  verify(args: VerifyArgs): Promise<VerifyOutcome>;
+}
+
+let pipeline: RuntimePipeline | null = null;
+
+export function getRuntimePipeline(): RuntimePipeline {
+  if (!pipeline) {
+    pipeline = createPipeline();
+  }
+  return pipeline;
+}
+
+function createPipeline(): RuntimePipeline {
+  return {
+    async signMemory(args: SignMemoryArgs): Promise<SignMemoryResult> {
+      const { content, tags, source } = args;
+      if (!content || content.trim() === "") {
+        throw new Error("signMemory: content must not be empty");
+      }
+      const identity = await loadIdentity();
+      if (!identity) {
+        throw new Error("signMemory: identity not configured");
+      }
+
+      // Lazy: WASM + embedder. The embedder cold-start can take ~3s the
+      // first time it downloads the model; the popup shows a spinner.
+      const [{ embedText }, cose] = await Promise.all([
+        import("./embedder-bridge.js"),
+        import("../runtime/sign/cose.js"),
+      ]);
+      const embedding = await embedText(content);
+
+      // Mirror the server's MEMORY_V1 artifact shape (canonical CBOR
+      // order is field-defined; we hand the object as-is to the WASM
+      // canonicaliser which knows the field ordering).
+      const compressed = await cose.compressEmbedding(embedding, 4);
+      const created_at = new Date().toISOString();
+      const artifact = {
+        v: 1,
+        content,
+        tags,
+        embedding_compressed: compressed,
+        signer_pubkey: identity.pubkey_base58,
+        owner_pubkey: identity.pubkey_base58,
+        created_at,
+      };
+      const cbor = await cose.toCanonicalCbor(artifact);
+      const content_hash = await cose.blake3HashHex(cbor);
+      const cose_bytes = await cose.signCosePayload(cbor, {
+        secret: identity.secret,
+        pubkey_base58: identity.pubkey_base58,
+      });
+      const truncated = content_hash.slice(0, 16);
+      const tx = `local:${truncated}`;
+      const attestation_id = `att_${truncated}`;
+      const row: AttestationRow = {
+        attestation_id,
+        content,
+        content_hash,
+        tags,
+        embedding,
+        cose_bytes,
+        created_at,
+        signer_pubkey: identity.pubkey_base58,
+        owner_pubkey: identity.pubkey_base58,
+        solana_tx: tx,
+        arweave_tx: tx,
+        ...(source ? { source_meta: source } : {}),
+      };
+      await getStore().saveAttestation(row);
+      return {
+        attestation_id,
+        content_hash,
+        signer_pubkey: identity.pubkey_base58,
+        solana_tx: tx,
+        arweave_tx: tx,
+        created_at,
+      };
+    },
+
+    async recall(query: string, limit: number): Promise<SearchResult[]> {
+      const trimmed = query.trim();
+      if (trimmed === "" || limit <= 0) return [];
+      const identity = await loadIdentity();
+      if (!identity) return [];
+      const { embedText } = await import("./embedder-bridge.js");
+      const vector = await embedText(trimmed);
+      return getStore().search(vector, identity.pubkey_base58, limit);
+    },
+
+    async verify(args: VerifyArgs): Promise<VerifyOutcome> {
+      if (args.attestationId) {
+        const id = args.attestationId.trim();
+        if (!id) {
+          return { status: "not_found" };
+        }
+        // The store keys attestations by `attestation_id`; today we only
+        // expose `findByTx`, so for `att_<hash>` we synthesise the
+        // matching `local:<hash>` tx-id and look up via that. T18 will
+        // add a direct `findById` helper for cloud rows.
+        const txCandidate = `local:${id.replace(/^att_/, "")}`;
+        const row = await getStore().findByTx(txCandidate);
+        if (!row) {
+          return { status: "not_found", attestation_id: id };
+        }
+        return verifyRow(row);
+      }
+      if (args.fileBytes && args.fileBytes.length > 0) {
+        // Phase 1 popup: we don't yet ship full COSE verification in
+        // the popup bundle. Surface a meaningful "not_found" so the UI
+        // can prompt the user for an `attestation_id` instead. T18 will
+        // replace this with a real `verify_artifact` WASM call.
+        return {
+          status: "not_found",
+        };
+      }
+      return { status: "not_found" };
+    },
+  };
+}
+
+function verifyRow(row: AttestationRow): VerifyOutcome {
+  // The COSE envelope is already stored — its presence is sufficient
+  // evidence at this layer (the canonical proof check happens server-
+  // side or via the dedicated `verify_artifact` WASM in the recall
+  // overlay). Tampered detection lives on the dedicated path; in the
+  // popup we conservatively report "verified" when the row round-trips
+  // and "tampered" only when the COSE bytes are missing/empty.
+  if (!row.cose_bytes || row.cose_bytes.length === 0) {
+    return { status: "tampered", reason: "missing COSE envelope" };
+  }
+  const result: VerifyOutcome = {
+    status: "verified",
+    signer_pubkey: row.signer_pubkey,
+    created_at: row.created_at,
+    content_hash: row.content_hash,
+    ...(row.source_meta ? { source: row.source_meta } : {}),
+    ...(row.solana_tx ? { solana_tx: row.solana_tx } : {}),
+    ...(row.arweave_tx ? { arweave_tx: row.arweave_tx } : {}),
+  };
+  return result;
+}
+
+interface FullIdentity {
+  pubkey_base58: string;
+  secret: number[];
+}
+
+async function loadIdentity(): Promise<FullIdentity | null> {
+  const stored = (await chrome.storage.local.get([
+    "identity",
+    "identity_secret",
+  ])) as {
+    identity?: { pubkey_base58?: string } | null;
+    identity_secret?: number[] | null;
+  };
+  const pub = stored.identity?.pubkey_base58;
+  const sec = stored.identity_secret;
+  if (!pub || !Array.isArray(sec)) return null;
+  return { pubkey_base58: pub, secret: sec };
+}

--- a/packages/extension/src/popup/runtime-impl.ts
+++ b/packages/extension/src/popup/runtime-impl.ts
@@ -12,6 +12,14 @@ import type {
   VerifyOutcome,
 } from "./runtime.js";
 
+/**
+ * Popup-realm `IndexedDbStore` singleton. MV3 popups live in their own
+ * document and reload on each open, so a module-level singleton here is
+ * effectively a per-open cache. The service worker (background) does
+ * NOT share this realm — if a background recall path is ever added,
+ * it must build its own `IndexedDbStore` instance via the `runtime/
+ * store/indexeddb.ts` constructor rather than importing this module.
+ */
 let store: IndexedDbStore | null = null;
 
 function getStore(): IndexedDbStore {
@@ -139,13 +147,14 @@ function createPipeline(): RuntimePipeline {
         return verifyRow(row);
       }
       if (args.fileBytes && args.fileBytes.length > 0) {
-        // Phase 1 popup: we don't yet ship full COSE verification in
-        // the popup bundle. Surface a meaningful "not_found" so the UI
-        // can prompt the user for an `attestation_id` instead. T18 will
-        // replace this with a real `verify_artifact` WASM call.
-        return {
-          status: "not_found",
-        };
+        // Phase 1 popup: file-drop verification is not yet implemented.
+        // The WASM `verify_artifact` export is a pending T05 follow-up;
+        // until then we surface the not-yet-supported state explicitly
+        // so the UI can render a clear placeholder ("paste an
+        // attestation id — file-drop coming soon") instead of the
+        // misleading generic "not found" outcome the round-1 review
+        // flagged.
+        return { status: "not_found", reason: "file_drop_unsupported" };
       }
       return { status: "not_found" };
     },
@@ -153,17 +162,20 @@ function createPipeline(): RuntimePipeline {
 }
 
 function verifyRow(row: AttestationRow): VerifyOutcome {
-  // The COSE envelope is already stored — its presence is sufficient
-  // evidence at this layer (the canonical proof check happens server-
-  // side or via the dedicated `verify_artifact` WASM in the recall
-  // overlay). Tampered detection lives on the dedicated path; in the
-  // popup we conservatively report "verified" when the row round-trips
-  // and "tampered" only when the COSE bytes are missing/empty.
+  // Round-2 fix (MAJ-2): the popup does NOT yet perform cryptographic
+  // signature verification — the WASM `verify_artifact` export is a
+  // pending T05 follow-up. Until it lands we run a presence check
+  // (row exists + COSE envelope is non-empty) and mark the result
+  // `presence_only: true`. The UI renders a "STORED LOCALLY —
+  // cryptographic verification coming soon" caveat instead of a plain
+  // green "VERIFIED" banner so the user is not misled. Missing COSE
+  // bytes still trip the tampered path.
   if (!row.cose_bytes || row.cose_bytes.length === 0) {
     return { status: "tampered", reason: "missing COSE envelope" };
   }
   const result: VerifyOutcome = {
     status: "verified",
+    presence_only: true,
     signer_pubkey: row.signer_pubkey,
     created_at: row.created_at,
     content_hash: row.content_hash,
@@ -180,15 +192,26 @@ interface FullIdentity {
 }
 
 async function loadIdentity(): Promise<FullIdentity | null> {
-  const stored = (await chrome.storage.local.get([
-    "identity",
-    "identity_secret",
-  ])) as {
+  // Goes through the same defensive read pattern as `runtime.ts`'s
+  // `readChromeStorage` (try/catch around `chrome.storage.local.get` so
+  // the popup never crashes on storage permission errors). Also guards
+  // against a truncated `identity_secret` write — Solana keypairs are
+  // 64 bytes (32-byte seed || 32-byte pubkey); anything else is bogus
+  // and would produce malformed signatures if we let it through.
+  let stored: {
     identity?: { pubkey_base58?: string } | null;
     identity_secret?: number[] | null;
-  };
+  } = {};
+  try {
+    stored = (await chrome.storage.local.get([
+      "identity",
+      "identity_secret",
+    ])) as typeof stored;
+  } catch {
+    return null;
+  }
   const pub = stored.identity?.pubkey_base58;
   const sec = stored.identity_secret;
-  if (!pub || !Array.isArray(sec)) return null;
+  if (!pub || !Array.isArray(sec) || sec.length !== 64) return null;
   return { pubkey_base58: pub, secret: sec };
 }

--- a/packages/extension/src/popup/runtime.ts
+++ b/packages/extension/src/popup/runtime.ts
@@ -47,9 +47,31 @@ export type VerifyOutcome =
       source?: SourceMeta;
       solana_tx?: string;
       arweave_tx?: string;
+      /**
+       * `true` when the popup only confirmed that the local row exists
+       * + has a non-empty COSE envelope (presence check), without
+       * running the cryptographic signature verification. The WASM
+       * `verify_artifact` export is pending (T05 follow-up); until it
+       * lands, the UI renders a "STORED LOCALLY — cryptographic
+       * verification coming soon" caveat instead of a plain green
+       * "VERIFIED" banner. Cloud-path verification (T18) will return
+       * this field `false` once full cryptographic verify is wired.
+       */
+      presence_only?: boolean;
     }
   | { status: "tampered"; reason: string }
-  | { status: "not_found"; attestation_id?: string };
+  | {
+      status: "not_found";
+      attestation_id?: string;
+      /**
+       * Set when the popup received `fileBytes` instead of an
+       * attestation id. File-drop verification is not yet implemented
+       * (T05 follow-up). The UI renders a clear placeholder message
+       * rather than the generic "not found" state to avoid misleading
+       * the user.
+       */
+      reason?: "file_drop_unsupported";
+    };
 
 export interface VerifyArgs {
   /** Either an `attestation_id` string OR raw COSE_Sign1 bytes from a

--- a/packages/extension/src/popup/runtime.ts
+++ b/packages/extension/src/popup/runtime.ts
@@ -1,0 +1,209 @@
+// Popup-facing runtime facade. Glues the chat-adapter registry (T06),
+// the IndexedDB store (T03), the WASM signing pipeline (T05), and the
+// embedder worker (T04) into the three actions the popup needs:
+// `signMemory`, `recall`, `verify`. Concrete implementations are wired
+// here; tests replace the exported `setRuntime` function to inject
+// mocks (the popup never imports the implementation directly).
+//
+// `signRemote` is a no-op stub on Local tier. T18 will replace it with
+// the deferred-signing cloud-client; until then Cloud-tier writes fall
+// back to Local + the pending_uploads queue.
+
+import type { ChatTurn, ChatAdapter } from "../runtime/chat/types.js";
+import type { SearchResult, SourceMeta } from "../runtime/store/types.js";
+
+/** Identity loaded out of `chrome.storage.local`. `null` when the user
+ *  has not completed T16 onboarding yet (popup renders a "not signed
+ *  in" badge in that case). */
+export interface PopupIdentity {
+  pubkey_base58: string;
+  /** Optional human-readable label (T16 sets this from Google sign-in). */
+  label?: string;
+}
+
+export type StorageTier = "local" | "cloud";
+
+export interface SignMemoryArgs {
+  content: string;
+  tags: string[];
+  source?: SourceMeta;
+}
+
+export interface SignMemoryResult {
+  attestation_id: string;
+  content_hash: string;
+  signer_pubkey: string;
+  solana_tx: string;
+  arweave_tx: string;
+  created_at: string;
+}
+
+export type VerifyOutcome =
+  | {
+      status: "verified";
+      signer_pubkey: string;
+      created_at: string;
+      content_hash: string;
+      source?: SourceMeta;
+      solana_tx?: string;
+      arweave_tx?: string;
+    }
+  | { status: "tampered"; reason: string }
+  | { status: "not_found"; attestation_id?: string };
+
+export interface VerifyArgs {
+  /** Either an `attestation_id` string OR raw COSE_Sign1 bytes from a
+   *  dropped file. The popup hands one or the other; the runtime decides
+   *  which path to take. */
+  attestationId?: string;
+  fileBytes?: Uint8Array;
+}
+
+/** Abstract runtime contract the popup consumes. Real impl lives at the
+ *  bottom of this file; tests inject a stub via `setRuntime`. */
+export interface PopupRuntime {
+  loadIdentity(): Promise<PopupIdentity | null>;
+  loadStorageTier(): Promise<StorageTier>;
+  /** Read the active tab URL and match against the adapter registry.
+   *  Returns `null` when not on a supported chat page or the URL cannot
+   *  be matched (the popup falls back to selection-only capture). */
+  getActiveTabAdapter(): Promise<ChatAdapter | null>;
+  /** Ask the active tab's content script for any current selection.
+   *  Resolves to "" when nothing is selected or the active tab does not
+   *  host a Mnemonik content script. Never throws — failures surface as
+   *  empty strings so the popup textarea stays empty. */
+  getActiveTabSelection(): Promise<string>;
+  /** Ask the active tab's adapter to extract the current conversation.
+   *  Returns `null` when no adapter matches the active tab. */
+  getActiveTabConversation(): Promise<ChatTurn[] | null>;
+  signMemory(args: SignMemoryArgs): Promise<SignMemoryResult>;
+  /** T18 placeholder. On Local tier this is a no-op; on Cloud tier it
+   *  would push the attestation to the hosted MCP server. */
+  signRemote(args: SignMemoryArgs & SignMemoryResult): Promise<void>;
+  recall(query: string, limit: number): Promise<SearchResult[]>;
+  verify(args: VerifyArgs): Promise<VerifyOutcome>;
+}
+
+let current: PopupRuntime | null = null;
+
+/** Test-only entry point — production code never calls this. */
+export function setRuntime(runtime: PopupRuntime | null): void {
+  current = runtime;
+}
+
+/** Lazy accessor. Tests call `setRuntime` first; production callers
+ *  fall through to {@link createDefaultRuntime}. */
+export function getRuntime(): PopupRuntime {
+  if (!current) {
+    current = createDefaultRuntime();
+  }
+  return current;
+}
+
+// ── Default implementation ──────────────────────────────────────────────────
+
+/**
+ * Build the production runtime. Heavy paths (embedder worker, WASM
+ * crypto) are imported lazily so the popup's initial JS stays under the
+ * 50KB size-limit budget — Recall is the only tab that triggers the
+ * embedder cold-start. The factory is exported so a future test that
+ * wants the real pipeline (e.g. a fixture-only round-trip) can call it
+ * directly without going through `getRuntime`.
+ */
+export function createDefaultRuntime(): PopupRuntime {
+  return {
+    async loadIdentity() {
+      const stored = await readChromeStorage<{
+        identity?: PopupIdentity | null;
+      }>("local", ["identity"]);
+      return stored.identity ?? null;
+    },
+    async loadStorageTier() {
+      const stored = await readChromeStorage<{
+        storage_tier?: StorageTier;
+      }>("local", ["storage_tier"]);
+      return stored.storage_tier ?? "local";
+    },
+    async getActiveTabAdapter() {
+      const url = await activeTabUrl();
+      if (!url) return null;
+      const { selectAdapter } = await import("../runtime/chat/registry.js");
+      // Side-effect import wires concrete adapters into the registry.
+      await import("../runtime/chat/adapters/index.js");
+      return selectAdapter(url);
+    },
+    async getActiveTabSelection() {
+      const tabId = await activeTabId();
+      if (typeof tabId !== "number") return "";
+      try {
+        const response = (await chrome.tabs.sendMessage(tabId, {
+          type: "ui:get-selection",
+        })) as { selectionText?: string } | undefined;
+        return response?.selectionText ?? "";
+      } catch {
+        return "";
+      }
+    },
+    async getActiveTabConversation() {
+      const tabId = await activeTabId();
+      if (typeof tabId !== "number") return null;
+      try {
+        const response = (await chrome.tabs.sendMessage(tabId, {
+          type: "ui:extract-conversation",
+        })) as { turns?: ChatTurn[] } | undefined;
+        return response?.turns ?? null;
+      } catch {
+        return null;
+      }
+    },
+    async signMemory(args) {
+      const { getRuntimePipeline } = await import("./runtime-impl.js");
+      return getRuntimePipeline().signMemory(args);
+    },
+    async signRemote() {
+      // T18 wires the cloud client. Local-tier and pre-T18 builds are
+      // both fine to no-op here.
+      return;
+    },
+    async recall(query, limit) {
+      const { getRuntimePipeline } = await import("./runtime-impl.js");
+      return getRuntimePipeline().recall(query, limit);
+    },
+    async verify(args) {
+      const { getRuntimePipeline } = await import("./runtime-impl.js");
+      return getRuntimePipeline().verify(args);
+    },
+  };
+}
+
+// ── chrome.* helpers (test-friendly) ────────────────────────────────────────
+
+async function activeTabUrl(): Promise<string | null> {
+  const tabs = await chrome.tabs.query({
+    active: true,
+    currentWindow: true,
+  });
+  return tabs[0]?.url ?? null;
+}
+
+async function activeTabId(): Promise<number | null> {
+  const tabs = await chrome.tabs.query({
+    active: true,
+    currentWindow: true,
+  });
+  return tabs[0]?.id ?? null;
+}
+
+async function readChromeStorage<T>(
+  area: "local" | "sync",
+  keys: string[]
+): Promise<Partial<T>> {
+  try {
+    const result = (await chrome.storage[area].get(
+      keys as unknown as string
+    )) as unknown as Partial<T>;
+    return result;
+  } catch {
+    return {};
+  }
+}

--- a/packages/extension/src/popup/styles.css
+++ b/packages/extension/src/popup/styles.css
@@ -1,0 +1,31 @@
+/* Tailwind entrypoint for the popup. The popup pulls only the utilities
+ * the components actually use — content globs in `tailwind.config.js`
+ * limit the JIT scan to `src/popup/**` + `src/options/**`. The dark
+ * theme is the only theme; the popup intentionally has no light-mode
+ * variant per `work/chrome-extension/decisions.md` D8 (privacy-first,
+ * minimal surface). */
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+/* Popup viewport. Chrome MV3 caps action popups at 800x600; we render
+ * at 360x520 by default and let `min-h-fit` grow content vertically.
+ * Set on the root <html> so the OS toolbar paints behind the dark BG
+ * before React mounts (no white flash on slow cold-opens). */
+html,
+body {
+  background-color: #0a0f1e;
+  color: #ffffff;
+  margin: 0;
+  padding: 0;
+  font-family:
+    ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+
+body {
+  width: 360px;
+  min-height: 480px;
+}

--- a/packages/extension/src/popup/tabs/Capture.tsx
+++ b/packages/extension/src/popup/tabs/Capture.tsx
@@ -116,13 +116,13 @@ export function Capture(props: CaptureProps): JSX.Element {
         </div>
       )}
 
-      <label className="flex flex-col gap-1 text-xs">
+      <label className="flex flex-col gap-1 text-xs" htmlFor="capture-content">
         <span className="text-text-muted">Selection / content</span>
         <textarea
+          id="capture-content"
           value={selection}
           onChange={(e) => setSelection(e.target.value)}
           rows={6}
-          aria-label="Capture content"
           className="bg-black/40 border border-white/10 rounded p-2 text-xs font-mono focus:outline-none focus:border-accent-primary resize-none"
           placeholder="Paste or capture the snippet to sign…"
         />
@@ -169,9 +169,12 @@ export function Capture(props: CaptureProps): JSX.Element {
           kind="success"
           message={`Signed → ${truncate(result.attestation_id, 18)}`}
           copyValue={result.attestation_id}
+          onDismiss={() => setResult(null)}
         />
       ) : null}
-      {error ? <Toast kind="error" message={error} /> : null}
+      {error ? (
+        <Toast kind="error" message={error} onDismiss={() => setError(null)} />
+      ) : null}
     </div>
   );
 }

--- a/packages/extension/src/popup/tabs/Capture.tsx
+++ b/packages/extension/src/popup/tabs/Capture.tsx
@@ -1,0 +1,196 @@
+// Capture tab — "Save chat" / "Save selection". Both flows funnel into
+// the same `runtime.signMemory` call; the difference is just the
+// content source (full conversation transcript vs. textarea selection).
+//
+// Per D8 + D11 the popup never assumes `<all_urls>`. Selection capture
+// only works when the active tab matches an adapter (host_permission)
+// or when the user has already triggered an `activeTab` gesture — the
+// content script delivers the selection text via `chrome.runtime.send-
+// Message`, this tab just reads what arrived.
+
+import { useEffect, useState, type JSX } from "react";
+import type { ChatAdapter } from "../../runtime/chat/types.js";
+import { getRuntime, type SignMemoryResult } from "../runtime.js";
+import { Toast } from "../components/Toast.js";
+
+export interface CaptureProps {
+  adapter: ChatAdapter | null;
+  prefilledSelection: string;
+}
+
+export function Capture(props: CaptureProps): JSX.Element {
+  const { adapter, prefilledSelection } = props;
+  const [selection, setSelection] = useState(prefilledSelection);
+  const [tagsRaw, setTagsRaw] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [result, setResult] = useState<SignMemoryResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  // Pick up newly-arrived selection from the content script. Updating
+  // local state only when the incoming value is non-empty avoids
+  // clobbering edits the user already made.
+  useEffect(() => {
+    if (prefilledSelection && selection === "") {
+      setSelection(prefilledSelection);
+    }
+    // selection intentionally excluded — we only want to seed on
+    // prefilled-change, not echo back into ourselves.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [prefilledSelection]);
+
+  const handleSaveSelection = async (): Promise<void> => {
+    setError(null);
+    setResult(null);
+    const trimmed = selection.trim();
+    if (trimmed === "") {
+      setError("Add something to capture first.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const tags = parseTags(tagsRaw, adapter);
+      const runtime = getRuntime();
+      const res = await runtime.signMemory({
+        content: trimmed,
+        tags,
+        ...(adapter
+          ? {
+              source: {
+                platform: adapter.platform,
+              },
+            }
+          : {}),
+      });
+      await runtime.signRemote({ content: trimmed, tags, ...res });
+      setResult(res);
+    } catch (e) {
+      setError(formatError(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleSaveChat = async (): Promise<void> => {
+    if (!adapter) return;
+    setError(null);
+    setResult(null);
+    setBusy(true);
+    try {
+      const runtime = getRuntime();
+      const turns = await runtime.getActiveTabConversation();
+      if (!turns || turns.length === 0) {
+        setError("Could not read this chat. Open the conversation tab first.");
+        setBusy(false);
+        return;
+      }
+      const transcript = turns
+        .map((t) => `### ${t.role}\n\n${t.content}`)
+        .join("\n\n");
+      const tags = parseTags(tagsRaw, adapter);
+      const res = await runtime.signMemory({
+        content: transcript,
+        tags,
+        source: { platform: adapter.platform },
+      });
+      await runtime.signRemote({ content: transcript, tags, ...res });
+      setResult(res);
+    } catch (e) {
+      setError(formatError(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      {adapter ? (
+        <div className="flex items-center gap-2 text-[10px] uppercase tracking-wide text-text-muted">
+          <span>Detected platform:</span>
+          <span className="text-accent-primary font-mono">
+            {adapter.platform}
+          </span>
+        </div>
+      ) : (
+        <div className="text-[10px] uppercase tracking-wide text-text-muted">
+          Selection capture available via activeTab.
+        </div>
+      )}
+
+      <label className="flex flex-col gap-1 text-xs">
+        <span className="text-text-muted">Selection / content</span>
+        <textarea
+          value={selection}
+          onChange={(e) => setSelection(e.target.value)}
+          rows={6}
+          aria-label="Capture content"
+          className="bg-black/40 border border-white/10 rounded p-2 text-xs font-mono focus:outline-none focus:border-accent-primary resize-none"
+          placeholder="Paste or capture the snippet to sign…"
+        />
+      </label>
+
+      <label className="flex flex-col gap-1 text-xs">
+        <span className="text-text-muted">Tags (comma-separated)</span>
+        <input
+          value={tagsRaw}
+          onChange={(e) => setTagsRaw(e.target.value)}
+          type="text"
+          aria-label="Tags"
+          className="bg-black/40 border border-white/10 rounded p-2 text-xs font-mono focus:outline-none focus:border-accent-primary"
+          placeholder="research, q4-2026"
+        />
+      </label>
+
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleSaveSelection}
+          disabled={busy}
+          className="flex-1 bg-accent-primary/20 hover:bg-accent-primary/30 disabled:opacity-50 text-accent-primary border border-accent-primary/50 text-xs font-mono uppercase tracking-wide py-2 rounded transition-colors"
+        >
+          {busy ? "Signing…" : "Sign"}
+        </button>
+        <button
+          type="button"
+          onClick={handleSaveChat}
+          disabled={busy || !adapter}
+          title={
+            adapter
+              ? "Capture the full conversation on the active tab"
+              : "Open a supported AI-chat page first"
+          }
+          className="flex-1 bg-white/5 hover:bg-white/10 disabled:opacity-30 text-text-primary border border-white/10 text-xs font-mono uppercase tracking-wide py-2 rounded transition-colors"
+        >
+          Save chat
+        </button>
+      </div>
+
+      {result ? (
+        <Toast
+          kind="success"
+          message={`Signed → ${truncate(result.attestation_id, 18)}`}
+          copyValue={result.attestation_id}
+        />
+      ) : null}
+      {error ? <Toast kind="error" message={error} /> : null}
+    </div>
+  );
+}
+
+function parseTags(raw: string, adapter: ChatAdapter | null): string[] {
+  const explicit = raw
+    .split(/[\s,]+/)
+    .map((t) => t.trim())
+    .filter(Boolean);
+  const auto: string[] = [];
+  if (adapter) auto.push(`source:${adapter.platform}`);
+  return Array.from(new Set([...auto, ...explicit]));
+}
+
+function truncate(value: string, max: number): string {
+  return value.length <= max ? value : `${value.slice(0, max - 1)}…`;
+}
+
+function formatError(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  return String(e);
+}

--- a/packages/extension/src/popup/tabs/Recall.tsx
+++ b/packages/extension/src/popup/tabs/Recall.tsx
@@ -1,8 +1,8 @@
 // Recall tab — query input + result list. Hits `runtime.recall` which
 // runs cosine search over the IndexedDB store under the current
 // identity. "Insert into chat" is disabled when the active-tab adapter
-// has no `findInputBox` (T11 TDD anchor #2). "Copy markdown" + "Open"
-// are always available.
+// reports `supportsInsert: false` (T11 TDD anchor #2). "Copy markdown"
+// + "Open" are always available.
 
 import { useState, type JSX } from "react";
 import type { ChatAdapter } from "../../runtime/chat/types.js";
@@ -18,28 +18,27 @@ export function Recall(props: RecallProps): JSX.Element {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState<SearchResult[]>([]);
   const [busy, setBusy] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Probe the adapter once per render. We cannot dereference
-  // `findInputBox(document)` here because the popup runs in its own
-  // document; instead we ask the adapter to *report* support purely by
-  // method identity. The convention adopted by all three Phase 1
-  // adapters (T07/T08/T09) is that adapters lacking insert support
-  // return `null` unconditionally — we surface that as a disabled
-  // button + tooltip per the TDD anchor.
-  const insertSupported = isInsertSupported(adapter);
+  // Adapters declare insert support via a `supportsInsert: boolean`
+  // flag (BLK-1 fix). Minifier-safe — no `Function.prototype.toString`
+  // introspection.
+  const insertSupported = Boolean(adapter?.supportsInsert);
 
   const handleSearch = async (): Promise<void> => {
     setError(null);
     const trimmed = query.trim();
     if (trimmed === "") {
       setResults([]);
+      setHasSearched(false);
       return;
     }
     setBusy(true);
     try {
       const hits = await getRuntime().recall(trimmed, 5);
       setResults(hits);
+      setHasSearched(true);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -54,8 +53,15 @@ export function Recall(props: RecallProps): JSX.Element {
         type: "ui:insert-into-chat",
         payload: { text },
       });
-    } catch {
-      // Surface to user later — non-blocking for popup state.
+    } catch (e) {
+      // Surface the failure — the button is enabled, so a silent
+      // no-op would be misleading. The toast lives in <Recall> via
+      // the inline error block above the results list.
+      setError(
+        e instanceof Error
+          ? `Insert failed — ${e.message}. Reload the chat tab and try again.`
+          : "Insert failed — reload the chat tab and try again."
+      );
     }
   };
 
@@ -83,9 +89,10 @@ export function Recall(props: RecallProps): JSX.Element {
         <button
           type="submit"
           disabled={busy}
+          aria-busy={busy}
           className="bg-accent-primary/20 hover:bg-accent-primary/30 disabled:opacity-50 text-accent-primary border border-accent-primary/50 text-xs font-mono uppercase tracking-wide px-3 py-1.5 rounded transition-colors"
         >
-          {busy ? "…" : "Find"}
+          {busy ? "Recalling" : "Find"}
         </button>
       </form>
 
@@ -94,9 +101,9 @@ export function Recall(props: RecallProps): JSX.Element {
       ) : null}
 
       <ul className="flex flex-col gap-2" aria-label="Recall results">
-        {results.length === 0 && !busy ? (
+        {hasSearched && results.length === 0 && !busy ? (
           <li className="text-[11px] text-text-muted italic">
-            No results yet — type a query and press Enter.
+            Recall returned no results for this query.
           </li>
         ) : null}
         {results.map((r) => (
@@ -109,7 +116,11 @@ export function Recall(props: RecallProps): JSX.Element {
                 {r.relevance_score.toFixed(3)}
               </span>
               <PlatformPill tags={r.tags} />
-              <span className="text-text-muted font-mono ml-auto">
+              <span
+                className="text-text-muted font-mono ml-auto"
+                title={r.attestation_id}
+                aria-label={`Attestation ID: ${r.attestation_id}`}
+              >
                 {truncateMiddle(r.attestation_id, 6, 4)}
               </span>
             </div>
@@ -181,49 +192,4 @@ function toMarkdown(r: SearchResult): string {
 function truncateMiddle(value: string, head: number, tail: number): string {
   if (value.length <= head + tail + 1) return value;
   return `${value.slice(0, head)}…${value.slice(-tail)}`;
-}
-
-/**
- * The popup runs in its own document, so we can't probe `findInputBox`
- * against the active tab's DOM here. We treat adapters that ship a
- * `findInputBox` implementation in the registry as "claiming support";
- * Phase 1 ChatGPT does, Claude / Gemini do not.
- *
- * Convention: adapters that don't support insert pin their `findInputBox`
- * to a constant `() => null` (T08 + T09 do this explicitly). We detect
- * the no-op by calling it against an empty in-popup `Document` — a
- * `null` return without an actual chat DOM is the only signal we have
- * from inside the popup process. The result is a faithful proxy for
- * "the adapter has implemented insert support" — a true-positive
- * adapter returns null here too, but the *button click* path runs in
- * the content-script context where the real DOM lookup succeeds, so
- * the disabled-state is purely an informational gating step.
- *
- * To avoid the false-negative an explicit metadata channel would be
- * better; adapters expose `findInputBox` as a method, and adapters that
- * have no plans to support insert (T08 Claude, T09 Gemini) make the
- * function reference equal to a shared sentinel. We compare against the
- * sentinel by name — adapters that DO support insert define
- * `findInputBox` with a non-empty function body whose `toString()`
- * length exceeds the sentinel's. This is a heuristic; the TDD anchor
- * (Recall.test.tsx::insert_into_chat_disabled_when_no_input_box) drives
- * the false-negative case for an adapter returning null.
- */
-function isInsertSupported(adapter: ChatAdapter | null): boolean {
-  if (!adapter) return false;
-  // Heuristic detection: adapters that explicitly disable insert ship a
-  // single-statement body that returns `null`. Adapters that implement
-  // it have a multi-statement body that performs DOM lookups. The
-  // popup probe is conservative — when in doubt, allow the action and
-  // let the content script no-op on its side.
-  try {
-    const src = adapter.findInputBox.toString();
-    if (/return\s+null\s*;?\s*\}\s*$/.test(src.trim())) {
-      return false;
-    }
-    if (src.length < 60) return false;
-    return true;
-  } catch {
-    return false;
-  }
 }

--- a/packages/extension/src/popup/tabs/Recall.tsx
+++ b/packages/extension/src/popup/tabs/Recall.tsx
@@ -1,0 +1,229 @@
+// Recall tab — query input + result list. Hits `runtime.recall` which
+// runs cosine search over the IndexedDB store under the current
+// identity. "Insert into chat" is disabled when the active-tab adapter
+// has no `findInputBox` (T11 TDD anchor #2). "Copy markdown" + "Open"
+// are always available.
+
+import { useState, type JSX } from "react";
+import type { ChatAdapter } from "../../runtime/chat/types.js";
+import { getRuntime } from "../runtime.js";
+import type { SearchResult } from "../../runtime/store/types.js";
+
+export interface RecallProps {
+  adapter: ChatAdapter | null;
+}
+
+export function Recall(props: RecallProps): JSX.Element {
+  const { adapter } = props;
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<SearchResult[]>([]);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Probe the adapter once per render. We cannot dereference
+  // `findInputBox(document)` here because the popup runs in its own
+  // document; instead we ask the adapter to *report* support purely by
+  // method identity. The convention adopted by all three Phase 1
+  // adapters (T07/T08/T09) is that adapters lacking insert support
+  // return `null` unconditionally — we surface that as a disabled
+  // button + tooltip per the TDD anchor.
+  const insertSupported = isInsertSupported(adapter);
+
+  const handleSearch = async (): Promise<void> => {
+    setError(null);
+    const trimmed = query.trim();
+    if (trimmed === "") {
+      setResults([]);
+      return;
+    }
+    setBusy(true);
+    try {
+      const hits = await getRuntime().recall(trimmed, 5);
+      setResults(hits);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleInsert = async (text: string): Promise<void> => {
+    if (!insertSupported) return;
+    try {
+      await chrome.runtime.sendMessage({
+        type: "ui:insert-into-chat",
+        payload: { text },
+      });
+    } catch {
+      // Surface to user later — non-blocking for popup state.
+    }
+  };
+
+  const handleCopy = async (md: string): Promise<void> => {
+    await navigator.clipboard?.writeText(md);
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          void handleSearch();
+        }}
+        className="flex items-center gap-2"
+      >
+        <input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          type="search"
+          aria-label="Recall query"
+          placeholder="What do you remember about…"
+          className="flex-1 bg-black/40 border border-white/10 rounded px-2 py-1.5 text-xs font-mono focus:outline-none focus:border-accent-primary"
+        />
+        <button
+          type="submit"
+          disabled={busy}
+          className="bg-accent-primary/20 hover:bg-accent-primary/30 disabled:opacity-50 text-accent-primary border border-accent-primary/50 text-xs font-mono uppercase tracking-wide px-3 py-1.5 rounded transition-colors"
+        >
+          {busy ? "…" : "Find"}
+        </button>
+      </form>
+
+      {error ? (
+        <div className="text-xs text-error font-mono">{error}</div>
+      ) : null}
+
+      <ul className="flex flex-col gap-2" aria-label="Recall results">
+        {results.length === 0 && !busy ? (
+          <li className="text-[11px] text-text-muted italic">
+            No results yet — type a query and press Enter.
+          </li>
+        ) : null}
+        {results.map((r) => (
+          <li
+            key={r.attestation_id}
+            className="border border-white/10 rounded p-2 flex flex-col gap-1.5"
+          >
+            <div className="flex items-center gap-2 text-[10px] uppercase tracking-wide">
+              <span className="text-accent-primary font-mono">
+                {r.relevance_score.toFixed(3)}
+              </span>
+              <PlatformPill tags={r.tags} />
+              <span className="text-text-muted font-mono ml-auto">
+                {truncateMiddle(r.attestation_id, 6, 4)}
+              </span>
+            </div>
+            <p className="text-xs text-text-primary line-clamp-3">
+              {r.content}
+            </p>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => void handleCopy(toMarkdown(r))}
+                className="text-[10px] uppercase tracking-wide font-mono text-text-muted hover:text-accent-primary border border-white/10 hover:border-accent-primary/50 rounded px-2 py-0.5 transition-colors"
+              >
+                Copy markdown
+              </button>
+              <button
+                type="button"
+                onClick={() => void handleInsert(r.content)}
+                disabled={!insertSupported}
+                title={
+                  insertSupported
+                    ? "Insert this memory at the chat input"
+                    : "This platform does not support insert-into-chat yet"
+                }
+                aria-label="Insert into chat"
+                className="text-[10px] uppercase tracking-wide font-mono text-text-muted hover:text-accent-primary border border-white/10 hover:border-accent-primary/50 disabled:opacity-40 disabled:hover:text-text-muted disabled:hover:border-white/10 rounded px-2 py-0.5 transition-colors"
+              >
+                Insert into chat
+              </button>
+              <a
+                href={`https://mnemonik.xyz/m/${encodeURIComponent(
+                  r.attestation_id
+                )}`}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="text-[10px] uppercase tracking-wide font-mono text-text-muted hover:text-accent-primary border border-white/10 hover:border-accent-primary/50 rounded px-2 py-0.5 transition-colors"
+              >
+                Open
+              </a>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function PlatformPill({
+  tags,
+}: {
+  tags: readonly string[];
+}): JSX.Element | null {
+  const source = tags.find((t) => t.startsWith("source:"));
+  if (!source) return null;
+  const platform = source.slice("source:".length);
+  return (
+    <span className="text-[10px] uppercase tracking-wide font-mono text-text-muted border border-white/10 rounded px-1.5 py-0">
+      {platform}
+    </span>
+  );
+}
+
+function toMarkdown(r: SearchResult): string {
+  const tagLine = r.tags.length ? `tags: [${r.tags.join(", ")}]\n` : "";
+  return `---\nattestation_id: ${r.attestation_id}\ncreated_at: ${
+    r.created_at
+  }\nscore: ${r.relevance_score.toFixed(4)}\n${tagLine}---\n\n${r.content}\n`;
+}
+
+function truncateMiddle(value: string, head: number, tail: number): string {
+  if (value.length <= head + tail + 1) return value;
+  return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}
+
+/**
+ * The popup runs in its own document, so we can't probe `findInputBox`
+ * against the active tab's DOM here. We treat adapters that ship a
+ * `findInputBox` implementation in the registry as "claiming support";
+ * Phase 1 ChatGPT does, Claude / Gemini do not.
+ *
+ * Convention: adapters that don't support insert pin their `findInputBox`
+ * to a constant `() => null` (T08 + T09 do this explicitly). We detect
+ * the no-op by calling it against an empty in-popup `Document` — a
+ * `null` return without an actual chat DOM is the only signal we have
+ * from inside the popup process. The result is a faithful proxy for
+ * "the adapter has implemented insert support" — a true-positive
+ * adapter returns null here too, but the *button click* path runs in
+ * the content-script context where the real DOM lookup succeeds, so
+ * the disabled-state is purely an informational gating step.
+ *
+ * To avoid the false-negative an explicit metadata channel would be
+ * better; adapters expose `findInputBox` as a method, and adapters that
+ * have no plans to support insert (T08 Claude, T09 Gemini) make the
+ * function reference equal to a shared sentinel. We compare against the
+ * sentinel by name — adapters that DO support insert define
+ * `findInputBox` with a non-empty function body whose `toString()`
+ * length exceeds the sentinel's. This is a heuristic; the TDD anchor
+ * (Recall.test.tsx::insert_into_chat_disabled_when_no_input_box) drives
+ * the false-negative case for an adapter returning null.
+ */
+function isInsertSupported(adapter: ChatAdapter | null): boolean {
+  if (!adapter) return false;
+  // Heuristic detection: adapters that explicitly disable insert ship a
+  // single-statement body that returns `null`. Adapters that implement
+  // it have a multi-statement body that performs DOM lookups. The
+  // popup probe is conservative — when in doubt, allow the action and
+  // let the content script no-op on its side.
+  try {
+    const src = adapter.findInputBox.toString();
+    if (/return\s+null\s*;?\s*\}\s*$/.test(src.trim())) {
+      return false;
+    }
+    if (src.length < 60) return false;
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/extension/src/popup/tabs/Verify.tsx
+++ b/packages/extension/src/popup/tabs/Verify.tsx
@@ -1,9 +1,22 @@
-// Verify tab — paste an `attestation_id` or drop a `.cose` file and
-// show the verification outcome. Three terminal states: verified,
-// tampered, not_found. Cloud-tier details (signer, tx ids) render when
-// the attestation row carries them.
+// Verify tab — paste an `attestation_id` or drop / pick a `.cose`
+// file and show the verification outcome. Three terminal states:
+// verified, tampered, not_found. Cloud-tier details (signer, tx ids)
+// render when the attestation row carries them.
+//
+// Round-2 review fixes:
+//   - MAJ-1: file-drop runs through the runtime which returns
+//     `not_found { reason: "file_drop_unsupported" }`; the UI renders
+//     a clear placeholder instead of the misleading generic "not
+//     found" state.
+//   - MAJ-2: the local presence check returns `verified` with
+//     `presence_only: true`; the UI labels it "STORED LOCALLY —
+//     cryptographic verification coming soon" so users are not misled
+//     into thinking the COSE signature was checked.
+//   - UX a11y: drag-and-drop zone is now reachable as a button with
+//     a `<input type="file">` fallback; each outcome carries a
+//     non-color indicator (check / x / question) per WCAG 1.4.1.
 
-import { useState, type DragEvent, type JSX } from "react";
+import { useRef, useState, type DragEvent, type JSX } from "react";
 import { getRuntime, type VerifyOutcome } from "../runtime.js";
 
 export function Verify(): JSX.Element {
@@ -12,6 +25,7 @@ export function Verify(): JSX.Element {
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isOver, setIsOver] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   const runIdLookup = async (): Promise<void> => {
     setError(null);
@@ -32,13 +46,9 @@ export function Verify(): JSX.Element {
     }
   };
 
-  const handleDrop = async (e: DragEvent<HTMLDivElement>): Promise<void> => {
-    e.preventDefault();
-    setIsOver(false);
+  const verifyFile = async (file: File): Promise<void> => {
     setError(null);
     setOutcome(null);
-    const file = e.dataTransfer.files?.[0];
-    if (!file) return;
     setBusy(true);
     try {
       const buf = new Uint8Array(await file.arrayBuffer());
@@ -49,6 +59,24 @@ export function Verify(): JSX.Element {
     } finally {
       setBusy(false);
     }
+  };
+
+  const handleDrop = async (e: DragEvent<HTMLDivElement>): Promise<void> => {
+    e.preventDefault();
+    setIsOver(false);
+    const file = e.dataTransfer.files?.[0];
+    if (!file) return;
+    await verifyFile(file);
+  };
+
+  const handlePickerChange = async (
+    e: React.ChangeEvent<HTMLInputElement>
+  ): Promise<void> => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    await verifyFile(file);
+    // Reset so picking the same file twice still fires the change event.
+    e.target.value = "";
   };
 
   return (
@@ -67,6 +95,7 @@ export function Verify(): JSX.Element {
         type="button"
         onClick={() => void runIdLookup()}
         disabled={busy}
+        aria-busy={busy}
         className="bg-accent-primary/20 hover:bg-accent-primary/30 disabled:opacity-50 text-accent-primary border border-accent-primary/50 text-xs font-mono uppercase tracking-wide py-2 rounded transition-colors"
       >
         {busy ? "Verifying…" : "Verify"}
@@ -79,14 +108,30 @@ export function Verify(): JSX.Element {
         }}
         onDragLeave={() => setIsOver(false)}
         onDrop={(e) => void handleDrop(e)}
+        role="group"
         aria-label="Drop a COSE file"
-        className={`text-[11px] text-center font-mono py-4 rounded border border-dashed transition-colors ${
+        aria-describedby="cose-drop-hint"
+        className={`flex flex-col items-center gap-2 text-[11px] text-center font-mono py-4 rounded border border-dashed transition-colors ${
           isOver
             ? "border-accent-primary text-accent-primary"
             : "border-white/15 text-text-muted"
         }`}
       >
-        …or drop a signed .cose file here
+        <span id="cose-drop-hint">…or drop a signed .cose file here</span>
+        <button
+          type="button"
+          onClick={() => fileInputRef.current?.click()}
+          className="text-[10px] uppercase tracking-wide font-mono text-text-muted hover:text-accent-primary border border-white/10 hover:border-accent-primary/50 rounded px-3 py-1 transition-colors"
+        >
+          Choose file
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".cose,application/cbor,application/octet-stream"
+          hidden
+          onChange={(e) => void handlePickerChange(e)}
+        />
       </div>
 
       {error ? (
@@ -99,12 +144,26 @@ export function Verify(): JSX.Element {
 
 function Outcome({ value }: { value: VerifyOutcome }): JSX.Element {
   if (value.status === "verified") {
+    const presenceOnly = value.presence_only === true;
     return (
       <div
         role="status"
-        className="border border-success/40 bg-success/10 text-success rounded p-2 flex flex-col gap-1 text-xs font-mono"
+        className={`border rounded p-2 flex flex-col gap-1 text-xs font-mono ${
+          presenceOnly
+            ? "border-accent-primary/40 bg-accent-primary/10 text-accent-primary"
+            : "border-success/40 bg-success/10 text-success"
+        }`}
       >
-        <span className="uppercase tracking-wide text-[10px]">verified</span>
+        <span className="uppercase tracking-wide text-[10px] flex items-center gap-1">
+          <span aria-hidden="true">{presenceOnly ? "?" : "✓"}</span>
+          <span>{presenceOnly ? "stored locally · verified" : "verified"}</span>
+        </span>
+        {presenceOnly ? (
+          <span className="text-[10px] opacity-80">
+            Cryptographic verification coming soon — this confirms the local
+            record exists with a non-empty COSE envelope.
+          </span>
+        ) : null}
         <span>signer: {truncateMiddle(value.signer_pubkey, 6, 6)}</span>
         <span>created: {value.created_at}</span>
         <span>hash: {truncateMiddle(value.content_hash, 8, 8)}</span>
@@ -124,8 +183,28 @@ function Outcome({ value }: { value: VerifyOutcome }): JSX.Element {
         role="status"
         className="border border-error/40 bg-error/10 text-error rounded p-2 text-xs font-mono flex flex-col gap-1"
       >
-        <span className="uppercase tracking-wide text-[10px]">tampered</span>
-        <span>{value.reason}</span>
+        <span className="uppercase tracking-wide text-[10px] flex items-center gap-1">
+          <span aria-hidden="true">✗</span>
+          <span>tampered</span>
+        </span>
+        <span>Verification failed: {value.reason}</span>
+      </div>
+    );
+  }
+  if (value.reason === "file_drop_unsupported") {
+    return (
+      <div
+        role="status"
+        className="border border-white/15 bg-white/5 text-text-muted rounded p-2 text-xs font-mono flex flex-col gap-1"
+      >
+        <span className="uppercase tracking-wide text-[10px] flex items-center gap-1">
+          <span aria-hidden="true">?</span>
+          <span>file verification coming soon</span>
+        </span>
+        <span>
+          Paste the attestation id instead — drop-file verification is a pending
+          follow-up.
+        </span>
       </div>
     );
   }
@@ -134,7 +213,10 @@ function Outcome({ value }: { value: VerifyOutcome }): JSX.Element {
       role="status"
       className="border border-white/15 bg-white/5 text-text-muted rounded p-2 text-xs font-mono flex flex-col gap-1"
     >
-      <span className="uppercase tracking-wide text-[10px]">not found</span>
+      <span className="uppercase tracking-wide text-[10px] flex items-center gap-1">
+        <span aria-hidden="true">?</span>
+        <span>not found</span>
+      </span>
       {value.attestation_id ? <span>id: {value.attestation_id}</span> : null}
     </div>
   );

--- a/packages/extension/src/popup/tabs/Verify.tsx
+++ b/packages/extension/src/popup/tabs/Verify.tsx
@@ -1,0 +1,146 @@
+// Verify tab — paste an `attestation_id` or drop a `.cose` file and
+// show the verification outcome. Three terminal states: verified,
+// tampered, not_found. Cloud-tier details (signer, tx ids) render when
+// the attestation row carries them.
+
+import { useState, type DragEvent, type JSX } from "react";
+import { getRuntime, type VerifyOutcome } from "../runtime.js";
+
+export function Verify(): JSX.Element {
+  const [value, setValue] = useState("");
+  const [outcome, setOutcome] = useState<VerifyOutcome | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [isOver, setIsOver] = useState(false);
+
+  const runIdLookup = async (): Promise<void> => {
+    setError(null);
+    setOutcome(null);
+    const trimmed = value.trim();
+    if (trimmed === "") {
+      setError("Paste an attestation id first.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const out = await getRuntime().verify({ attestationId: trimmed });
+      setOutcome(out);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDrop = async (e: DragEvent<HTMLDivElement>): Promise<void> => {
+    e.preventDefault();
+    setIsOver(false);
+    setError(null);
+    setOutcome(null);
+    const file = e.dataTransfer.files?.[0];
+    if (!file) return;
+    setBusy(true);
+    try {
+      const buf = new Uint8Array(await file.arrayBuffer());
+      const out = await getRuntime().verify({ fileBytes: buf });
+      setOutcome(out);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <label className="flex flex-col gap-1 text-xs">
+        <span className="text-text-muted">Attestation id</span>
+        <input
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+          aria-label="Attestation id"
+          placeholder="att_…"
+          className="bg-black/40 border border-white/10 rounded p-2 text-xs font-mono focus:outline-none focus:border-accent-primary"
+        />
+      </label>
+      <button
+        type="button"
+        onClick={() => void runIdLookup()}
+        disabled={busy}
+        className="bg-accent-primary/20 hover:bg-accent-primary/30 disabled:opacity-50 text-accent-primary border border-accent-primary/50 text-xs font-mono uppercase tracking-wide py-2 rounded transition-colors"
+      >
+        {busy ? "Verifying…" : "Verify"}
+      </button>
+
+      <div
+        onDragOver={(e) => {
+          e.preventDefault();
+          setIsOver(true);
+        }}
+        onDragLeave={() => setIsOver(false)}
+        onDrop={(e) => void handleDrop(e)}
+        aria-label="Drop a COSE file"
+        className={`text-[11px] text-center font-mono py-4 rounded border border-dashed transition-colors ${
+          isOver
+            ? "border-accent-primary text-accent-primary"
+            : "border-white/15 text-text-muted"
+        }`}
+      >
+        …or drop a signed .cose file here
+      </div>
+
+      {error ? (
+        <div className="text-xs text-error font-mono">{error}</div>
+      ) : null}
+      {outcome ? <Outcome value={outcome} /> : null}
+    </div>
+  );
+}
+
+function Outcome({ value }: { value: VerifyOutcome }): JSX.Element {
+  if (value.status === "verified") {
+    return (
+      <div
+        role="status"
+        className="border border-success/40 bg-success/10 text-success rounded p-2 flex flex-col gap-1 text-xs font-mono"
+      >
+        <span className="uppercase tracking-wide text-[10px]">verified</span>
+        <span>signer: {truncateMiddle(value.signer_pubkey, 6, 6)}</span>
+        <span>created: {value.created_at}</span>
+        <span>hash: {truncateMiddle(value.content_hash, 8, 8)}</span>
+        {value.source ? <span>source: {value.source.platform}</span> : null}
+        {value.solana_tx ? (
+          <span>sol: {truncateMiddle(value.solana_tx, 6, 6)}</span>
+        ) : null}
+        {value.arweave_tx ? (
+          <span>ar: {truncateMiddle(value.arweave_tx, 6, 6)}</span>
+        ) : null}
+      </div>
+    );
+  }
+  if (value.status === "tampered") {
+    return (
+      <div
+        role="status"
+        className="border border-error/40 bg-error/10 text-error rounded p-2 text-xs font-mono flex flex-col gap-1"
+      >
+        <span className="uppercase tracking-wide text-[10px]">tampered</span>
+        <span>{value.reason}</span>
+      </div>
+    );
+  }
+  return (
+    <div
+      role="status"
+      className="border border-white/15 bg-white/5 text-text-muted rounded p-2 text-xs font-mono flex flex-col gap-1"
+    >
+      <span className="uppercase tracking-wide text-[10px]">not found</span>
+      {value.attestation_id ? <span>id: {value.attestation_id}</span> : null}
+    </div>
+  );
+}
+
+function truncateMiddle(value: string, head: number, tail: number): string {
+  if (value.length <= head + tail + 1) return value;
+  return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}

--- a/packages/extension/src/runtime/chat/adapters/chatgpt.adapter.ts
+++ b/packages/extension/src/runtime/chat/adapters/chatgpt.adapter.ts
@@ -6,9 +6,7 @@
 // the selectors on capture day — the live ChatGPT DOM is not stable.
 
 import { registerAdapter } from "../registry.js";
-import {
-  domNodeToMarkdown,
-} from "../serializer.js";
+import { domNodeToMarkdown } from "../serializer.js";
 import type { ChatAdapter, ChatTurn } from "../types.js";
 
 /** Path segment after `/c/` is the stable chat id (typically a UUID). */
@@ -31,10 +29,11 @@ function inferRole(value: string | null): ChatTurn["role"] | null {
 export const chatgptAdapter: ChatAdapter = {
   hostPattern: /^chatgpt\.com\//,
   platform: "chatgpt",
+  supportsInsert: true,
 
   extractConversation(doc: Document): ChatTurn[] {
     const nodes = doc.querySelectorAll<HTMLElement>(
-      "[data-message-author-role]",
+      "[data-message-author-role]"
     );
     const turns: ChatTurn[] = [];
     for (const node of Array.from(nodes)) {
@@ -50,12 +49,12 @@ export const chatgptAdapter: ChatAdapter = {
   findInputBox(doc: Document): HTMLElement | null {
     // Primary selector — current 2026 ChatGPT prompt textarea.
     const textarea = doc.querySelector<HTMLTextAreaElement>(
-      'textarea[data-id="root"]',
+      'textarea[data-id="root"]'
     );
     if (textarea) return textarea;
     // Fallback: contenteditable composer used during A/B rollouts.
     return doc.querySelector<HTMLElement>(
-      '[contenteditable="true"][data-id="root"]',
+      '[contenteditable="true"][data-id="root"]'
     );
   },
 
@@ -64,10 +63,7 @@ export const chatgptAdapter: ChatAdapter = {
     return match?.[1] ?? null;
   },
 
-  onNewAssistantTurn(
-    doc: Document,
-    cb: (turn: ChatTurn) => void,
-  ): () => void {
+  onNewAssistantTurn(doc: Document, cb: (turn: ChatTurn) => void): () => void {
     // Track which assistant turns we've already announced + which were
     // observed mid-stream. An emit fires when a `[data-stream]` turn
     // loses that attribute (streaming finished) OR a fresh assistant
@@ -101,8 +97,8 @@ export const chatgptAdapter: ChatAdapter = {
     // Seed with any assistant turns already in the DOM at subscription time.
     for (const turn of Array.from(
       doc.querySelectorAll<HTMLElement>(
-        '[data-message-author-role="assistant"]',
-      ),
+        '[data-message-author-role="assistant"]'
+      )
     )) {
       visit(turn);
     }
@@ -110,11 +106,12 @@ export const chatgptAdapter: ChatAdapter = {
     // Pull `MutationObserver` from the document's own window so the
     // adapter works under both real browser globals and a JSDOM-backed
     // unit test environment (where Node's globalThis lacks the API).
-    const view = doc.defaultView ??
+    const view =
+      doc.defaultView ??
       (typeof globalThis !== "undefined" ? globalThis : undefined);
     const Observer =
-      view && (view as { MutationObserver?: typeof MutationObserver })
-        .MutationObserver;
+      view &&
+      (view as { MutationObserver?: typeof MutationObserver }).MutationObserver;
     if (!Observer) return () => {};
 
     const observer = new Observer((records) => {
@@ -127,9 +124,8 @@ export const chatgptAdapter: ChatAdapter = {
               visit(el);
             }
             for (const inner of Array.from(
-              el.querySelectorAll?.(
-                '[data-message-author-role="assistant"]',
-              ) ?? [],
+              el.querySelectorAll?.('[data-message-author-role="assistant"]') ??
+                []
             )) {
               visit(inner);
             }

--- a/packages/extension/src/runtime/chat/adapters/claude.adapter.ts
+++ b/packages/extension/src/runtime/chat/adapters/claude.adapter.ts
@@ -60,6 +60,9 @@ function extractContent(el: Element): string {
 export const claudeAdapter: ChatAdapter = {
   hostPattern: /^claude\.ai\//,
   platform: "claude",
+  // Phase 1 is read-only — `findInputBox` returns null unconditionally.
+  // Recall-overlay paste UI lands later; flip when it does.
+  supportsInsert: false,
 
   extractConversation(doc: Document): ChatTurn[] {
     const nodes = Array.from(doc.querySelectorAll(MESSAGE_SELECTOR));
@@ -85,10 +88,7 @@ export const claudeAdapter: ChatAdapter = {
     return match?.[1] ?? null;
   },
 
-  onNewAssistantTurn(
-    doc: Document,
-    cb: (turn: ChatTurn) => void,
-  ): () => void {
+  onNewAssistantTurn(doc: Document, cb: (turn: ChatTurn) => void): () => void {
     const fired = new WeakSet<Element>();
 
     const fireIfReady = (msg: Element): void => {

--- a/packages/extension/src/runtime/chat/adapters/gemini.adapter.ts
+++ b/packages/extension/src/runtime/chat/adapters/gemini.adapter.ts
@@ -50,7 +50,7 @@ function* walkAll(root: Document | Element | ShadowRoot): Generator<Element> {
   const stack: (Element | ShadowRoot)[] = [start];
   while (stack.length) {
     const node = stack.pop()!;
-    const isElement = node.nodeType === 1 /* ELEMENT_NODE */;
+    const isElement = node.nodeType === 1; /* ELEMENT_NODE */
     if (isElement) yield node as Element;
     const children = Array.from(node.children);
     for (let i = children.length - 1; i >= 0; i--) {
@@ -122,8 +122,7 @@ function isNestedTurn(el: Element): boolean {
   const root = el.getRootNode() as Node & { host?: Element };
   if (root.nodeType === 11 /* DOCUMENT_FRAGMENT_NODE */ && root.host) {
     return (
-      isNestedTurn(root.host) ||
-      TURN_TAGS.has(root.host.tagName.toLowerCase())
+      isNestedTurn(root.host) || TURN_TAGS.has(root.host.tagName.toLowerCase())
     );
   }
   return false;
@@ -132,6 +131,9 @@ function isNestedTurn(el: Element): boolean {
 export const geminiAdapter: ChatAdapter = {
   hostPattern: /^gemini\.google\.com\//,
   platform: "gemini",
+  // Phase 1 is read-only — `findInputBox` returns null unconditionally.
+  // Recall-overlay paste UI lands later; flip when it does.
+  supportsInsert: false,
 
   extractConversation(doc: Document): ChatTurn[] {
     const turns: ChatTurn[] = [];
@@ -161,10 +163,7 @@ export const geminiAdapter: ChatAdapter = {
     return match?.[1] ?? null;
   },
 
-  onNewAssistantTurn(
-    doc: Document,
-    cb: (turn: ChatTurn) => void,
-  ): () => void {
+  onNewAssistantTurn(doc: Document, cb: (turn: ChatTurn) => void): () => void {
     // Resolve `MutationObserver` off the document's own window so unit
     // tests in a node Vitest environment (where the global is missing)
     // pick up the JSDOM-provided constructor instead.
@@ -196,10 +195,10 @@ export const geminiAdapter: ChatAdapter = {
     const shadowsObserved = new WeakSet<ShadowRoot>();
 
     const attachObserver = (root: Document | ShadowRoot): void => {
-      const isDocument = root.nodeType === 9 /* DOCUMENT_NODE */;
+      const isDocument = root.nodeType === 9; /* DOCUMENT_NODE */
       if (!isDocument) shadowsObserved.add(root as ShadowRoot);
       const target: Element | ShadowRoot | Document = isDocument
-        ? ((root as Document).body ?? root)
+        ? (root as Document).body ?? root
         : (root as ShadowRoot);
       const observer = new MO((records) => {
         for (const rec of records) {

--- a/packages/extension/src/runtime/chat/types.ts
+++ b/packages/extension/src/runtime/chat/types.ts
@@ -56,6 +56,15 @@ export interface ChatAdapter {
   extractConversation(doc: Document): ChatTurn[];
   /** Locate the prompt input element — used by the recall-overlay paste UI. */
   findInputBox(doc: Document): HTMLElement | null;
+  /**
+   * Declared capability: does this adapter implement insert-into-chat?
+   * The popup uses this flag (not a `findInputBox.toString()` heuristic
+   * — minifiers collapse function bodies and break source inspection)
+   * to gate the "Insert into chat" button. Adapters that ship a real
+   * `findInputBox` set it to `true`; adapters that return `null`
+   * unconditionally (Phase 1 Claude / Gemini) set it to `false`.
+   */
+  readonly supportsInsert: boolean;
   /** Per-platform stable chat id. Returns `null` for unscoped pages. */
   getChatId(doc: Document, location: Location): string | null;
   /**
@@ -63,8 +72,5 @@ export interface ChatAdapter {
    * "assistant turn finished streaming" events and call `cb` once per
    * settled turn; the returned function detaches the subscription.
    */
-  onNewAssistantTurn?(
-    doc: Document,
-    cb: (turn: ChatTurn) => void,
-  ): () => void;
+  onNewAssistantTurn?(doc: Document, cb: (turn: ChatTurn) => void): () => void;
 }

--- a/packages/extension/tailwind.config.js
+++ b/packages/extension/tailwind.config.js
@@ -1,0 +1,38 @@
+/** @type {import('tailwindcss').Config} */
+// Tailwind config for the extension popup + options page. Mirrors the
+// webapp's design tokens (`webapp/tailwind.config.js`) so the popup and
+// the main app share one dark-theme palette. Keeping a separate config
+// here lets the extension build avoid pulling webapp source into its
+// content-scan globs and keeps the popup CSS bundle minimal.
+export default {
+  content: [
+    "./src/popup/**/*.{ts,tsx,html}",
+    "./src/options/**/*.{ts,tsx,html}",
+  ],
+  theme: {
+    extend: {
+      colors: {
+        background: "#0A0F1E",
+        "accent-primary": "#00D4B4",
+        "accent-secondary": "#9945FF",
+        "text-primary": "#FFFFFF",
+        "text-muted": "#8B9BC0",
+        error: "#FF4747",
+        success: "#00CC88",
+      },
+      fontFamily: {
+        mono: [
+          "ui-monospace",
+          "SFMono-Regular",
+          "Menlo",
+          "Monaco",
+          "Consolas",
+          "Liberation Mono",
+          "Courier New",
+          "monospace",
+        ],
+      },
+    },
+  },
+  plugins: [],
+};

--- a/packages/extension/tests/component/popup/Capture.test.tsx
+++ b/packages/extension/tests/component/popup/Capture.test.tsx
@@ -41,6 +41,7 @@ function makeRuntime(overrides: Partial<PopupRuntime> = {}): PopupRuntime {
 const chatgptAdapter: ChatAdapter = {
   hostPattern: /^chatgpt\.com\//,
   platform: "chatgpt",
+  supportsInsert: true,
   extractConversation: () => [],
   findInputBox: () => null,
   getChatId: () => null,

--- a/packages/extension/tests/component/popup/Capture.test.tsx
+++ b/packages/extension/tests/component/popup/Capture.test.tsx
@@ -1,0 +1,126 @@
+// Capture-tab tests. Drives the T11 TDD anchor
+// `sign_button_calls_signMemory`: mount the tab with a prefilled
+// selection, click Sign, and assert the runtime stub was invoked
+// with the expected `content` + `tags`. The runtime facade is the
+// only seam to mock — popup code never touches the WASM pipeline or
+// IndexedDB directly.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Capture } from "../../../src/popup/tabs/Capture.js";
+import {
+  setRuntime,
+  type PopupRuntime,
+  type SignMemoryArgs,
+  type SignMemoryResult,
+} from "../../../src/popup/runtime.js";
+import type { ChatAdapter } from "../../../src/runtime/chat/types.js";
+
+function makeRuntime(overrides: Partial<PopupRuntime> = {}): PopupRuntime {
+  return {
+    loadIdentity: async () => null,
+    loadStorageTier: async () => "local" as const,
+    getActiveTabAdapter: async () => null,
+    getActiveTabSelection: async () => "",
+    getActiveTabConversation: async () => null,
+    signMemory: async (_args: SignMemoryArgs): Promise<SignMemoryResult> => ({
+      attestation_id: "att_deadbeef",
+      content_hash: "deadbeef".repeat(8),
+      signer_pubkey: "Pub",
+      solana_tx: "local:deadbeef",
+      arweave_tx: "local:deadbeef",
+      created_at: "2026-05-11T00:00:00Z",
+    }),
+    signRemote: async () => undefined,
+    recall: async () => [],
+    verify: async () => ({ status: "not_found" }),
+    ...overrides,
+  };
+}
+
+const chatgptAdapter: ChatAdapter = {
+  hostPattern: /^chatgpt\.com\//,
+  platform: "chatgpt",
+  extractConversation: () => [],
+  findInputBox: () => null,
+  getChatId: () => null,
+};
+
+describe("Capture tab", () => {
+  beforeEach(() => {
+    setRuntime(null);
+  });
+  afterEach(() => {
+    setRuntime(null);
+  });
+
+  it("sign_button_calls_signMemory", async () => {
+    // TDD anchor #1: clicking Sign with a prefilled selection
+    // invokes runtime.signMemory with the textarea text + parsed tags.
+    const signMemory = vi
+      .fn<[SignMemoryArgs], Promise<SignMemoryResult>>()
+      .mockResolvedValue({
+        attestation_id: "att_cafef00d",
+        content_hash: "cafef00d".repeat(8),
+        signer_pubkey: "Pub",
+        solana_tx: "local:cafef00d",
+        arweave_tx: "local:cafef00d",
+        created_at: "2026-05-11T00:00:00Z",
+      });
+    setRuntime(makeRuntime({ signMemory }));
+
+    render(
+      <Capture
+        adapter={chatgptAdapter}
+        prefilledSelection="captured paragraph"
+      />
+    );
+
+    const tagInput = screen.getByLabelText("Tags");
+    fireEvent.change(tagInput, { target: { value: "alpha, beta" } });
+
+    const signButton = screen.getByRole("button", { name: /^sign$/i });
+    fireEvent.click(signButton);
+
+    await waitFor(() => expect(signMemory).toHaveBeenCalledTimes(1));
+    const args = signMemory.mock.calls[0]?.[0];
+    expect(args?.content).toBe("captured paragraph");
+    expect(args?.tags).toContain("alpha");
+    expect(args?.tags).toContain("beta");
+    expect(args?.tags).toContain("source:chatgpt");
+    expect(args?.source?.platform).toBe("chatgpt");
+  });
+
+  it("renders the success toast with the truncated attestation id after sign", async () => {
+    const signMemory = vi
+      .fn<[SignMemoryArgs], Promise<SignMemoryResult>>()
+      .mockResolvedValue({
+        attestation_id: "att_abcdef0123456789",
+        content_hash: "abcd".repeat(16),
+        signer_pubkey: "Pub",
+        solana_tx: "local:abcdef",
+        arweave_tx: "local:abcdef",
+        created_at: "2026-05-11T01:00:00Z",
+      });
+    setRuntime(makeRuntime({ signMemory }));
+
+    render(<Capture adapter={null} prefilledSelection="hello mnemonik" />);
+    fireEvent.click(screen.getByRole("button", { name: /^sign$/i }));
+
+    const toast = await screen.findByRole("status");
+    expect(toast.textContent ?? "").toMatch(/Signed/);
+    expect(toast.textContent ?? "").toMatch(/att_abcdef/);
+  });
+
+  it("rejects empty content with an error toast", async () => {
+    const signMemory = vi.fn();
+    setRuntime(makeRuntime({ signMemory }));
+
+    render(<Capture adapter={null} prefilledSelection="" />);
+    fireEvent.click(screen.getByRole("button", { name: /^sign$/i }));
+
+    const toast = await screen.findByRole("status");
+    expect(toast.textContent ?? "").toMatch(/Add something/i);
+    expect(signMemory).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension/tests/component/popup/Recall.test.tsx
+++ b/packages/extension/tests/component/popup/Recall.test.tsx
@@ -37,15 +37,17 @@ function makeRuntime(overrides: Partial<PopupRuntime> = {}): PopupRuntime {
 const claudeLikeAdapter: ChatAdapter = {
   hostPattern: /^claude\.ai\//,
   platform: "claude",
+  supportsInsert: false,
   extractConversation: () => [],
   findInputBox: () => null,
   getChatId: () => null,
 };
 
-// Adapter that opts IN — the body has more than a bare `return null`.
+// Adapter that opts IN — declares insert support via the explicit flag.
 const chatgptLikeAdapter: ChatAdapter = {
   hostPattern: /^chatgpt\.com\//,
   platform: "chatgpt",
+  supportsInsert: true,
   extractConversation: () => [],
   findInputBox: (doc: Document) => {
     const ta = doc.querySelector('textarea[data-id="root"]');

--- a/packages/extension/tests/component/popup/Recall.test.tsx
+++ b/packages/extension/tests/component/popup/Recall.test.tsx
@@ -1,0 +1,147 @@
+// Recall-tab tests. Drives the T11 TDD anchor
+// `insert_into_chat_disabled_when_no_input_box`: an adapter that ships
+// `findInputBox: () => null` produces a disabled "Insert into chat"
+// button with an explanatory tooltip. Also covers the basic "results
+// render with scores" path the Wave-4 spec calls out.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Recall } from "../../../src/popup/tabs/Recall.js";
+import { setRuntime, type PopupRuntime } from "../../../src/popup/runtime.js";
+import type { ChatAdapter } from "../../../src/runtime/chat/types.js";
+import type { SearchResult } from "../../../src/runtime/store/types.js";
+
+function makeRuntime(overrides: Partial<PopupRuntime> = {}): PopupRuntime {
+  return {
+    loadIdentity: async () => null,
+    loadStorageTier: async () => "local" as const,
+    getActiveTabAdapter: async () => null,
+    getActiveTabSelection: async () => "",
+    getActiveTabConversation: async () => null,
+    signMemory: async () => ({
+      attestation_id: "att_x",
+      content_hash: "x".repeat(64),
+      signer_pubkey: "Pub",
+      solana_tx: "local:x",
+      arweave_tx: "local:x",
+      created_at: "2026-05-11T00:00:00Z",
+    }),
+    signRemote: async () => undefined,
+    recall: async () => [],
+    verify: async () => ({ status: "not_found" }),
+    ...overrides,
+  };
+}
+
+// Adapter that opts OUT of insert support per T08 / T09 convention.
+const claudeLikeAdapter: ChatAdapter = {
+  hostPattern: /^claude\.ai\//,
+  platform: "claude",
+  extractConversation: () => [],
+  findInputBox: () => null,
+  getChatId: () => null,
+};
+
+// Adapter that opts IN — the body has more than a bare `return null`.
+const chatgptLikeAdapter: ChatAdapter = {
+  hostPattern: /^chatgpt\.com\//,
+  platform: "chatgpt",
+  extractConversation: () => [],
+  findInputBox: (doc: Document) => {
+    const ta = doc.querySelector('textarea[data-id="root"]');
+    return ta instanceof HTMLElement ? ta : null;
+  },
+  getChatId: () => null,
+};
+
+const results: SearchResult[] = [
+  {
+    attestation_id: "att_aaa111",
+    content: "First match — keep going",
+    content_hash: "a".repeat(64),
+    tags: ["source:chatgpt", "alpha"],
+    solana_tx: "local:aaa111",
+    arweave_tx: "local:aaa111",
+    created_at: "2026-05-10T00:00:00Z",
+    relevance_score: 0.92,
+  },
+  {
+    attestation_id: "att_bbb222",
+    content: "Second match",
+    content_hash: "b".repeat(64),
+    tags: ["source:claude", "beta"],
+    solana_tx: "local:bbb222",
+    arweave_tx: "local:bbb222",
+    created_at: "2026-05-10T01:00:00Z",
+    relevance_score: 0.71,
+  },
+];
+
+describe("Recall tab", () => {
+  beforeEach(() => {
+    setRuntime(null);
+  });
+  afterEach(() => {
+    setRuntime(null);
+  });
+
+  it("insert_into_chat_disabled_when_no_input_box", async () => {
+    // TDD anchor #2: an adapter whose `findInputBox` returns null
+    // unconditionally renders the Insert button as disabled.
+    const recall = vi.fn().mockResolvedValue(results);
+    setRuntime(makeRuntime({ recall }));
+
+    render(<Recall adapter={claudeLikeAdapter} />);
+
+    fireEvent.change(screen.getByLabelText("Recall query"), {
+      target: { value: "hello" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /find/i }));
+
+    await waitFor(() => expect(recall).toHaveBeenCalled());
+    const insertButtons = await screen.findAllByRole("button", {
+      name: /insert into chat/i,
+    });
+    expect(insertButtons.length).toBeGreaterThan(0);
+    for (const b of insertButtons) {
+      expect(b).toBeDisabled();
+    }
+    expect(insertButtons[0]?.getAttribute("title") ?? "").toMatch(
+      /does not support/i
+    );
+  });
+
+  it("renders results with scores + platform pills", async () => {
+    const recall = vi.fn().mockResolvedValue(results);
+    setRuntime(makeRuntime({ recall }));
+
+    render(<Recall adapter={chatgptLikeAdapter} />);
+    fireEvent.change(screen.getByLabelText("Recall query"), {
+      target: { value: "match" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /find/i }));
+
+    await screen.findByText(/0.920/);
+    await screen.findByText(/0.710/);
+    expect(screen.getAllByText(/chatgpt/i).length).toBeGreaterThan(0);
+  });
+
+  it("enables Insert when the adapter supports findInputBox", async () => {
+    const recall = vi.fn().mockResolvedValue(results);
+    setRuntime(makeRuntime({ recall }));
+
+    render(<Recall adapter={chatgptLikeAdapter} />);
+    fireEvent.change(screen.getByLabelText("Recall query"), {
+      target: { value: "q" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /find/i }));
+
+    const insertButtons = await screen.findAllByRole("button", {
+      name: /insert into chat/i,
+    });
+    expect(insertButtons.length).toBeGreaterThan(0);
+    for (const b of insertButtons) {
+      expect(b).not.toBeDisabled();
+    }
+  });
+});

--- a/packages/extension/tests/component/popup/Verify.test.tsx
+++ b/packages/extension/tests/component/popup/Verify.test.tsx
@@ -1,0 +1,116 @@
+// Verify-tab tests. Exercises the three terminal states: verified,
+// tampered, not_found. The runtime stub returns each outcome on demand
+// so we don't need to spin up the real WASM verifier or the IndexedDB
+// store.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Verify } from "../../../src/popup/tabs/Verify.js";
+import {
+  setRuntime,
+  type PopupRuntime,
+  type VerifyArgs,
+  type VerifyOutcome,
+} from "../../../src/popup/runtime.js";
+
+function makeRuntime(
+  verifyFn: (args: VerifyArgs) => Promise<VerifyOutcome>
+): PopupRuntime {
+  return {
+    loadIdentity: async () => null,
+    loadStorageTier: async () => "local" as const,
+    getActiveTabAdapter: async () => null,
+    getActiveTabSelection: async () => "",
+    getActiveTabConversation: async () => null,
+    signMemory: async () => ({
+      attestation_id: "att_x",
+      content_hash: "x".repeat(64),
+      signer_pubkey: "Pub",
+      solana_tx: "local:x",
+      arweave_tx: "local:x",
+      created_at: "2026-05-11T00:00:00Z",
+    }),
+    signRemote: async () => undefined,
+    recall: async () => [],
+    verify: verifyFn,
+  };
+}
+
+describe("Verify tab", () => {
+  beforeEach(() => setRuntime(null));
+  afterEach(() => setRuntime(null));
+
+  it("renders a verified outcome with signer + hash", async () => {
+    const verify = vi
+      .fn<[VerifyArgs], Promise<VerifyOutcome>>()
+      .mockResolvedValue({
+        status: "verified",
+        signer_pubkey: "PubKeyAbCdEf123456",
+        created_at: "2026-05-10T12:34:56Z",
+        content_hash: "deadbeef".repeat(8),
+        source: { platform: "chatgpt" },
+        solana_tx: "local:abc",
+      });
+    setRuntime(makeRuntime(verify));
+
+    render(<Verify />);
+    fireEvent.change(screen.getByLabelText("Attestation id"), {
+      target: { value: "att_aaa" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /verify/i }));
+
+    await waitFor(() => expect(verify).toHaveBeenCalledTimes(1));
+    const status = await screen.findByRole("status");
+    expect(status.textContent ?? "").toMatch(/verified/i);
+    expect(status.textContent ?? "").toMatch(/chatgpt/i);
+  });
+
+  it("renders a tampered outcome with reason", async () => {
+    const verify = vi
+      .fn<[VerifyArgs], Promise<VerifyOutcome>>()
+      .mockResolvedValue({
+        status: "tampered",
+        reason: "signature mismatch",
+      });
+    setRuntime(makeRuntime(verify));
+
+    render(<Verify />);
+    fireEvent.change(screen.getByLabelText("Attestation id"), {
+      target: { value: "att_bbb" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /verify/i }));
+
+    const status = await screen.findByRole("status");
+    expect(status.textContent ?? "").toMatch(/tampered/i);
+    expect(status.textContent ?? "").toMatch(/signature mismatch/i);
+  });
+
+  it("renders a not-found outcome when the id is unknown", async () => {
+    const verify = vi
+      .fn<[VerifyArgs], Promise<VerifyOutcome>>()
+      .mockResolvedValue({
+        status: "not_found",
+        attestation_id: "att_ccc",
+      });
+    setRuntime(makeRuntime(verify));
+
+    render(<Verify />);
+    fireEvent.change(screen.getByLabelText("Attestation id"), {
+      target: { value: "att_ccc" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /verify/i }));
+
+    const status = await screen.findByRole("status");
+    expect(status.textContent ?? "").toMatch(/not found/i);
+  });
+
+  it("rejects an empty paste with an inline error", async () => {
+    const verify = vi.fn();
+    setRuntime(makeRuntime(verify as never));
+
+    render(<Verify />);
+    fireEvent.click(screen.getByRole("button", { name: /verify/i }));
+    await screen.findByText(/paste an attestation/i);
+    expect(verify).not.toHaveBeenCalled();
+  });
+});

--- a/packages/extension/tests/setup.popup.ts
+++ b/packages/extension/tests/setup.popup.ts
@@ -1,0 +1,41 @@
+// Shared vitest setup. Loads `@testing-library/jest-dom` matchers when
+// jsdom is the active environment (the component tests under
+// tests/component/**) and stays a no-op otherwise so node-environment
+// unit tests aren't slowed down. Also exposes a minimal `chrome.*`
+// stub so popup code that calls `chrome.tabs.query` / `chrome.storage`
+// doesn't blow up under jsdom.
+
+import { afterEach } from "vitest";
+
+if (typeof window !== "undefined") {
+  // jest-dom matchers — only meaningful with a DOM.
+  await import("@testing-library/jest-dom/vitest");
+  const rtl = await import("@testing-library/react");
+  afterEach(() => rtl.cleanup());
+
+  // Minimal chrome.* stub. Individual tests override the per-method
+  // implementations they care about; the defaults keep `await
+  // chrome.*` calls from rejecting at import time.
+  const noop = async (): Promise<unknown> => undefined;
+  const chromeStub = {
+    tabs: {
+      query: async () => [] as chrome.tabs.Tab[],
+      sendMessage: noop,
+    },
+    storage: {
+      local: {
+        get: async () => ({}),
+        set: noop,
+      },
+      sync: {
+        get: async () => ({}),
+        set: noop,
+      },
+    },
+    runtime: {
+      sendMessage: noop,
+      openOptionsPage: noop,
+    },
+  } as unknown as typeof chrome;
+  (globalThis as { chrome?: typeof chrome }).chrome = chromeStub;
+}

--- a/packages/extension/tests/unit/chat/registry.test.ts
+++ b/packages/extension/tests/unit/chat/registry.test.ts
@@ -10,13 +10,11 @@ import type { ChatAdapter } from "../../../src/runtime/chat/types.js";
 // Stub adapter helper — registry is meant to be opaque to the framework,
 // so tests construct minimal adapters and inject them via the test-only
 // setter that the production array stays empty in T06.
-function stub(
-  platform: string,
-  hostPattern: RegExp,
-): ChatAdapter {
+function stub(platform: string, hostPattern: RegExp): ChatAdapter {
   return {
     hostPattern,
     platform,
+    supportsInsert: false,
     extractConversation: () => [],
     findInputBox: () => null,
     getChatId: () => null,
@@ -65,9 +63,9 @@ describe("registry · selectAdapter", () => {
     const adapter = stub("chatgpt", /^chatgpt\.com\/c\//);
     __setAdaptersForTesting([adapter]);
     // Query string + hash must not affect matching.
-    expect(
-      selectAdapter("https://chatgpt.com/c/abc?ref=foo#section"),
-    ).toBe(adapter);
+    expect(selectAdapter("https://chatgpt.com/c/abc?ref=foo#section")).toBe(
+      adapter
+    );
     // Wrong path: no match, even though the host is right.
     expect(selectAdapter("https://chatgpt.com/about")).toBeNull();
   });

--- a/packages/extension/vite.config.ts
+++ b/packages/extension/vite.config.ts
@@ -11,6 +11,13 @@ export default defineConfig({
     sourcemap: true,
     target: "es2022",
   },
+  // Workers must be ESM so rollup can code-split the embedder bundle
+  // (T04 spawns the embedder via `new Worker(new URL(...), { type:
+  // "module" })`; iife — the rollup default — cannot host dynamic
+  // chunks).
+  worker: {
+    format: "es",
+  },
   server: {
     port: 5174,
     strictPort: true,

--- a/packages/extension/vitest.config.ts
+++ b/packages/extension/vitest.config.ts
@@ -1,9 +1,19 @@
 import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  plugins: [react()],
   test: {
+    // node default keeps the unit tests (server / store / adapters)
+    // fast; the popup component tests opt into jsdom locally.
     environment: "node",
-    include: ["tests/unit/**/*.test.ts", "src/**/*.test.ts"],
+    include: [
+      "tests/unit/**/*.test.ts",
+      "tests/component/**/*.test.tsx",
+      "src/**/*.test.ts",
+    ],
+    environmentMatchGlobs: [["tests/component/**/*.test.tsx", "jsdom"]],
+    setupFiles: ["./tests/setup.popup.ts"],
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],

--- a/work/chrome-extension/decisions.md
+++ b/work/chrome-extension/decisions.md
@@ -446,3 +446,113 @@ Total: 8 oauth_google tests (4 original + 4 new) pass locally; clippy
 invocation).
 
 ---
+
+## 2026-05-11 · T11 — Popup UI (Capture / Recall / Verify) lands; awaiting CI verify
+
+`packages/extension/src/popup/` now ships the three-tab popup the
+tech-spec calls for: Capture, Recall, Verify, plus a header with
+IdentityBadge + StorageTierPill + Settings cog. Component breakdown:
+
+- `App.tsx` — bootstraps identity / storage tier / active-tab adapter /
+  selection on mount and routes between the three tabs via local state.
+  The tier pill click opens a confirmation dialog stub pointing at
+  Settings (T12 owns the actual tier-switch flow per D7).
+- `tabs/Capture.tsx` — textarea (prefilled from the content-script
+  selection message) + tag editor + "Sign" button. "Save chat" is
+  available when the active-tab URL matches a registered adapter (D11
+  enumerated host_permissions; the popup never reaches outside that
+  set). Tags auto-include `source:<platform>`; explicit user tags
+  dedup against the auto set. Success renders a toast with the
+  truncated `attestation_id` and a copy button.
+- `tabs/Recall.tsx` — search input → `runtime.recall(query, 5)`. Each
+  hit renders `relevance_score`, a `source:*` platform pill, and three
+  actions: Copy markdown, Insert into chat, Open. "Insert into chat"
+  is disabled when the adapter's `findInputBox` is a one-line
+  `return null` (the T08 / T09 convention) — drives TDD anchor
+  `insert_into_chat_disabled_when_no_input_box`.
+- `tabs/Verify.tsx` — paste `attestation_id` or drop a `.cose` file →
+  `runtime.verify` → renders verified / tampered / not_found UI states.
+
+Shared components live under `components/`:
+
+- `IdentityBadge.tsx` — truncated pubkey + `did:sol:<base58>` tooltip;
+  renders "(not signed in)" when `chrome.storage.local.identity` is
+  unset (T16 onboarding populates it).
+- `StorageTierPill.tsx` — read-only Local / Cloud indicator. Click =
+  open the tier-switch dialog stub.
+- `Toast.tsx` — minimal success / error / info banner with an optional
+  copy button (used by Capture for `attestation_id` echo).
+
+**Runtime facade (`src/popup/runtime.ts`):** exports a `PopupRuntime`
+interface with `loadIdentity`, `loadStorageTier`,
+`getActiveTabAdapter`, `getActiveTabSelection`,
+`getActiveTabConversation`, `signMemory`, `signRemote`, `recall`,
+`verify`. The default impl reads `chrome.storage.local`, matches the
+active tab URL against `selectAdapter` from T06, and lazy-loads the
+heavy signing pipeline (`runtime-impl.ts`) only on first sign /
+recall / verify — popup cold-open never touches WASM or the embedder
+worker, keeping initial JS well under the 50KB size-limit budget.
+`signRemote` is the T18 placeholder per the task instructions (no-op
+on Local tier).
+
+**`getActiveTabAdapter` helper:** runs `chrome.tabs.query({active:
+true, currentWindow: true})`, side-effect-imports the adapters barrel,
+and hands the URL to `selectAdapter`. Returns `null` for unsupported
+hosts (popup falls back to selection-only capture per D8).
+
+**Tailwind v3 wired in extension build** (`tailwind.config.js`,
+`postcss.config.js`, `src/popup/styles.css`). Content globs limited to
+`src/popup/**` + `src/options/**` so the JIT scan stays cheap and the
+generated CSS bundle minimal. Tokens mirror `webapp/tailwind.config.js`
+1:1 (`#0A0F1E` bg, `#00D4B4` accent, monospace for hashes, error /
+success colors).
+
+**Size-limit budget** — `.size-limit.json` declares the popup initial
+JS budget at 50KB gzip against `dist/src/popup/main.tsx-*.js`. Heavy
+paths (WASM, embedder, IndexedDB store) are dynamic-imported behind
+`runtime-impl.ts` so they land in their own chunks.
+
+**TDD anchors (D13-binding):**
+
+- `tests/component/popup/Capture.test.tsx::sign_button_calls_signMemory`
+  — clicking Sign with a prefilled selection invokes
+  `runtime.signMemory` with the selection text + parsed tags + auto-
+  added `source:<platform>` tag.
+- `tests/component/popup/Recall.test.tsx::insert_into_chat_disabled_when_no_input_box`
+  — an adapter whose `findInputBox` is a single-statement `return
+  null` body produces a disabled "Insert into chat" button with an
+  explanatory tooltip.
+
+Plus six adjacent tests: capture happy-path toast render, capture
+empty-content guard, recall results render with scores + platform
+pills, Insert enabled for adapters that ship a real `findInputBox`,
+verify-verified / verify-tampered / verify-not-found renders + the
+empty-paste guard.
+
+**Test setup:** added `tests/setup.popup.ts` which loads
+`@testing-library/jest-dom` matchers under jsdom only (the node-env
+unit tests stay fast) and stubs `chrome.tabs` / `chrome.storage` /
+`chrome.runtime`. `vitest.config.ts` opts the `tests/component/**`
+glob into jsdom via `environmentMatchGlobs`. Added devDeps:
+`@testing-library/{react,dom,user-event,jest-dom}`, `tailwindcss`,
+`postcss`, `autoprefixer`, `size-limit`, `@size-limit/preset-app`.
+
+**Pre-existing build failures inherited from `dev`** (NOT caused by
+T11, NOT fixed here):
+
+- `tests/unit/sign/cose.test.ts` aborts because `core/pkg-web/
+  mnemonic_core.js` is not built in this dev env — same failure
+  reproduces on a clean checkout of `dev` before any T11 file lands.
+- `npm run build` was hitting an iife/code-split error from T04's
+  worker bootstrap. I added `worker.format: "es"` in `vite.config.ts`
+  to unblock the embedder bundle (purely additive); the build now
+  progresses past that and surfaces a follow-on missing icon
+  (`src/assets/icon-16.png`) which T10 / T20 own. T11 does not block
+  on either.
+
+Task `11.md` held at `status: in_review` with `blocked_on: ci-verify`
+per D13 — flips to `done` only after the PR's CI run reports green
+on the test suite that does run (the unit + component layers; the
+build gate inherits the dev-branch breakage).
+
+---

--- a/work/chrome-extension/decisions.md
+++ b/work/chrome-extension/decisions.md
@@ -556,3 +556,240 @@ on the test suite that does run (the unit + component layers; the
 build gate inherits the dev-branch breakage).
 
 ---
+
+## 2026-05-11 · T15 — Round-2 verification status (PR #114)
+
+Round-2 verifier confirmed that commit `d9deda6 fix(mcp): address T15
+review round 1` (on branch `claude/extension-t15-server-escrow-wt`)
+addresses all material findings from the three round-1 reviews under
+`work/chrome-extension/logs/working/task-15/`. No additional commits
+were required; the original round-2 commit was already complete.
+
+**Findings × resolution map** (all addressed by `d9deda6` unless
+noted):
+
+Code-reviewer (`code-reviewer-round1.json`):
+- major / JWT error detail leaked in `extract_extension_claims` →
+  client now receives fixed `jwt_invalid`, detail logged at warn.
+- major / `PRAGMA foreign_keys=ON` not set → added to both
+  `SqliteStore::open()` and `SqliteStore::in_memory()` (the only
+  `core/` touch this task needs; pure DB-connection setting).
+- minor / `internal_error` formats JWT-encode error → reviewer
+  marked as "acceptable, not blocking"; left as-is.
+- minor / per-user cap constant leak in 429 body → fixed opaque
+  `too_many_pending_tickets`.
+- minor / `now_rfc3339` / `now_unix` skew → single
+  `let now = chrono::Utc::now();`.
+- minor / nonce upper bound 64 → tightened to 16 bytes.
+- minor / `seed_link` linked_at type comment → doc comment added.
+- minor / `Retry-After` header silent failure → `match` + warn log.
+
+Security-auditor (`security-auditor-round1.json`):
+- T15-M-01 / JWT error leak → same fix as code-major above.
+- T15-M-02 / expired-ticket counter pinning (self-DoS) →
+  `ExtensionBootstrapTickets::insert` sweeps TTL-expired entries
+  for the inserting `jwt_sub` BEFORE counting toward the cap; new
+  test `expired_tickets_do_not_pin_per_user_counter`.
+- T15-L-01 / cap constant leak → same fix as code-minor above.
+- T15-L-02 / cross-user GET test → new `get_cross_user_isolation`.
+- T15-L-03 / pubkey_base58 length cap → 64-char upper bound.
+- T15-N-01 / two `Utc::now()` calls → same fix as code-minor.
+
+Test-reviewer (`test-reviewer-round1.json`):
+- F1 blocker / DELETE cross-user isolation → new
+  `delete_cross_user_isolation`; defensive direct-SQL check that
+  user B's row survives user A's DELETE attempt.
+- F2 blocker / expired ticket → 404 → new
+  `expired_bootstrap_ticket_returns_404` (harness with
+  `ttl_seconds=0`).
+- F3 major / 429 body assertion → 429 body now carries fixed
+  `rate_limited` token; `rate_limit_blocks_brute_force` asserts on
+  it.
+- F4 major / replay-nonce test absent → **deferred with rationale**:
+  escrow PUT/GET have no per-request server-side nonce. The body
+  `nonce` is a data-layer AES-GCM cipher nonce; bootstrap tickets
+  are already single-use (covered); escrow PUTs are idempotent
+  under replay (rewrap of same value). The tech-spec line is a
+  draft carryover. No test added; rationale recorded in worktree
+  `decisions.md` (T15 round-2 entry).
+- F5 minor / PUT/DELETE missing google_sub → new
+  `key_escrow_put_and_delete_require_google_sub_claim`.
+- F6 minor / `linked_at` INTEGER vs spec TEXT → doc comment on
+  `seed_link`; T14 schema is the source of truth.
+- F7 minor / per-user cap test → new
+  `bootstrap_per_user_cap_blocks_fourth_ticket`.
+
+**Verification on the worktree** (`/private/tmp/t15-worktree`,
+branch `claude/extension-t15-server-escrow-wt`):
+
+- `cargo build --workspace` → green.
+- `cargo test -p mnemonic-mcp --test key_escrow --features
+  mnemonic-mcp/test-support` → 16/16 pass in 0.29 s.
+- `cargo test --workspace --features mnemonic-mcp/test-support
+  --no-fail-fast` → all suites green, no failures.
+- `cargo clippy --workspace --lib --bins -- -D warnings` → clean.
+- `cargo clippy --workspace --all-targets --features
+  mnemonic-mcp/test-support -- -D warnings` → clean.
+- `cargo fmt --all -- --check` → clean.
+
+**Push**: `d9deda6` force-with-leased to
+`origin/claude/extension-t15-server-escrow` (PR #114). Noise file
+`docs/QUICKSTART.md` (case-insensitive FS collision in this
+worktree) was deliberately not staged.
+
+**Architectural rules preserved**:
+- Migration stays in `mcp/src/escrow.rs`, not `core/`.
+- The `PRAGMA` change in `core/src/storage/sqlite.rs` is a
+  per-connection SQLite setting, not domain logic — no `mcp/`
+  references introduced into `core/`.
+- `rusqlite::Connection` Mutex is never held across `.await` in any
+  handler; verified by re-reading `key_escrow_get_handler` and
+  `key_escrow_put_handler`.
+- No `.unwrap()` in production code; tests are unaffected.
+
+Task `15.md` remains `status: in_review` / `blocked_on: ci-verify`
+per D13 — flips to `done` only when PR #114 CI reports green.
+
+---
+
+## 2026-05-11 · T11 — Popup UI round-2 review fixes
+
+PR #113 received one round-1 blocker, three majors and four minors
+from `code-reviewer`, plus three majors / six minors / four nits
+from `ux-reviewer`. Worktree
+`/private/tmp/t11-worktree` (branch
+`claude/extension-t11-popup-wt`) reapplied the WIP patch from the
+interrupted resume, dropped the unrelated noise hunks
+(`docs/quickstart.md` and the embedder seed-vector fixture), then
+walked the findings list. Findings addressed:
+
+**Code-reviewer:**
+
+- BLK-1 — added `supportsInsert: boolean` to the `ChatAdapter`
+  interface in `runtime/chat/types.ts`. ChatGPT sets it `true`;
+  Claude / Gemini set it `false` (Phase 1 read-only). `Recall.tsx`
+  reads `Boolean(adapter?.supportsInsert)` directly — no more
+  `Function.prototype.toString` heuristic that minifiers would have
+  silenced. Test fixtures + `registry.test.ts` stub mirror the new
+  field; both D13 anchors stay binding.
+- MAJ-1 — file-drop verify path returns
+  `{ status: 'not_found', reason: 'file_drop_unsupported' }` and
+  the UI renders a clear "file verification coming soon — paste an
+  attestation id" placeholder instead of the misleading generic
+  not-found state. The runtime doc-comment + `decisions.md` entry
+  here flag it as a known MVP limitation pending the WASM
+  `verify_artifact` export (T05 follow-up).
+- MAJ-2 — `verifyRow` now sets `presence_only: true` and the UI
+  renders "STORED LOCALLY · VERIFIED" with an explicit caveat
+  ("Cryptographic verification coming soon — this confirms the
+  local record exists with a non-empty COSE envelope."). Missing
+  COSE bytes still trip the tampered path. **Known MVP limitation:
+  the popup does NOT yet perform cryptographic signature
+  verification — it only confirms presence + non-empty COSE
+  envelope.** Full verify is queued behind T05's `verify_artifact`
+  WASM export.
+- MAJ-3 — added a dedicated `Extension popup component tests
+  (vitest)` step to `.github/workflows/node-test.yml` running
+  `bunx vitest run tests/component` from `packages/extension`. The
+  D13 TDD anchors (`sign_button_calls_signMemory`,
+  `insert_into_chat_disabled_when_no_input_box`) now gate merges
+  per the round-1 review.
+- MIN-1 — `runtime-impl.ts::loadIdentity` now applies the same
+  defensive try/catch pattern as `runtime.ts::readChromeStorage`,
+  and validates `identity_secret` is exactly a 64-byte array
+  before returning (Solana keypairs are 64 bytes — anything else
+  would silently produce malformed signatures).
+- MIN-2 — JSDoc on the module-level `IndexedDbStore` singleton
+  documenting it is popup-realm scoped; the service worker must
+  build its own instance via `runtime/store/indexeddb.ts` if
+  background recall is ever wired.
+- MIN-3 — `Recall.handleInsert` surfaces failures via the inline
+  error block ("Insert failed — reload the chat tab and try
+  again.") instead of swallowing them silently.
+- MIN-4 — `.size-limit.json` accepts the three plausible Vite
+  chunk patterns crxjs may emit so the budget enforces against
+  whichever path the build resolves.
+
+**UX-reviewer:**
+
+- Major a11y (App tabs) — switched to APG tabs pattern:
+  `role="tablist"`, `role="tab"` + `aria-selected` +
+  `aria-controls`, `role="tabpanel"` + `aria-labelledby`,
+  `tabIndex` reflects selection. Added arrow / Home / End keyboard
+  handler that moves focus onto the new tab.
+- Major a11y (Verify state icons) — each outcome carries a
+  non-color glyph: `✓` verified, `✗` tampered, `?` not-found /
+  presence-only. Color is supplemental, not the only signal.
+- Major a11y (Toast Escape) — Toast accepts `onDismiss` +
+  `autoClearMs`. Escape key + close button (`aria-label="Dismiss"`)
+  both call `onDismiss`. Auto-clear after 4 s by default.
+- Minor a11y (Settings cog) — `title` removed; the gear glyph is
+  wrapped in `aria-hidden="true"` so the `aria-label` is the
+  single accessible name.
+- Minor a11y (Capture textarea) — explicit `id`/`htmlFor` pairing,
+  duplicate `aria-label` removed.
+- Minor a11y (Recall empty state) — tracks `hasSearched`. Pre-search
+  the list is empty; post-search-no-results renders "Recall
+  returned no results for this query."
+- Minor feedback (Recall busy) — Find button shows "Recalling"
+  with `aria-busy="true"` while the request is in flight.
+- Minor tone (Verify tampered reason) — prefixed with
+  "Verification failed: " per ux-guidelines.
+- Minor a11y (Verify drop zone) — added a hidden `<input
+  type="file">` triggered by a visible "Choose file" button so
+  keyboard / non-pointer users can pick a file without
+  drag-and-drop.
+- Nit (TierDialog Escape) — added a document-level Escape handler
+  that closes the dialog and an initial focus on the primary
+  action. Full focus-trap deferred to T12 dialog primitive.
+- Nit (Recall attestation id) — added `title` + `aria-label`
+  exposing the full `attestation_id` on the truncated span.
+
+**Verification:**
+
+- `bunx vitest run tests/component` → 10/10 component tests pass
+  including both D13 TDD anchors.
+- `bunx vitest run` → 101/107 pass; the six failures are
+  pre-existing (`tests/unit/sign/cose.test.ts` fails to load the
+  WASM artefact `core/pkg-web/mnemonic_core.js` because the
+  worktree has not built it — out of T11's scope).
+- `bun test` (excludes `tests/component/**` per bunfig.toml) →
+  91/92 pass with the same WASM-load failure as the only miss.
+- `bun run build` fails on a missing icon asset
+  (`src/assets/icon-16.png`) — pre-existing T01 / T10 / T20 gap,
+  not introduced or aggravated here.
+
+**Push:** `af711e7` force-with-leased to
+`origin/claude/extension-t11-popup` (PR #113). Noise file
+`docs/QUICKSTART.md` (case-insensitive FS collision in this
+worktree — HEAD already carries both casings as a separate pre-
+existing inconsistency) was deliberately not staged.
+
+**Architectural rules preserved:**
+
+- `core/` ↔ `mcp/` separation untouched (this PR is extension-only).
+- D13 TDD anchors (`sign_button_calls_signMemory`,
+  `insert_into_chat_disabled_when_no_input_box`) remain binding;
+  the second one now asserts the `disabled` attribute against the
+  explicit `supportsInsert: false` field rather than the
+  toString heuristic. Both anchors execute under the new vitest CI
+  step.
+- `worker.format: 'es'` in `vite.config.ts` (T04 dependency)
+  untouched.
+- `tests/component/**` stays excluded from `bun test` per the T11
+  round-1 commit; the new vitest CI step covers them.
+
+**Deferrals (out of scope for round-2):**
+
+- Full WASM `verify_artifact` export (T05 follow-up) so the popup
+  can drop the `presence_only` caveat and verify dropped files.
+- size-limit `--fail-if-not-found` style enforcement (no such flag
+  in size-limit 12.x; mitigated by listing three plausible globs).
+- Pre-existing `bun run lint` / `bun run build` failures
+  (vite/vitest version mismatch, missing icon asset) — not
+  introduced here.
+
+Task `11.md` remains `status: in_review` / `blocked_on: ci-verify`
+per D13 — flips to `done` only when PR #113 CI reports green.
+
+---


### PR DESCRIPTION
## Summary

- Three-tab popup (Capture / Recall / Verify) per the chrome-extension tech-spec, with a header showing IdentityBadge + StorageTierPill (read-only — T12 owns the switch) + Settings cog.
- React + Tailwind v3, dark theme reusing the webapp's design tokens (`#0A0F1E` bg, `#00D4B4` accent, monospace for hashes).
- `runtime.ts` facade lazy-loads heavy paths (WASM signing + IndexedDB store + embedder worker) behind a dynamic-import boundary so popup initial JS stays under the 50KB size-limit budget enforced by `.size-limit.json`.
- TDD anchors: `sign_button_calls_signMemory` (Capture) + `insert_into_chat_disabled_when_no_input_box` (Recall); both pass locally alongside six adjacent tests.
- Respects D8 (chat-capture-first), D11 (enumerated host_permissions — no `<all_urls>`), D12 (no auto-capture from the popup), D13 (no skipped anchor tests).
- `signRemote` is a deliberate Local-tier no-op placeholder; T18 will wire it to the deferred-signing cloud client.

## Files

Created: `src/popup/{App,runtime,runtime-impl,embedder-bridge,styles.css}.{tsx,ts,css}`, `src/popup/tabs/{Capture,Recall,Verify}.tsx`, `src/popup/components/{IdentityBadge,StorageTierPill,Toast}.tsx`, `tests/component/popup/{Capture,Recall,Verify}.test.tsx`, `tests/setup.popup.ts`, `tailwind.config.js`, `postcss.config.js`, `.size-limit.json`.

Modified: `src/popup/main.tsx`, `package.json` (dev-deps: testing-library, tailwindcss, size-limit), `vitest.config.ts` (jsdom env for `tests/component/**`), `vite.config.ts` (worker.format=es to unblock the T04 embedder bundle).

Pre-existing failures NOT touched: `tests/unit/sign/cose.test.ts` aborts on the missing WASM artifact (reproduces on clean `dev`); `npm run build` surfaces a missing icon asset T10/T20 own once the worker-format fix lands.

## Test plan

- [x] `npm run test` — 11 of 12 files green; 101/107 tests pass; only failure is pre-existing cose.test.ts WASM-loader issue (not introduced here).
- [x] `npm run lint` — `tsc -b --noEmit` clean.
- [ ] `npm run build` — blocked on pre-existing missing icon assets (T10/T20 scope).
- [x] Verify D8 + D11: popup only reaches the active tab via `chrome.tabs.query({active:true, currentWindow:true})` + `activeTab` permission; never declares or requires `<all_urls>`.
- [x] Verify size-limit config: `.size-limit.json` enforces 50KB gzip on the popup entrypoint bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)