### PR TITLE
feat(mcp): T15 — extension-bootstrap + key-escrow endpoints

### DIFF
--- a/core/src/storage/sqlite.rs
+++ b/core/src/storage/sqlite.rs
@@ -255,8 +255,16 @@ impl SqliteStore {
         // that loses the lock race queues for up to 5s rather than
         // returning SQLITE_BUSY immediately (rusqlite default is 0ms),
         // which also stabilizes the payment race tests.
-        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000;")
-            .context("setting WAL + busy_timeout pragmas")?;
+        // `PRAGMA foreign_keys=ON` is per-connection and must be set
+        // explicitly; SQLite defaults to OFF, which would silently demote
+        // `FOREIGN KEY ... ON DELETE CASCADE` clauses (such as the one on
+        // `key_escrow_blobs(google_sub) REFERENCES google_identity_links`)
+        // to no-ops. We enable it here so cascade-delete and FK-violation
+        // rejection actually fire.
+        conn.execute_batch(
+            "PRAGMA journal_mode=WAL; PRAGMA busy_timeout=5000; PRAGMA foreign_keys=ON;",
+        )
+        .context("setting WAL + busy_timeout + foreign_keys pragmas")?;
         conn.execute_batch(SCHEMA).context("initializing schema")?;
         migrate_payment_events_unique_index(&conn)?;
         migrate_owner_pubkey_columns(&conn)?;
@@ -268,8 +276,10 @@ impl SqliteStore {
         let conn = Connection::open_in_memory()?;
         // busy_timeout is harmless on in-memory DBs and keeps behavior
         // consistent with file-backed stores. WAL mode is meaningless in
-        // memory and not requested.
-        conn.execute_batch("PRAGMA busy_timeout=5000;")?;
+        // memory and not requested. `foreign_keys=ON` mirrors `open()` so
+        // FK CASCADE clauses (e.g. `key_escrow_blobs` → `google_identity_links`)
+        // are enforced in tests using `in_memory()` too.
+        conn.execute_batch("PRAGMA busy_timeout=5000; PRAGMA foreign_keys=ON;")?;
         conn.execute_batch(SCHEMA)?;
         migrate_payment_events_unique_index(&conn)?;
         migrate_owner_pubkey_columns(&conn)?;

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -131,6 +131,12 @@ name = "oauth_google"
 path = "tests/oauth_google.rs"
 required-features = ["test-support"]
 
+# Same feature-gating pattern for the chrome-extension key-escrow tests (T15).
+[[test]]
+name = "key_escrow"
+path = "tests/key_escrow.rs"
+required-features = ["test-support"]
+
 [dev-dependencies]
 tempfile = "3"
 httpmock = "0.8"

--- a/mcp/src/config.rs
+++ b/mcp/src/config.rs
@@ -84,6 +84,15 @@ pub struct Config {
     /// Google OAuth redirect URI configured in Google Cloud Console. Must be
     /// HTTPS in production; defaults to `https://mc.mnemonik.xyz/oauth/google/callback`.
     pub google_oauth_redirect_uri: String,
+
+    // ── Extension key escrow (chrome-extension T15, Decision 9) ─────────────
+    /// Max GET fetches against `/api/key-escrow` per rolling 24h per
+    /// `google_sub`. Bounds online brute-force on the encrypted blob; the
+    /// Argon2id KDF bounds the offline brute-force on stolen ciphertext.
+    /// `main.rs::run_http` reads this value when constructing the escrow
+    /// router state — there is no `std::env::var` re-read downstream
+    /// (round-1 code-reviewer finding #2). Default 5.
+    pub key_escrow_rate_limit: u32,
 }
 
 impl Config {
@@ -136,6 +145,7 @@ impl Config {
                 "GOOGLE_OAUTH_REDIRECT_URI",
                 "https://mc.mnemonik.xyz/oauth/google/callback",
             ),
+            key_escrow_rate_limit: env_or("KEY_ESCROW_RATE_LIMIT", "5").parse().unwrap_or(5),
         }
     }
 

--- a/mcp/src/escrow.rs
+++ b/mcp/src/escrow.rs
@@ -1,0 +1,865 @@
+//! Chrome-extension key escrow + extension-bootstrap endpoints — T15 of
+//! `work/chrome-extension/`.
+//!
+//! Implements Decision 9 server-side:
+//!
+//! - Argon2id-AES-GCM blob stored opaquely per `google_sub`. Server never
+//!   sees plaintext.
+//! - PUT validates `pubkey_base58` matches the linked `pubkey_base58` in
+//!   `google_identity_links` (binds the encrypted key to the user's
+//!   on-chain identity; stolen-Google-account → swap-key attack rejected).
+//! - GET rate-limited to `KEY_ESCROW_RATE_LIMIT` (default 5) per rolling
+//!   24h per `google_sub`. The window resets when `last_fetch_at` is older
+//!   than 24h. Returns 429 with `Retry-After` once exceeded.
+//! - DELETE is hard delete (D9 explicit revocation).
+//!
+//! ## Extension bootstrap (handshake)
+//!
+//! Mirrors the existing `cli-bootstrap` flow (`api.rs`), with one structural
+//! difference: the **redeem response is a fresh JWT bound to `aud=extension`**,
+//! not a raw keypair (the extension already has its own Ed25519 keypair from
+//! T13's seed-restore flow). The webapp calls
+//! `POST /api/extension-bootstrap/issue` with its current `aud=mcp` JWT (the
+//! one minted via the Google OAuth callback path in T14); the server returns
+//! a one-time UUID ticket. The extension polls
+//! `GET /api/extension-bootstrap/redeem/:ticket` to consume the ticket and
+//! get a JWT it can use against `/api/key-escrow`. Tickets are LRU + TTL
+//! 10 min, single-use; the UUID is the capability so the redeem path needs
+//! no Authorization header (uri-allowlisted in the bearer-auth middleware,
+//! same model as cli-bootstrap).
+//!
+//! ## Architecture note
+//!
+//! The migration for `key_escrow_blobs` lives in this module under `mcp/`,
+//! NOT in `core/src/storage/sqlite.rs`. This matches T14's precedent for
+//! `google_identity_links` (see
+//! `oauth/google.rs::migrate_google_identity_links`) and the project-wide
+//! rule that OAuth/escrow tables are server concerns (per CLAUDE.md and
+//! `decisions.md` D9). The original T15 task spec said migrations live in
+//! `core/`; the deviation is documented in `decisions.md`.
+
+use std::num::NonZeroUsize;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{anyhow, Context, Result};
+use axum::{
+    extract::{Path, State},
+    http::{HeaderMap, HeaderValue, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use base64::Engine;
+use jsonwebtoken::{decode, encode, Algorithm, Header, Validation};
+use lru::LruCache;
+use rusqlite::{params, OptionalExtension};
+use serde::{Deserialize, Serialize};
+
+use crate::mcp::McpState;
+use crate::oauth::{Claims, OAuthState, JWT_ISSUER, JWT_TTL_SECS};
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/// `aud` claim for extension-scoped JWTs. Separate from the `mcp` audience
+/// used by AI-tool clients so the bearer-auth middleware on `/mcp` rejects
+/// extension JWTs cleanly — they only get past the explicit escrow handlers
+/// (which verify against this audience inline).
+pub const EXTENSION_JWT_AUDIENCE: &str = "extension";
+
+/// TTL of an extension-bootstrap ticket: 10 minutes — matches D9.
+pub const EXTENSION_BOOTSTRAP_TTL_SECS: i64 = 600;
+
+/// LRU capacity for in-flight extension-bootstrap tickets. Independent of
+/// the cli-bootstrap cap (they're different flows).
+pub const EXTENSION_BOOTSTRAP_LRU_CAP: usize = 10_000;
+
+/// Per-user cap on outstanding extension-bootstrap tickets. Prevents a
+/// compromised JWT from spamming tickets into the LRU.
+pub const EXTENSION_BOOTSTRAP_PER_USER_CAP: usize = 3;
+
+/// Rolling rate-limit window for key-escrow GETs: 24h. The DB row tracks the
+/// count + last fetch timestamp so we never hold in-memory state for this.
+pub const KEY_ESCROW_WINDOW_SECS: i64 = 24 * 3600;
+
+// ── DB migration ─────────────────────────────────────────────────────────────
+
+/// Create `key_escrow_blobs` if it does not exist. Idempotent — safe to call
+/// on every startup. Lives in `mcp/` per the architectural rule that
+/// OAuth/escrow tables are server-side, not part of the cross-client
+/// `mnemonic-core` storage schema.
+///
+/// Schema (D9):
+///   - `google_sub TEXT PRIMARY KEY`  — link key to `google_identity_links`.
+///   - `ciphertext BLOB NOT NULL`     — AES-GCM ciphertext of the Ed25519
+///     secret key. Server never decrypts.
+///   - `nonce BLOB NOT NULL`          — AES-GCM 96-bit nonce.
+///   - `kdf TEXT NOT NULL`            — KDF identifier (e.g. "argon2id").
+///   - `kdf_params TEXT NOT NULL`     — JSON-encoded KDF params (mem/time/
+///     parallelism/salt). Opaque to the server.
+///   - `pubkey_base58 TEXT NOT NULL`  — bound Ed25519 pubkey. MUST equal the
+///     `pubkey_base58` in `google_identity_links` for this `google_sub`. PUT
+///     rejects mismatches with 403 — closes the stolen-google-account →
+///     swap-key attack.
+///   - `updated_at TEXT NOT NULL`     — RFC3339 timestamp of last PUT.
+///   - `fetch_count_24h INTEGER`      — GET counter in the current 24h
+///     window. Reset whenever the previous `last_fetch_at` is > 24h old.
+///   - `last_fetch_at TEXT`           — RFC3339 timestamp of the previous GET
+///     (NULL until first GET).
+///
+/// Foreign key constraint cascades on DELETE of the parent row so unlinking
+/// a Google account cleans up its escrow. SQLite enforces FKs only when
+/// `PRAGMA foreign_keys = ON;` is set — `SqliteStore::open` does this in
+/// `core/` (verified at startup).
+pub fn migrate_key_escrow_blobs(conn: &rusqlite::Connection) -> Result<()> {
+    conn.execute_batch(MIGRATION_SQL)
+        .context("create key_escrow_blobs table")?;
+    Ok(())
+}
+
+/// Raw migration string — kept as a module-level `const` so the T15 TDD
+/// anchor `server_never_stores_plaintext` can read it via this re-export
+/// and assert that no plaintext-leaking column name is present.
+pub const MIGRATION_SQL: &str = "CREATE TABLE IF NOT EXISTS key_escrow_blobs (
+    google_sub      TEXT PRIMARY KEY,
+    ciphertext      BLOB NOT NULL,
+    nonce           BLOB NOT NULL,
+    kdf             TEXT NOT NULL,
+    kdf_params      TEXT NOT NULL,
+    pubkey_base58   TEXT NOT NULL,
+    updated_at      TEXT NOT NULL,
+    fetch_count_24h INTEGER NOT NULL DEFAULT 0,
+    last_fetch_at   TEXT,
+    FOREIGN KEY (google_sub) REFERENCES google_identity_links(google_sub) ON DELETE CASCADE
+);";
+
+// ── Helpers — DB ─────────────────────────────────────────────────────────────
+
+/// Look up the `pubkey_base58` linked to `google_sub` in
+/// `google_identity_links`. Returns `Ok(None)` when no row is present.
+fn lookup_linked_pubkey(conn: &rusqlite::Connection, google_sub: &str) -> Result<Option<String>> {
+    conn.query_row(
+        "SELECT pubkey_base58 FROM google_identity_links WHERE google_sub = ?1 LIMIT 1",
+        params![google_sub],
+        |r| r.get::<_, String>(0),
+    )
+    .optional()
+    .context("query google_identity_links for pubkey_base58")
+}
+
+/// Atomic UPSERT of the escrow row. Resets the rolling 24h window
+/// (`fetch_count_24h=0`, `last_fetch_at=NULL`) on every PUT — the previous
+/// counter is irrelevant once the user rewraps with a fresh ciphertext.
+#[allow(clippy::too_many_arguments)]
+fn upsert_escrow(
+    conn: &rusqlite::Connection,
+    google_sub: &str,
+    ciphertext: &[u8],
+    nonce: &[u8],
+    kdf: &str,
+    kdf_params: &str,
+    pubkey_base58: &str,
+    updated_at: &str,
+) -> Result<()> {
+    conn.execute(
+        "INSERT INTO key_escrow_blobs \
+         (google_sub, ciphertext, nonce, kdf, kdf_params, pubkey_base58, updated_at, fetch_count_24h, last_fetch_at) \
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, 0, NULL) \
+         ON CONFLICT(google_sub) DO UPDATE SET \
+             ciphertext = excluded.ciphertext, \
+             nonce = excluded.nonce, \
+             kdf = excluded.kdf, \
+             kdf_params = excluded.kdf_params, \
+             pubkey_base58 = excluded.pubkey_base58, \
+             updated_at = excluded.updated_at, \
+             fetch_count_24h = 0, \
+             last_fetch_at = NULL",
+        params![
+            google_sub,
+            ciphertext,
+            nonce,
+            kdf,
+            kdf_params,
+            pubkey_base58,
+            updated_at,
+        ],
+    )
+    .context("upsert key_escrow_blobs")?;
+    Ok(())
+}
+
+/// One escrow row as held in memory after a successful GET.
+#[derive(Debug, Clone)]
+pub struct EscrowRow {
+    pub ciphertext: Vec<u8>,
+    pub nonce: Vec<u8>,
+    pub kdf: String,
+    pub kdf_params: String,
+    pub pubkey_base58: String,
+    pub fetch_count_24h: i64,
+    pub last_fetch_at: Option<String>,
+}
+
+/// Read the escrow row for `google_sub`. Returns `Ok(None)` when absent.
+fn read_escrow(conn: &rusqlite::Connection, google_sub: &str) -> Result<Option<EscrowRow>> {
+    conn.query_row(
+        "SELECT ciphertext, nonce, kdf, kdf_params, pubkey_base58, fetch_count_24h, last_fetch_at \
+         FROM key_escrow_blobs WHERE google_sub = ?1 LIMIT 1",
+        params![google_sub],
+        |r| {
+            Ok(EscrowRow {
+                ciphertext: r.get(0)?,
+                nonce: r.get(1)?,
+                kdf: r.get(2)?,
+                kdf_params: r.get(3)?,
+                pubkey_base58: r.get(4)?,
+                fetch_count_24h: r.get(5)?,
+                last_fetch_at: r.get(6)?,
+            })
+        },
+    )
+    .optional()
+    .context("read key_escrow_blobs row")
+}
+
+/// Atomic counter update for a GET fetch. Combines "set last_fetch_at" with
+/// "increment or reset counter" in a single SQL statement so two concurrent
+/// GETs cannot both observe count=N and both write count=N+1.
+///
+/// Logic (single UPDATE):
+///   - If `last_fetch_at IS NULL` OR (`now` - `last_fetch_at`) >= 24h →
+///     fetch_count_24h = 1.
+///   - Else → fetch_count_24h = fetch_count_24h + 1.
+///   - `last_fetch_at = now_rfc3339` in either branch.
+///
+/// We pass `now_unix` separately so SQLite computes the window-elapsed check
+/// off integers — RFC3339 string subtraction is brittle.
+fn increment_fetch_counter(
+    conn: &rusqlite::Connection,
+    google_sub: &str,
+    now_rfc3339: &str,
+    now_unix: i64,
+    window_secs: i64,
+) -> Result<()> {
+    conn.execute(
+        "UPDATE key_escrow_blobs SET \
+            fetch_count_24h = CASE \
+                WHEN last_fetch_at IS NULL THEN 1 \
+                WHEN (?2 - CAST(strftime('%s', last_fetch_at) AS INTEGER)) >= ?3 THEN 1 \
+                ELSE fetch_count_24h + 1 \
+            END, \
+            last_fetch_at = ?4 \
+         WHERE google_sub = ?1",
+        params![google_sub, now_unix, window_secs, now_rfc3339],
+    )
+    .context("increment fetch_count_24h on key_escrow_blobs")?;
+    Ok(())
+}
+
+/// Hard-delete the row for `google_sub`. Returns the number of rows removed
+/// so the handler can answer 404 vs 200 cleanly.
+fn delete_escrow(conn: &rusqlite::Connection, google_sub: &str) -> Result<usize> {
+    let changes = conn
+        .execute(
+            "DELETE FROM key_escrow_blobs WHERE google_sub = ?1",
+            params![google_sub],
+        )
+        .context("delete key_escrow_blobs row")?;
+    Ok(changes)
+}
+
+// ── Bootstrap ticket store ───────────────────────────────────────────────────
+
+/// One outstanding extension-bootstrap ticket. Held in the LRU until the
+/// extension redeems it or the TTL expires.
+#[derive(Debug, Clone)]
+struct ExtensionBootstrapTicket {
+    /// JWT subject (base58 pubkey) of the webapp caller that issued the
+    /// ticket. Used both for the per-user cap and as the subject of the
+    /// fresh `aud=extension` JWT minted at redeem time.
+    jwt_sub: String,
+    /// `google_sub` of the user (carried over from the issuing JWT). The
+    /// redeem-time JWT carries this too — `/api/key-escrow` reads it.
+    google_sub: Option<String>,
+    /// Unix-seconds expiry. `consume` returns `None` after this.
+    expires_at: i64,
+}
+
+/// In-memory LRU+TTL store of extension-bootstrap tickets. Same lock
+/// discipline as `BootstrapTickets` in `api.rs` — `std::sync::Mutex` because
+/// the critical sections are pure SQL/LRU work with no `.await` points.
+pub struct ExtensionBootstrapTickets {
+    inner: Mutex<ExtensionBootstrapInner>,
+}
+
+struct ExtensionBootstrapInner {
+    lru: LruCache<uuid::Uuid, ExtensionBootstrapTicket>,
+    per_user: std::collections::HashMap<String, usize>,
+    per_user_cap: usize,
+    ttl_seconds: i64,
+}
+
+impl ExtensionBootstrapInner {
+    fn dec_user(&mut self, jwt_sub: &str) {
+        if let Some(c) = self.per_user.get_mut(jwt_sub) {
+            *c = c.saturating_sub(1);
+            if *c == 0 {
+                self.per_user.remove(jwt_sub);
+            }
+        }
+    }
+}
+
+/// Errors surfaced by `ExtensionBootstrapTickets::insert`.
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum ExtensionBootstrapInsertError {
+    PerUserCapExceeded,
+}
+
+impl ExtensionBootstrapTickets {
+    pub fn new(lru_capacity: usize, per_user_cap: usize, ttl_seconds: i64) -> Self {
+        let cap = NonZeroUsize::new(lru_capacity.max(1)).expect("nonzero capacity");
+        Self {
+            inner: Mutex::new(ExtensionBootstrapInner {
+                lru: LruCache::new(cap),
+                per_user: std::collections::HashMap::new(),
+                per_user_cap,
+                ttl_seconds,
+            }),
+        }
+    }
+
+    pub fn with_defaults() -> Self {
+        Self::new(
+            EXTENSION_BOOTSTRAP_LRU_CAP,
+            EXTENSION_BOOTSTRAP_PER_USER_CAP,
+            EXTENSION_BOOTSTRAP_TTL_SECS,
+        )
+    }
+
+    fn insert(
+        &self,
+        jwt_sub: String,
+        google_sub: Option<String>,
+    ) -> std::result::Result<uuid::Uuid, ExtensionBootstrapInsertError> {
+        let mut guard = self
+            .inner
+            .lock()
+            .map_err(|_| ExtensionBootstrapInsertError::PerUserCapExceeded)?;
+        let count = guard.per_user.get(&jwt_sub).copied().unwrap_or(0);
+        if count >= guard.per_user_cap {
+            return Err(ExtensionBootstrapInsertError::PerUserCapExceeded);
+        }
+        let ticket_id = uuid::Uuid::new_v4();
+        let now = now_unix();
+        let expires_at = now + guard.ttl_seconds;
+        let entry = ExtensionBootstrapTicket {
+            jwt_sub: jwt_sub.clone(),
+            google_sub,
+            expires_at,
+        };
+        if let Some((_evicted_id, evicted)) = guard.lru.push(ticket_id, entry) {
+            // Defense: if the LRU evicts an unrelated entry (because cap was
+            // reached), decrement THAT user's counter. The freshly-minted
+            // UUID guarantees the eviction is not our own row.
+            guard.dec_user(&evicted.jwt_sub);
+        }
+        *guard.per_user.entry(jwt_sub).or_insert(0) += 1;
+        Ok(ticket_id)
+    }
+
+    /// Atomic remove-and-return. Returns the entry exactly once. Expired
+    /// entries are evicted lazily and return None.
+    fn consume(&self, ticket_id: uuid::Uuid) -> Option<ExtensionBootstrapTicket> {
+        let mut guard = self.inner.lock().ok()?;
+        let entry = guard.lru.pop(&ticket_id)?;
+        let now = now_unix();
+        if now >= entry.expires_at {
+            guard.dec_user(&entry.jwt_sub);
+            return None;
+        }
+        guard.dec_user(&entry.jwt_sub);
+        Some(entry)
+    }
+}
+
+// ── Escrow router state ──────────────────────────────────────────────────────
+
+/// Shared state for the escrow + extension-bootstrap routes. Wraps the
+/// rate-limit threshold + the bootstrap-ticket store + back-references to
+/// the MCP and OAuth states (so handlers can read/write SQLite and verify
+/// JWTs without holding any other mutable state).
+pub struct EscrowState {
+    pub rate_limit: u32,
+    pub bootstrap_tickets: Arc<ExtensionBootstrapTickets>,
+    pub mcp: Arc<McpState>,
+    pub oauth: Arc<OAuthState>,
+}
+
+impl EscrowState {
+    pub fn new(rate_limit: u32, mcp: Arc<McpState>, oauth: Arc<OAuthState>) -> Self {
+        Self {
+            rate_limit: rate_limit.max(1),
+            bootstrap_tickets: Arc::new(ExtensionBootstrapTickets::with_defaults()),
+            mcp,
+            oauth,
+        }
+    }
+}
+
+// ── Handlers — extension-bootstrap ───────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub struct ExtensionBootstrapIssueResponse {
+    pub ticket_id: String,
+}
+
+/// `POST /api/extension-bootstrap/issue` — auth: server JWT (Bearer, aud=mcp,
+/// optionally with `google_sub`). Returns a one-time UUID ticket the
+/// extension can redeem at `/redeem/:ticket` for a fresh `aud=extension` JWT.
+///
+/// Auth is enforced by the global `bearer_auth_middleware` which injects
+/// `Claims` into the request extension before this handler runs.
+pub async fn extension_bootstrap_issue_handler(
+    State(state): State<Arc<EscrowState>>,
+    axum::Extension(claims): axum::Extension<Claims>,
+) -> Response {
+    match state
+        .bootstrap_tickets
+        .insert(claims.sub.clone(), claims.google_sub.clone())
+    {
+        Ok(ticket_id) => (
+            StatusCode::OK,
+            Json(ExtensionBootstrapIssueResponse {
+                ticket_id: ticket_id.to_string(),
+            }),
+        )
+            .into_response(),
+        Err(ExtensionBootstrapInsertError::PerUserCapExceeded) => (
+            StatusCode::TOO_MANY_REQUESTS,
+            Json(serde_json::json!({
+                "error": format!(
+                    "per-user extension-bootstrap cap exceeded ({} active)",
+                    EXTENSION_BOOTSTRAP_PER_USER_CAP
+                ),
+            })),
+        )
+            .into_response(),
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct ExtensionBootstrapRedeemResponse {
+    pub access_token: String,
+    pub aud: &'static str,
+    pub expires_in: u64,
+}
+
+/// `GET /api/extension-bootstrap/redeem/:ticket` — NO auth: the UUID is the
+/// capability (single-use, 10-min TTL). Identical 404 body for "garbage UUID",
+/// "expired", "already consumed" so an attacker probing tickets cannot
+/// distinguish failure modes.
+pub async fn extension_bootstrap_redeem_handler(
+    State(state): State<Arc<EscrowState>>,
+    Path(ticket_str): Path<String>,
+) -> Response {
+    let ticket_id = match uuid::Uuid::parse_str(&ticket_str) {
+        Ok(id) => id,
+        Err(_) => return extension_ticket_not_found(),
+    };
+    let entry = match state.bootstrap_tickets.consume(ticket_id) {
+        Some(t) => t,
+        None => return extension_ticket_not_found(),
+    };
+
+    // Mint a fresh JWT with aud=extension + the carried google_sub. We sign
+    // it with the same secret as the production OAuth flow so all server
+    // endpoints can verify it against the same key.
+    let token = match mint_extension_jwt(&state.oauth, &entry.jwt_sub, entry.google_sub.clone()) {
+        Ok(t) => t,
+        Err(e) => return internal_error(&format!("mint extension JWT: {e}")),
+    };
+    (
+        StatusCode::OK,
+        Json(ExtensionBootstrapRedeemResponse {
+            access_token: token,
+            aud: EXTENSION_JWT_AUDIENCE,
+            expires_in: JWT_TTL_SECS,
+        }),
+    )
+        .into_response()
+}
+
+fn extension_ticket_not_found() -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({
+            "error": "ticket not found, already consumed, or expired",
+        })),
+    )
+        .into_response()
+}
+
+// ── Handlers — key escrow ────────────────────────────────────────────────────
+
+/// PUT body. Base64 transport keeps the wire format JSON-clean while the DB
+/// holds raw BLOBs.
+#[derive(Debug, Deserialize)]
+pub struct KeyEscrowPutRequest {
+    pub ciphertext_b64: String,
+    pub nonce_b64: String,
+    pub kdf: String,
+    pub kdf_params: String,
+    pub pubkey_base58: String,
+}
+
+/// GET response. Symmetric to PUT — base64 BLOBs + opaque KDF params + the
+/// bound pubkey (so the extension can verify it matches its local keypair
+/// before attempting decryption).
+#[derive(Debug, Serialize)]
+pub struct KeyEscrowGetResponse {
+    pub ciphertext_b64: String,
+    pub nonce_b64: String,
+    pub kdf: String,
+    pub kdf_params: String,
+    pub pubkey_base58: String,
+}
+
+/// `PUT /api/key-escrow` — auth: extension JWT with `google_sub`. UPSERT the
+/// blob; resets the rate-limit counter. Rejects 403 when:
+///   - the JWT carries no `google_sub` claim, OR
+///   - no `google_identity_links` row exists for the `google_sub`, OR
+///   - the `pubkey_base58` in the request body does NOT match the linked
+///     pubkey (security: closes the stolen-google-account → swap-key attack).
+pub async fn key_escrow_put_handler(
+    State(state): State<Arc<EscrowState>>,
+    headers: HeaderMap,
+    Json(req): Json<KeyEscrowPutRequest>,
+) -> Response {
+    let claims = match extract_extension_claims(&state.oauth, &headers) {
+        Ok(c) => c,
+        Err(resp) => return *resp,
+    };
+    let google_sub = match claims.google_sub.as_deref() {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => return unauthorized("JWT missing google_sub claim"),
+    };
+
+    // Decode base64 BLOBs first so we fail fast on garbage input before
+    // touching the DB.
+    let ciphertext =
+        match base64::engine::general_purpose::STANDARD.decode(req.ciphertext_b64.as_bytes()) {
+            Ok(b) => b,
+            Err(_) => return bad_request("ciphertext_b64 is not valid base64"),
+        };
+    let nonce = match base64::engine::general_purpose::STANDARD.decode(req.nonce_b64.as_bytes()) {
+        Ok(b) => b,
+        Err(_) => return bad_request("nonce_b64 is not valid base64"),
+    };
+    if ciphertext.is_empty() {
+        return bad_request("ciphertext_b64 must not be empty");
+    }
+    // AES-GCM-256 standard nonce is 96 bits = 12 bytes. We do not enforce
+    // the wrap algorithm at the schema layer (D9 keeps the server agnostic),
+    // but reject obviously-malformed nonces.
+    if nonce.is_empty() || nonce.len() > 64 {
+        return bad_request("nonce_b64 must be 1..=64 bytes after base64-decode");
+    }
+    if req.kdf.is_empty() || req.kdf.len() > 64 {
+        return bad_request("kdf is required (1..=64 chars)");
+    }
+    if req.kdf_params.is_empty() || req.kdf_params.len() > 4096 {
+        return bad_request("kdf_params is required (1..=4096 chars)");
+    }
+    if req.pubkey_base58.is_empty() {
+        return bad_request("pubkey_base58 is required");
+    }
+
+    // Lookup-then-upsert under one critical section so the binding check is
+    // atomic w.r.t. concurrent `/oauth/google/link` calls flipping the
+    // pubkey for the same `google_sub`.
+    let updated_at = chrono::Utc::now().to_rfc3339();
+    let result: Response = {
+        let store = match state.mcp.store.lock() {
+            Ok(g) => g,
+            Err(_) => return internal_error("store mutex poisoned"),
+        };
+        let conn = store.conn();
+        let linked = match lookup_linked_pubkey(conn, &google_sub) {
+            Ok(x) => x,
+            Err(e) => {
+                tracing::error!("key_escrow PUT: lookup_linked_pubkey: {e:#}");
+                return internal_error("internal error");
+            }
+        };
+        match linked {
+            None => return forbidden("no google_identity_links row for google_sub"),
+            Some(pk) if pk != req.pubkey_base58 => {
+                return forbidden("pubkey_base58 does not match linked owner_pubkey")
+            }
+            Some(_) => {}
+        }
+        match upsert_escrow(
+            conn,
+            &google_sub,
+            &ciphertext,
+            &nonce,
+            &req.kdf,
+            &req.kdf_params,
+            &req.pubkey_base58,
+            &updated_at,
+        ) {
+            Ok(_) => Json(serde_json::json!({
+                "status": "ok",
+                "updated_at": updated_at,
+            }))
+            .into_response(),
+            Err(e) => {
+                tracing::error!("key_escrow PUT: upsert_escrow: {e:#}");
+                internal_error("internal error")
+            }
+        }
+    };
+    result
+}
+
+/// `GET /api/key-escrow` — auth: extension JWT with `google_sub`. Returns
+/// the escrow row if any. Enforces the rolling 24h rate limit by:
+///   1. Reading the row.
+///   2. If `last_fetch_at` is set AND the window has not elapsed AND the
+///      counter is already >= rate_limit → return 429 + `Retry-After:
+///      seconds_until_window_resets`.
+///   3. Otherwise increment (atomically: the SQL UPDATE handles both
+///      reset-on-elapsed and bump-in-window in one statement) and return
+///      the body.
+pub async fn key_escrow_get_handler(
+    State(state): State<Arc<EscrowState>>,
+    headers: HeaderMap,
+) -> Response {
+    let claims = match extract_extension_claims(&state.oauth, &headers) {
+        Ok(c) => c,
+        Err(resp) => return *resp,
+    };
+    let google_sub = match claims.google_sub.as_deref() {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => return unauthorized("JWT missing google_sub claim"),
+    };
+
+    let rate_limit = state.rate_limit;
+    let now_rfc3339 = chrono::Utc::now().to_rfc3339();
+    let now_unix = chrono::Utc::now().timestamp();
+
+    // Single critical section: read → rate-check → increment → return.
+    // No `.await` while the SQLite mutex is held.
+    let row: EscrowRow = {
+        let store = match state.mcp.store.lock() {
+            Ok(g) => g,
+            Err(_) => return internal_error("store mutex poisoned"),
+        };
+        let conn = store.conn();
+        let row = match read_escrow(conn, &google_sub) {
+            Ok(Some(r)) => r,
+            Ok(None) => return not_found("escrow not found"),
+            Err(e) => {
+                tracing::error!("key_escrow GET: read_escrow: {e:#}");
+                return internal_error("internal error");
+            }
+        };
+
+        // Compute how long ago the previous fetch was. None → no fetch yet
+        // (counter is 0); Some(seconds) → seconds since last fetch.
+        let elapsed_secs = match row.last_fetch_at.as_deref() {
+            None => None,
+            Some(s) => match chrono::DateTime::parse_from_rfc3339(s) {
+                Ok(dt) => Some(now_unix - dt.timestamp()),
+                Err(_) => {
+                    tracing::warn!("key_escrow GET: malformed last_fetch_at in DB, resetting");
+                    None
+                }
+            },
+        };
+
+        // The counter only blocks when the window is NOT elapsed AND we are
+        // at-or-over the cap. A fresh row (counter 0) or stale window
+        // (elapsed >= 24h) is allowed through.
+        let within_window = matches!(elapsed_secs, Some(e) if e < KEY_ESCROW_WINDOW_SECS);
+        if within_window && row.fetch_count_24h as u32 >= rate_limit {
+            let retry_after = KEY_ESCROW_WINDOW_SECS
+                .saturating_sub(elapsed_secs.unwrap_or(0))
+                .max(1);
+            return rate_limited(retry_after);
+        }
+
+        if let Err(e) = increment_fetch_counter(
+            conn,
+            &google_sub,
+            &now_rfc3339,
+            now_unix,
+            KEY_ESCROW_WINDOW_SECS,
+        ) {
+            tracing::error!("key_escrow GET: increment_fetch_counter: {e:#}");
+            return internal_error("internal error");
+        }
+        row
+    };
+
+    Json(KeyEscrowGetResponse {
+        ciphertext_b64: base64::engine::general_purpose::STANDARD.encode(&row.ciphertext),
+        nonce_b64: base64::engine::general_purpose::STANDARD.encode(&row.nonce),
+        kdf: row.kdf,
+        kdf_params: row.kdf_params,
+        pubkey_base58: row.pubkey_base58,
+    })
+    .into_response()
+}
+
+/// `DELETE /api/key-escrow` — auth: extension JWT with `google_sub`.
+/// Removes the row. 200 on success (also when the row was already absent —
+/// idempotent revocation).
+pub async fn key_escrow_delete_handler(
+    State(state): State<Arc<EscrowState>>,
+    headers: HeaderMap,
+) -> Response {
+    let claims = match extract_extension_claims(&state.oauth, &headers) {
+        Ok(c) => c,
+        Err(resp) => return *resp,
+    };
+    let google_sub = match claims.google_sub.as_deref() {
+        Some(s) if !s.is_empty() => s.to_string(),
+        _ => return unauthorized("JWT missing google_sub claim"),
+    };
+
+    let removed = {
+        let store = match state.mcp.store.lock() {
+            Ok(g) => g,
+            Err(_) => return internal_error("store mutex poisoned"),
+        };
+        match delete_escrow(store.conn(), &google_sub) {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::error!("key_escrow DELETE: {e:#}");
+                return internal_error("internal error");
+            }
+        }
+    };
+    Json(serde_json::json!({"status": "ok", "removed": removed})).into_response()
+}
+
+// ── JWT helpers (aud=extension) ──────────────────────────────────────────────
+
+/// Issue an HS256 JWT bound to `sub` + `google_sub` with `aud=extension`.
+/// Shares the signing key with the production OAuth flow so a single
+/// `MCP_JWT_SECRET` suffices.
+pub fn mint_extension_jwt(
+    oauth: &OAuthState,
+    sub: &str,
+    google_sub: Option<String>,
+) -> Result<String> {
+    let now = now_unix() as u64;
+    let claims = Claims {
+        iss: JWT_ISSUER.to_string(),
+        aud: EXTENSION_JWT_AUDIENCE.to_string(),
+        sub: sub.to_string(),
+        iat: now,
+        exp: now + JWT_TTL_SECS,
+        jti: uuid::Uuid::new_v4().to_string(),
+        google_sub,
+    };
+    let header = Header::new(Algorithm::HS256);
+    encode(&header, &claims, oauth.jwt_encoding_key())
+        .map_err(|e| anyhow!("JWT encode failed: {e}"))
+}
+
+/// Verify the Bearer JWT in `headers` and require `aud=extension`. The
+/// production bearer-auth middleware accepts only `aud=mcp`, so the escrow
+/// router intentionally runs OUTSIDE of it and verifies inline here.
+fn extract_extension_claims(
+    oauth: &OAuthState,
+    headers: &HeaderMap,
+) -> std::result::Result<Claims, Box<Response>> {
+    let token = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| Box::new(unauthorized("missing Bearer JWT")))?;
+
+    let mut validation = Validation::new(Algorithm::HS256);
+    validation.set_audience(&[EXTENSION_JWT_AUDIENCE]);
+    let mut iss_set = std::collections::HashSet::new();
+    iss_set.insert(JWT_ISSUER.to_string());
+    validation.iss = Some(iss_set);
+    validation.validate_exp = true;
+
+    let data = decode::<Claims>(token.as_str(), oauth.jwt_decoding_key(), &validation)
+        .map_err(|e| Box::new(unauthorized(&format!("invalid JWT: {e}"))))?;
+    if data.claims.iss != JWT_ISSUER || data.claims.aud != EXTENSION_JWT_AUDIENCE {
+        return Err(Box::new(unauthorized("invalid JWT iss/aud")));
+    }
+    Ok(data.claims)
+}
+
+// ── Response helpers ─────────────────────────────────────────────────────────
+
+fn bad_request(msg: &str) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({"error": msg})),
+    )
+        .into_response()
+}
+
+fn unauthorized(msg: &str) -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(serde_json::json!({"error": msg})),
+    )
+        .into_response()
+}
+
+fn forbidden(msg: &str) -> Response {
+    (
+        StatusCode::FORBIDDEN,
+        Json(serde_json::json!({"error": msg})),
+    )
+        .into_response()
+}
+
+fn not_found(msg: &str) -> Response {
+    (
+        StatusCode::NOT_FOUND,
+        Json(serde_json::json!({"error": msg})),
+    )
+        .into_response()
+}
+
+fn rate_limited(retry_after_secs: i64) -> Response {
+    let mut resp = (
+        StatusCode::TOO_MANY_REQUESTS,
+        Json(serde_json::json!({
+            "error": "rate limit exceeded: too many GETs in 24h window",
+            "retry_after_secs": retry_after_secs,
+        })),
+    )
+        .into_response();
+    if let Ok(hv) = HeaderValue::from_str(&retry_after_secs.to_string()) {
+        resp.headers_mut().insert("Retry-After", hv);
+    }
+    resp
+}
+
+fn internal_error(msg: &str) -> Response {
+    tracing::error!("key_escrow internal error: {msg}");
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(serde_json::json!({"error": "internal error"})),
+    )
+        .into_response()
+}
+
+fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}

--- a/mcp/src/escrow.rs
+++ b/mcp/src/escrow.rs
@@ -345,12 +345,31 @@ impl ExtensionBootstrapTickets {
             .inner
             .lock()
             .map_err(|_| ExtensionBootstrapInsertError::PerUserCapExceeded)?;
+
+        // Sweep TTL-expired entries belonging to this jwt_sub BEFORE counting
+        // toward the cap. Without this, a user who issues `per_user_cap`
+        // tickets and lets them all expire (10-min TTL) without redeeming is
+        // locked out of future bootstrap until the LRU evicts those entries —
+        // which in practice requires 10_000+ unrelated tickets to be inserted
+        // first. Security finding T15-M-02 (round 1).
+        let now = now_unix();
+        let expired_ids: Vec<uuid::Uuid> = guard
+            .lru
+            .iter()
+            .filter(|(_id, t)| t.jwt_sub == jwt_sub && now >= t.expires_at)
+            .map(|(id, _)| *id)
+            .collect();
+        for id in expired_ids {
+            if let Some(t) = guard.lru.pop(&id) {
+                guard.dec_user(&t.jwt_sub);
+            }
+        }
+
         let count = guard.per_user.get(&jwt_sub).copied().unwrap_or(0);
         if count >= guard.per_user_cap {
             return Err(ExtensionBootstrapInsertError::PerUserCapExceeded);
         }
         let ticket_id = uuid::Uuid::new_v4();
-        let now = now_unix();
         let expires_at = now + guard.ttl_seconds;
         let entry = ExtensionBootstrapTicket {
             jwt_sub: jwt_sub.clone(),
@@ -434,16 +453,22 @@ pub async fn extension_bootstrap_issue_handler(
             }),
         )
             .into_response(),
-        Err(ExtensionBootstrapInsertError::PerUserCapExceeded) => (
-            StatusCode::TOO_MANY_REQUESTS,
-            Json(serde_json::json!({
-                "error": format!(
-                    "per-user extension-bootstrap cap exceeded ({} active)",
-                    EXTENSION_BOOTSTRAP_PER_USER_CAP
-                ),
-            })),
-        )
-            .into_response(),
+        Err(ExtensionBootstrapInsertError::PerUserCapExceeded) => {
+            // Fixed opaque string — do not leak the numeric per-user cap
+            // constant into the response body. The server-side log carries
+            // the cap value for operators (security finding T15-L-01).
+            tracing::debug!(
+                "extension-bootstrap per-user cap exceeded (cap={})",
+                EXTENSION_BOOTSTRAP_PER_USER_CAP
+            );
+            (
+                StatusCode::TOO_MANY_REQUESTS,
+                Json(serde_json::json!({
+                    "error": "too_many_pending_tickets",
+                })),
+            )
+                .into_response()
+        }
     }
 }
 
@@ -560,9 +585,11 @@ pub async fn key_escrow_put_handler(
     }
     // AES-GCM-256 standard nonce is 96 bits = 12 bytes. We do not enforce
     // the wrap algorithm at the schema layer (D9 keeps the server agnostic),
-    // but reject obviously-malformed nonces.
-    if nonce.is_empty() || nonce.len() > 64 {
-        return bad_request("nonce_b64 must be 1..=64 bytes after base64-decode");
+    // but cap at 16 bytes to reject obviously-malformed nonces while still
+    // accommodating alternative AEAD constructions (some use a 128-bit
+    // nonce). 64-byte bound from round-1 was over-generous.
+    if nonce.is_empty() || nonce.len() > 16 {
+        return bad_request("nonce_b64 must be 1..=16 bytes after base64-decode");
     }
     if req.kdf.is_empty() || req.kdf.len() > 64 {
         return bad_request("kdf is required (1..=64 chars)");
@@ -570,8 +597,11 @@ pub async fn key_escrow_put_handler(
     if req.kdf_params.is_empty() || req.kdf_params.len() > 4096 {
         return bad_request("kdf_params is required (1..=4096 chars)");
     }
-    if req.pubkey_base58.is_empty() {
-        return bad_request("pubkey_base58 is required");
+    // Ed25519 base58-encoded pubkeys are 43–44 chars. 64-byte upper bound
+    // gives safe headroom while rejecting obvious storage-amplification
+    // payloads (security finding T15-L-03).
+    if req.pubkey_base58.is_empty() || req.pubkey_base58.len() > 64 {
+        return bad_request("pubkey_base58 is required (1..=64 chars)");
     }
 
     // Lookup-then-upsert under one critical section so the binding check is
@@ -645,8 +675,12 @@ pub async fn key_escrow_get_handler(
     };
 
     let rate_limit = state.rate_limit;
-    let now_rfc3339 = chrono::Utc::now().to_rfc3339();
-    let now_unix = chrono::Utc::now().timestamp();
+    // Single Utc::now() so the RFC3339 string and the unix timestamp used in
+    // the rate-limit check refer to exactly the same instant — eliminates a
+    // sub-millisecond skew that would otherwise appear on a contended lock.
+    let now = chrono::Utc::now();
+    let now_rfc3339 = now.to_rfc3339();
+    let now_unix = now.timestamp();
 
     // Single critical section: read → rate-check → increment → return.
     // No `.await` while the SQLite mutex is held.
@@ -791,10 +825,23 @@ fn extract_extension_claims(
     validation.iss = Some(iss_set);
     validation.validate_exp = true;
 
-    let data = decode::<Claims>(token.as_str(), oauth.jwt_decoding_key(), &validation)
-        .map_err(|e| Box::new(unauthorized(&format!("invalid JWT: {e}"))))?;
+    // jsonwebtoken's internal error strings (e.g. `InvalidSignature`,
+    // `ExpiredSignature`, `InvalidAudience`, `InvalidIssuer`) are logged
+    // server-side; clients receive a fixed `jwt_invalid` so they cannot
+    // calibrate forgery attempts against the exact failure mode. Mirrors
+    // the T14 round-2 fix for `id_token_invalid` in `oauth/google.rs`.
+    let data =
+        decode::<Claims>(token.as_str(), oauth.jwt_decoding_key(), &validation).map_err(|e| {
+            tracing::warn!("escrow JWT validation failed: {e:#}");
+            Box::new(unauthorized("jwt_invalid"))
+        })?;
     if data.claims.iss != JWT_ISSUER || data.claims.aud != EXTENSION_JWT_AUDIENCE {
-        return Err(Box::new(unauthorized("invalid JWT iss/aud")));
+        tracing::warn!(
+            "escrow JWT iss/aud mismatch: iss={:?} aud={:?}",
+            data.claims.iss,
+            data.claims.aud
+        );
+        return Err(Box::new(unauthorized("jwt_invalid")));
     }
     Ok(data.claims)
 }
@@ -837,13 +884,22 @@ fn rate_limited(retry_after_secs: i64) -> Response {
     let mut resp = (
         StatusCode::TOO_MANY_REQUESTS,
         Json(serde_json::json!({
-            "error": "rate limit exceeded: too many GETs in 24h window",
+            "error": "rate_limited",
             "retry_after_secs": retry_after_secs,
         })),
     )
         .into_response();
-    if let Ok(hv) = HeaderValue::from_str(&retry_after_secs.to_string()) {
-        resp.headers_mut().insert("Retry-After", hv);
+    // The header value is always a positive decimal integer, so this is
+    // expected to succeed. If construction ever fails (e.g. negative
+    // overflow into a non-ASCII string) we still return the 429 — but log
+    // at warn! so the missing Retry-After is observable in production.
+    match HeaderValue::from_str(&retry_after_secs.to_string()) {
+        Ok(hv) => {
+            resp.headers_mut().insert("Retry-After", hv);
+        }
+        Err(e) => {
+            tracing::warn!("Retry-After header construction failed: {e}");
+        }
     }
     resp
 }

--- a/mcp/src/lib.rs
+++ b/mcp/src/lib.rs
@@ -20,6 +20,7 @@ pub mod api;
 pub mod chat;
 pub mod config;
 pub mod cors_policy;
+pub mod escrow;
 pub mod llm;
 pub mod mcp;
 pub mod oauth;

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -2,6 +2,7 @@ mod api;
 mod chat;
 mod config;
 mod cors_policy;
+mod escrow;
 mod llm;
 mod mcp;
 mod oauth;
@@ -381,6 +382,12 @@ async fn main() -> anyhow::Result<()> {
             tracing::error!("FATAL: google_identity_links migration failed: {e}");
             std::process::exit(1);
         }
+        // T15: key escrow blob table — FK to google_identity_links, so only
+        // migrated when Google OAuth is enabled. Idempotent; safe to re-run.
+        if let Err(e) = escrow::migrate_key_escrow_blobs(store.conn()) {
+            tracing::error!("FATAL: key_escrow_blobs migration failed: {e}");
+            std::process::exit(1);
+        }
     }
     // Chat rate limiter: 10 requests per 60 seconds per IP
     let chat_limiter = {
@@ -467,10 +474,13 @@ async fn main() -> anyhow::Result<()> {
         client_secret: cfg.google_oauth_client_secret.clone(),
         redirect_uri: cfg.google_oauth_redirect_uri.clone(),
     };
+    let extension_settings = ExtensionSettings {
+        key_escrow_rate_limit: cfg.key_escrow_rate_limit,
+    };
 
     match transport.as_str() {
         "stdio" => run_stdio(state).await,
-        "http" => run_http(state, &cli.host, cli.port, google_oauth).await,
+        "http" => run_http(state, &cli.host, cli.port, google_oauth, extension_settings).await,
         other => anyhow::bail!("unknown transport: {other} (use 'stdio' or 'http')"),
     }
 }
@@ -483,6 +493,14 @@ struct GoogleOAuthSettings {
     client_id: String,
     client_secret: String,
     redirect_uri: String,
+}
+
+/// Bundle of chrome-extension settings resolved from `Config`. Same single-
+/// source-of-truth pattern as `GoogleOAuthSettings` — no `std::env::var`
+/// re-reads inside `run_http`. Extends naturally as more extension knobs
+/// are added (e.g. T18's cloud-sync caps).
+struct ExtensionSettings {
+    key_escrow_rate_limit: u32,
 }
 
 // ── stdio transport ───────────────────────────────────────────────────────────
@@ -562,6 +580,7 @@ async fn run_http(
     host: &str,
     port: u16,
     google_oauth: GoogleOAuthSettings,
+    extension_settings: ExtensionSettings,
 ) -> anyhow::Result<()> {
     use axum::http::{header, Method};
     use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
@@ -811,6 +830,60 @@ async fn run_http(
         Router::new()
     };
 
+    // ── T15: Extension key-escrow + extension-bootstrap (Decision 9) ─────────
+    // Only mounted when Google OAuth is enabled — escrow rows have an FK to
+    // `google_identity_links`. `KEY_ESCROW_RATE_LIMIT` is read once here from
+    // `Config` (single source of truth, no downstream `std::env::var`).
+    //
+    // Three sub-mounts:
+    //   1. `/api/extension-bootstrap/issue` — sits behind the standard
+    //      bearer-auth middleware (`aud=mcp` JWT required to mint a ticket).
+    //   2. `/api/extension-bootstrap/redeem/{ticket}` — UUID-as-capability,
+    //      bearer-auth URI-allowlisted (same model as `/api/cli-bootstrap/`).
+    //   3. `/api/key-escrow` PUT/GET/DELETE — verifies `aud=extension` JWT
+    //      inline, sits OUTSIDE bearer-auth (which only accepts `aud=mcp`).
+    let escrow_state = Arc::new(escrow::EscrowState::new(
+        extension_settings.key_escrow_rate_limit,
+        state.clone(),
+        oauth_state.clone(),
+    ));
+    let extension_bootstrap_issue_router = if google_enabled {
+        Router::new()
+            .route(
+                "/api/extension-bootstrap/issue",
+                post(escrow::extension_bootstrap_issue_handler),
+            )
+            .layer(middleware::from_fn_with_state(
+                oauth_state.clone(),
+                oauth::bearer_auth_middleware,
+            ))
+            .with_state(escrow_state.clone())
+    } else {
+        Router::new()
+    };
+    let extension_bootstrap_redeem_router = if google_enabled {
+        Router::new()
+            .route(
+                "/api/extension-bootstrap/redeem/{ticket}",
+                get(escrow::extension_bootstrap_redeem_handler),
+            )
+            .with_state(escrow_state.clone())
+    } else {
+        Router::new()
+    };
+    let key_escrow_router = if google_enabled {
+        Router::new()
+            .route(
+                "/api/key-escrow",
+                axum::routing::put(escrow::key_escrow_put_handler)
+                    .get(escrow::key_escrow_get_handler)
+                    .delete(escrow::key_escrow_delete_handler),
+            )
+            .with_state(escrow_state.clone())
+    } else {
+        Router::new()
+    };
+
     let app = Router::new()
         .route("/chat", post(chat::chat_handler))
         .route("/api-keys", post(create_api_key))
@@ -829,6 +902,9 @@ async fn run_http(
         .merge(google_public_routes)
         .merge(google_authed_lookup)
         .merge(google_authed_link)
+        .merge(extension_bootstrap_issue_router)
+        .merge(extension_bootstrap_redeem_router)
+        .merge(key_escrow_router)
         .merge(well_known_routes)
         .layer(cors);
 

--- a/mcp/src/oauth/mod.rs
+++ b/mcp/src/oauth/mod.rs
@@ -245,6 +245,19 @@ impl OAuthState {
         code
     }
 
+    /// Accessor for the HS256 encoding key. Used by the extension key-escrow
+    /// module (T15) to mint `aud=extension` JWTs signed by the same secret as
+    /// the main `aud=mcp` flow — a single `MCP_JWT_SECRET` suffices for both.
+    pub fn jwt_encoding_key(&self) -> &EncodingKey {
+        &self.jwt_encoding_key
+    }
+
+    /// Accessor for the HS256 decoding key. Used by the extension key-escrow
+    /// module (T15) to verify `aud=extension` JWTs against the same secret.
+    pub fn jwt_decoding_key(&self) -> &DecodingKey {
+        &self.jwt_decoding_key
+    }
+
     /// Validate redirect_uri against DCR first, then the static fallback list.
     pub fn allows_redirect(&self, uri: &str, client_id: &str) -> bool {
         if self.registered_redirect_allowed(uri, client_id) {
@@ -1295,6 +1308,15 @@ pub async fn bearer_auth_middleware(
         // on this allowlist; it uses standard Bearer-JWT auth so only an
         // already-authenticated webapp can mint tickets for its own user.
         || path.starts_with("/api/cli-bootstrap/redeem/")
+        // Extension bootstrap-ticket redeem endpoint (chrome-extension T15,
+        // Decision 9). Same UUID-as-capability model as cli-bootstrap; the
+        // extension exchanges the ticket for a fresh `aud=extension` JWT
+        // without sending the webapp's `aud=mcp` JWT (which would not be
+        // present in the extension service worker's request context).
+        || path.starts_with("/api/extension-bootstrap/redeem/")
+        // Key-escrow endpoints verify their own `aud=extension` JWTs inline
+        // (the production bearer-auth middleware only accepts `aud=mcp`).
+        || path == "/api/key-escrow"
     {
         return next.run(request).await;
     }

--- a/mcp/tests/key_escrow.rs
+++ b/mcp/tests/key_escrow.rs
@@ -37,7 +37,7 @@ use mnemonic_mcp::{
     escrow::{
         self, extension_bootstrap_issue_handler, extension_bootstrap_redeem_handler,
         key_escrow_delete_handler, key_escrow_get_handler, key_escrow_put_handler,
-        mint_extension_jwt, EscrowState, MIGRATION_SQL,
+        mint_extension_jwt, EscrowState, ExtensionBootstrapTickets, MIGRATION_SQL,
     },
     oauth::{self, OAuthState},
     test_support::mock_state,
@@ -130,6 +130,13 @@ async fn extension_bootstrap_issue_handler_with_claims(
 }
 
 fn make_harness() -> Harness {
+    make_harness_with_tickets(None)
+}
+
+/// Variant of `make_harness` that lets a test inject a custom
+/// `ExtensionBootstrapTickets` (e.g. with `ttl_seconds=0` to drive the
+/// expired-ticket path). `None` uses the production defaults.
+fn make_harness_with_tickets(tickets: Option<Arc<ExtensionBootstrapTickets>>) -> Harness {
     let oauth_state = Arc::new(OAuthState::new(TEST_SECRET));
     let mcp = mock_state();
     // Migrate both tables: T14's google_identity_links first (so the FK in
@@ -140,11 +147,11 @@ fn make_harness() -> Harness {
             .expect("migrate google_identity_links");
         escrow::migrate_key_escrow_blobs(store.conn()).expect("migrate key_escrow_blobs");
     }
-    let escrow_state = Arc::new(EscrowState::new(
-        TEST_RATE_LIMIT,
-        mcp.clone(),
-        oauth_state.clone(),
-    ));
+    let mut state = EscrowState::new(TEST_RATE_LIMIT, mcp.clone(), oauth_state.clone());
+    if let Some(t) = tickets {
+        state.bootstrap_tickets = t;
+    }
+    let escrow_state = Arc::new(state);
     let app = build_app(escrow_state.clone());
     Harness {
         app,
@@ -155,9 +162,16 @@ fn make_harness() -> Harness {
 }
 
 /// Seed a `google_identity_links` row so PUT can pass the binding check.
+///
+/// NOTE: `linked_at` is **unix seconds (INTEGER)** in the actual T14 migration
+/// (`oauth/google.rs::migrate_google_identity_links`), not RFC3339 TEXT as
+/// the original T15 task spec described. T14's schema is the source of
+/// truth; the T15 spec deviation is recorded in `decisions.md` (T15
+/// round-2 entry "linked_at column type"). Tests insert an integer here
+/// to match the real column type.
 fn seed_link(h: &Harness, google_sub: &str, pubkey: &str) {
     let store = h.mcp.store.lock().expect("store mutex");
-    let linked_at = chrono::Utc::now().timestamp();
+    let linked_at: i64 = chrono::Utc::now().timestamp();
     store
         .conn()
         .execute(
@@ -263,6 +277,17 @@ async fn rate_limit_blocks_brute_force() {
         st,
         StatusCode::TOO_MANY_REQUESTS,
         "6th GET must be rate-limited, got {st} body={val:?}"
+    );
+    // Body must carry the fixed `rate_limited` token. A regression that
+    // drops or renames the field (e.g. {"error": null}) would silently
+    // satisfy "any 429" without this assertion. F3 of test-reviewer-round1.
+    let body_err = val
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    assert_eq!(
+        body_err, "rate_limited",
+        "429 body error must be the fixed token 'rate_limited', got {body_err:?}"
     );
     let ra = retry_after.expect("Retry-After header must be set on 429");
     let ra_secs: i64 = ra.parse().expect("Retry-After must be an integer");
@@ -570,4 +595,284 @@ async fn bootstrap_ticket_round_trip_issues_extension_jwt() {
         StatusCode::NOT_FOUND,
         "second redeem of the same ticket must 404"
     );
+}
+
+// ── Round-2 review fixes ─────────────────────────────────────────────────────
+
+/// F1 (test-reviewer round-1, blocker): cross-user DELETE isolation.
+///
+/// User A's `aud=extension` JWT must NOT touch user B's escrow row. The
+/// production code scopes DELETE by `WHERE google_sub = ?` from the
+/// validated JWT claim, so a wrong-identity DELETE simply matches nothing
+/// and returns `removed=0`. This test pins that invariant by reading user
+/// B's row directly from SQLite after the cross-user DELETE attempt — a
+/// regression that drops the `WHERE` clause from the DELETE SQL would
+/// erase user B's row and fail this test.
+#[tokio::test]
+async fn delete_cross_user_isolation() {
+    let h = make_harness();
+    let user_a = Keypair::new();
+    let user_b = Keypair::new();
+    let pk_a = user_a.pubkey().to_string();
+    let pk_b = user_b.pubkey().to_string();
+    let sub_a = "user-cross-delete-a";
+    let sub_b = "user-cross-delete-b";
+    seed_link(&h, sub_a, &pk_a);
+    seed_link(&h, sub_b, &pk_b);
+
+    // User B puts an escrow row.
+    let token_b = mint_extension_jwt(&h.oauth_state, &pk_b, Some(sub_b.to_string())).unwrap();
+    let (st, _) = put_escrow(&h.app, &token_b, put_body(&pk_b)).await;
+    assert_eq!(st, StatusCode::OK, "user B PUT must succeed");
+
+    // User A's token: aud=extension, google_sub=sub_a.
+    let token_a = mint_extension_jwt(&h.oauth_state, &pk_a, Some(sub_a.to_string())).unwrap();
+    let (st, val) = delete_escrow(&h.app, &token_a).await;
+    assert_eq!(
+        st,
+        StatusCode::OK,
+        "DELETE with wrong identity must 200 with removed=0 (not 403), got {st} body={val:?}"
+    );
+    assert_eq!(
+        val["removed"].as_i64().unwrap_or(-1),
+        0,
+        "removed must be 0 — user A's DELETE must not touch user B's row"
+    );
+
+    // Defense: read user B's row directly from SQLite. A regression that
+    // dropped the WHERE clause from delete_escrow would have erased it.
+    let row_exists: bool = {
+        let store = h.mcp.store.lock().expect("store");
+        store
+            .conn()
+            .query_row(
+                "SELECT 1 FROM key_escrow_blobs WHERE google_sub = ?1",
+                params![sub_b],
+                |_r| Ok(true),
+            )
+            .unwrap_or(false)
+    };
+    assert!(
+        row_exists,
+        "user B's escrow row must still exist after user A's cross-user DELETE"
+    );
+}
+
+/// F2 (test-reviewer round-1, blocker): expired bootstrap ticket → 404.
+///
+/// Builds a harness with `ttl_seconds=0` so any ticket issued is already
+/// expired by the time consume() compares `now_unix() >= entry.expires_at`.
+/// Redeem must return 404 with the same body as garbage UUIDs (no oracle).
+#[tokio::test]
+async fn expired_bootstrap_ticket_returns_404() {
+    // ttl=0 → expires_at = now + 0 = now → consume's `now >= expires_at`
+    // is true immediately, so redeem sees the ticket as expired.
+    let tickets = Arc::new(ExtensionBootstrapTickets::new(
+        16, // small LRU cap — irrelevant for this test
+        3,  // per-user cap
+        0,  // ttl_seconds = 0 forces immediate expiry
+    ));
+    let h = make_harness_with_tickets(Some(tickets));
+    let kp = Keypair::new();
+    let pubkey = kp.pubkey().to_string();
+    let google_sub = "user-expired-ticket";
+    seed_link(&h, google_sub, &pubkey);
+
+    // Issue: needs a valid aud=mcp JWT.
+    let mcp_token =
+        oauth::issue_jwt_with_google_sub(&h.oauth_state, &pubkey, Some(google_sub.to_string()))
+            .expect("issue mcp JWT");
+    let issue_req = Request::builder()
+        .method("POST")
+        .uri("/api/extension-bootstrap/issue")
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {mcp_token}"))
+        .body(Body::from(b"{}".to_vec()))
+        .unwrap();
+    let resp = h.app.clone().oneshot(issue_req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK, "issue must succeed");
+    let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let issue_resp: Value = serde_json::from_slice(&body_bytes).unwrap();
+    let ticket = issue_resp["ticket_id"].as_str().unwrap().to_string();
+
+    // Redeem: ticket is already expired (ttl=0).
+    let redeem_req = Request::builder()
+        .method("GET")
+        .uri(format!("/api/extension-bootstrap/redeem/{ticket}"))
+        .body(Body::empty())
+        .unwrap();
+    let resp = h.app.clone().oneshot(redeem_req).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "expired ticket must 404 — same body as garbage UUID (no oracle)"
+    );
+}
+
+/// F5 (test-reviewer round-1, minor): PUT and DELETE must also 401 when the
+/// JWT carries no `google_sub` claim. The existing
+/// `key_escrow_requires_google_sub_claim` covers GET only; this pins the
+/// same invariant for the write verbs.
+#[tokio::test]
+async fn key_escrow_put_and_delete_require_google_sub_claim() {
+    let h = make_harness();
+    let kp = Keypair::new();
+    let pubkey = kp.pubkey().to_string();
+    // aud=extension JWT with NO google_sub claim.
+    let token = mint_extension_jwt(&h.oauth_state, &pubkey, None).expect("issue extension JWT");
+
+    let (st, _) = put_escrow(&h.app, &token, put_body(&pubkey)).await;
+    assert_eq!(
+        st,
+        StatusCode::UNAUTHORIZED,
+        "PUT without google_sub must 401, got {st}"
+    );
+
+    let (st, _) = delete_escrow(&h.app, &token).await;
+    assert_eq!(
+        st,
+        StatusCode::UNAUTHORIZED,
+        "DELETE without google_sub must 401, got {st}"
+    );
+}
+
+/// F7 (test-reviewer round-1, minor): per-user bootstrap-ticket cap is
+/// reached at the 4th issue.
+///
+/// Issues 3 tickets for the same `aud=mcp` sub, asserts all 200; the 4th
+/// must return 429 with the fixed `too_many_pending_tickets` body token.
+/// Defense in depth against the T15-M-02 attack where expired tickets
+/// otherwise pinned the counter (fix: insert-time expired-ticket sweep,
+/// also exercised below).
+#[tokio::test]
+async fn bootstrap_per_user_cap_blocks_fourth_ticket() {
+    let h = make_harness();
+    let kp = Keypair::new();
+    let pubkey = kp.pubkey().to_string();
+    let google_sub = "user-percap-1";
+    let mcp_token =
+        oauth::issue_jwt_with_google_sub(&h.oauth_state, &pubkey, Some(google_sub.to_string()))
+            .expect("issue mcp JWT");
+
+    async fn one_issue(app: &Router, token: &str) -> (StatusCode, Value) {
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/extension-bootstrap/issue")
+            .header("content-type", "application/json")
+            .header("authorization", format!("Bearer {token}"))
+            .body(Body::from(b"{}".to_vec()))
+            .unwrap();
+        let resp = app.clone().oneshot(req).await.unwrap();
+        let status = resp.status();
+        let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+        let parsed: Value = serde_json::from_slice(&body_bytes).unwrap_or(Value::Null);
+        (status, parsed)
+    }
+
+    for i in 0..3 {
+        let (st, val) = one_issue(&h.app, &mcp_token).await;
+        assert_eq!(
+            st,
+            StatusCode::OK,
+            "issue #{} of 3 must 200, got {st} body={val:?}",
+            i + 1
+        );
+    }
+    let (st, val) = one_issue(&h.app, &mcp_token).await;
+    assert_eq!(
+        st,
+        StatusCode::TOO_MANY_REQUESTS,
+        "4th issue must 429, got {st} body={val:?}"
+    );
+    let err = val.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert_eq!(
+        err, "too_many_pending_tickets",
+        "429 body must be the fixed opaque token (no constant leak), got {err:?}"
+    );
+}
+
+/// Round-1 finding T15-M-02 (security-auditor): after 3 expired tickets
+/// the user must be able to issue again. The insert-time sweep removes
+/// expired entries belonging to the same `jwt_sub` BEFORE counting toward
+/// the cap, so a self-DoS via three-then-wait is prevented.
+#[tokio::test]
+async fn expired_tickets_do_not_pin_per_user_counter() {
+    // ttl=0 → tickets are expired as soon as they're inserted.
+    let tickets = Arc::new(ExtensionBootstrapTickets::new(16, 3, 0));
+    let h = make_harness_with_tickets(Some(tickets));
+    let kp = Keypair::new();
+    let pubkey = kp.pubkey().to_string();
+    let google_sub = "user-expsweep-1";
+    let mcp_token =
+        oauth::issue_jwt_with_google_sub(&h.oauth_state, &pubkey, Some(google_sub.to_string()))
+            .expect("issue mcp JWT");
+
+    let do_issue = |token: String| {
+        let app = h.app.clone();
+        async move {
+            let req = Request::builder()
+                .method("POST")
+                .uri("/api/extension-bootstrap/issue")
+                .header("content-type", "application/json")
+                .header("authorization", format!("Bearer {token}"))
+                .body(Body::from(b"{}".to_vec()))
+                .unwrap();
+            app.oneshot(req).await.unwrap().status()
+        }
+    };
+
+    // Burn 3 tickets — they all expire immediately (ttl=0). Without the
+    // round-2 sweep, the per_user counter would stick at 3 and the 4th
+    // issue would 429. With the sweep, the 4th issue must 200.
+    for _ in 0..3 {
+        assert_eq!(do_issue(mcp_token.clone()).await, StatusCode::OK);
+    }
+    let st = do_issue(mcp_token.clone()).await;
+    assert_eq!(
+        st,
+        StatusCode::OK,
+        "4th issue must 200 — expired tickets must NOT pin the per-user counter \
+         (T15-M-02 round-1 finding)"
+    );
+}
+
+/// Round-1 finding T15-L-02 (security-auditor): explicit cross-user
+/// isolation on GET. User A's `aud=extension` JWT must not return user B's
+/// escrow row even if both users have rows. The production code reads
+/// `google_sub` only from the validated JWT claim, never from the request
+/// body — this test pins the invariant for future refactors.
+#[tokio::test]
+async fn get_cross_user_isolation() {
+    let h = make_harness();
+    let user_a = Keypair::new();
+    let user_b = Keypair::new();
+    let pk_a = user_a.pubkey().to_string();
+    let pk_b = user_b.pubkey().to_string();
+    let sub_a = "user-cross-get-a";
+    let sub_b = "user-cross-get-b";
+    seed_link(&h, sub_a, &pk_a);
+    seed_link(&h, sub_b, &pk_b);
+
+    // Only user B has an escrow row.
+    let token_b = mint_extension_jwt(&h.oauth_state, &pk_b, Some(sub_b.to_string())).unwrap();
+    let (st, _) = put_escrow(&h.app, &token_b, put_body(&pk_b)).await;
+    assert_eq!(st, StatusCode::OK, "user B PUT must succeed");
+
+    // User A's GET — must 404 (no row for sub_a). MUST NOT return user B's
+    // ciphertext under any circumstance.
+    let token_a = mint_extension_jwt(&h.oauth_state, &pk_a, Some(sub_a.to_string())).unwrap();
+    let (st, _ra, val) = get_escrow(&h.app, &token_a).await;
+    assert_eq!(
+        st,
+        StatusCode::NOT_FOUND,
+        "user A GET must 404 when only user B has a row, got {st} body={val:?}"
+    );
+    // Defense: even on 200 (future refactor regression), the body MUST NOT
+    // carry user B's pubkey.
+    if let Some(pk) = val.get("pubkey_base58").and_then(|v| v.as_str()) {
+        assert_ne!(
+            pk, pk_b,
+            "user A's GET response must NEVER contain user B's pubkey"
+        );
+    }
 }

--- a/mcp/tests/key_escrow.rs
+++ b/mcp/tests/key_escrow.rs
@@ -1,0 +1,573 @@
+//! Integration tests for the chrome-extension key-escrow endpoints (T15
+//! of `work/chrome-extension/`). Drives Decision 9 end-to-end:
+//!
+//! - **rate_limit_blocks_brute_force** — issue 5 GETs, 6th returns 429 with
+//!   `Retry-After`. Bounds online brute-force on the encrypted blob (the
+//!   Argon2id KDF bounds the offline brute-force; this test pins the online
+//!   side).
+//! - **pubkey_binding_enforced** — PUT with `pubkey_base58 !=
+//!   linked_owner_pubkey` returns 403. Closes the stolen-Google-account →
+//!   swap-key attack.
+//! - **server_never_stores_plaintext** — the migration SQL contains only
+//!   ciphertext + opaque KDF params + bound pubkey. No `plaintext_key` /
+//!   `secret_key` / `seed` field. Asserts D9's zero-knowledge property at
+//!   the schema level.
+//! - PUT then GET round-trip returns identical bytes.
+//! - Stale 24h window seeded into `last_fetch_at` → counter resets, GET
+//!   succeeds.
+//! - DELETE removes the row; subsequent GET → 404.
+//! - PUT without prior `google_identity_links` row → 403.
+//!
+//! Run with: `cargo test -p mnemonic-mcp --features test-support
+//!            --test key_escrow -- --nocapture`
+
+#![cfg(feature = "test-support")]
+
+use std::sync::Arc;
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+    routing::{get, post},
+    Router,
+};
+use base64::Engine as _;
+use http_body_util::BodyExt;
+use mnemonic_mcp::{
+    escrow::{
+        self, extension_bootstrap_issue_handler, extension_bootstrap_redeem_handler,
+        key_escrow_delete_handler, key_escrow_get_handler, key_escrow_put_handler,
+        mint_extension_jwt, EscrowState, MIGRATION_SQL,
+    },
+    oauth::{self, OAuthState},
+    test_support::mock_state,
+};
+use rusqlite::params;
+use serde_json::Value;
+use solana_sdk::signature::{Keypair, Signer};
+use tower::ServiceExt;
+
+const TEST_SECRET: &[u8; 32] = b"key-escrow-test-secret-32-bytes!";
+const TEST_RATE_LIMIT: u32 = 5;
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+
+struct Harness {
+    app: Router,
+    escrow_state: Arc<EscrowState>,
+    oauth_state: Arc<OAuthState>,
+    mcp: Arc<mnemonic_mcp::mcp::McpState>,
+}
+
+fn build_app(escrow_state: Arc<EscrowState>) -> Router {
+    // Same routing as production main.rs, minus the bearer-auth middleware on
+    // /issue (we mint the issue-time `aud=mcp` JWT inline in each test and
+    // simulate the Claims extension via a thin wrapper). This keeps the
+    // integration tests independent of the global middleware setup.
+    let issue_router = Router::new()
+        .route(
+            "/api/extension-bootstrap/issue",
+            post(extension_bootstrap_issue_handler_with_claims),
+        )
+        .with_state(escrow_state.clone());
+    let redeem_router = Router::new()
+        .route(
+            "/api/extension-bootstrap/redeem/{ticket}",
+            get(extension_bootstrap_redeem_handler),
+        )
+        .with_state(escrow_state.clone());
+    let key_escrow_router = Router::new()
+        .route(
+            "/api/key-escrow",
+            axum::routing::put(key_escrow_put_handler)
+                .get(key_escrow_get_handler)
+                .delete(key_escrow_delete_handler),
+        )
+        .with_state(escrow_state);
+    Router::new()
+        .merge(issue_router)
+        .merge(redeem_router)
+        .merge(key_escrow_router)
+}
+
+/// Test-side wrapper around `extension_bootstrap_issue_handler` that manually
+/// verifies the `aud=mcp` Bearer JWT (the production bearer-auth middleware
+/// does this in main.rs; we recreate the contract inline so tests don't have
+/// to thread the middleware).
+async fn extension_bootstrap_issue_handler_with_claims(
+    axum::extract::State(state): axum::extract::State<Arc<EscrowState>>,
+    headers: axum::http::HeaderMap,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    let token = match headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(|s| s.trim())
+    {
+        Some(t) if !t.is_empty() => t.to_string(),
+        _ => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                axum::Json(serde_json::json!({"error": "missing Bearer JWT"})),
+            )
+                .into_response()
+        }
+    };
+    let claims = match oauth::verify_jwt(&state.oauth, &token) {
+        Ok(c) => c,
+        Err(e) => {
+            return (
+                StatusCode::UNAUTHORIZED,
+                axum::Json(serde_json::json!({"error": format!("invalid JWT: {e}")})),
+            )
+                .into_response()
+        }
+    };
+    // Re-build a request with Extension<Claims> set and dispatch.
+    extension_bootstrap_issue_handler(axum::extract::State(state.clone()), axum::Extension(claims))
+        .await
+}
+
+fn make_harness() -> Harness {
+    let oauth_state = Arc::new(OAuthState::new(TEST_SECRET));
+    let mcp = mock_state();
+    // Migrate both tables: T14's google_identity_links first (so the FK in
+    // key_escrow_blobs can resolve), then T15's key_escrow_blobs.
+    {
+        let store = mcp.store.lock().expect("store mutex");
+        oauth::google::migrate_google_identity_links(store.conn())
+            .expect("migrate google_identity_links");
+        escrow::migrate_key_escrow_blobs(store.conn()).expect("migrate key_escrow_blobs");
+    }
+    let escrow_state = Arc::new(EscrowState::new(
+        TEST_RATE_LIMIT,
+        mcp.clone(),
+        oauth_state.clone(),
+    ));
+    let app = build_app(escrow_state.clone());
+    Harness {
+        app,
+        escrow_state,
+        oauth_state,
+        mcp,
+    }
+}
+
+/// Seed a `google_identity_links` row so PUT can pass the binding check.
+fn seed_link(h: &Harness, google_sub: &str, pubkey: &str) {
+    let store = h.mcp.store.lock().expect("store mutex");
+    let linked_at = chrono::Utc::now().timestamp();
+    store
+        .conn()
+        .execute(
+            "INSERT INTO google_identity_links (google_sub, pubkey_base58, linked_at) \
+             VALUES (?1, ?2, ?3)",
+            params![google_sub, pubkey, linked_at],
+        )
+        .expect("seed google_identity_links");
+}
+
+// ── HTTP helpers ─────────────────────────────────────────────────────────────
+
+async fn put_escrow(app: &Router, token: &str, body: Value) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("PUT")
+        .uri("/api/key-escrow")
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let parsed: Value = serde_json::from_slice(&body_bytes).unwrap_or(Value::Null);
+    (status, parsed)
+}
+
+async fn get_escrow(app: &Router, token: &str) -> (StatusCode, Option<String>, Value) {
+    let req = Request::builder()
+        .method("GET")
+        .uri("/api/key-escrow")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let retry_after = resp
+        .headers()
+        .get("Retry-After")
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.to_string());
+    let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let parsed: Value = serde_json::from_slice(&body_bytes).unwrap_or(Value::Null);
+    (status, retry_after, parsed)
+}
+
+async fn delete_escrow(app: &Router, token: &str) -> (StatusCode, Value) {
+    let req = Request::builder()
+        .method("DELETE")
+        .uri("/api/key-escrow")
+        .header("authorization", format!("Bearer {token}"))
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let parsed: Value = serde_json::from_slice(&body_bytes).unwrap_or(Value::Null);
+    (status, parsed)
+}
+
+fn put_body(pubkey: &str) -> Value {
+    let ct = b"\xfe\xed\xfa\xce\xde\xad\xbe\xef".to_vec();
+    let nonce = (0..12u8).collect::<Vec<u8>>();
+    serde_json::json!({
+        "ciphertext_b64": base64::engine::general_purpose::STANDARD.encode(&ct),
+        "nonce_b64": base64::engine::general_purpose::STANDARD.encode(&nonce),
+        "kdf": "argon2id",
+        "kdf_params": r#"{"m":65536,"t":3,"p":1,"s":"YWFhYWFhYWFhYWFhYWFhYQ=="}"#,
+        "pubkey_base58": pubkey,
+    })
+}
+
+// ── TDD anchor #1: rate-limit blocks brute force ─────────────────────────────
+
+#[tokio::test]
+async fn rate_limit_blocks_brute_force() {
+    let h = make_harness();
+    let kp = Keypair::new();
+    let pubkey = kp.pubkey().to_string();
+    let google_sub = "user-rate-limit-1";
+    seed_link(&h, google_sub, &pubkey);
+
+    let token = mint_extension_jwt(&h.oauth_state, &pubkey, Some(google_sub.to_string())).unwrap();
+
+    // PUT once to populate the row. The PUT resets the counter.
+    let (st, _) = put_escrow(&h.app, &token, put_body(&pubkey)).await;
+    assert_eq!(st, StatusCode::OK, "initial PUT must succeed");
+
+    // TEST_RATE_LIMIT=5 GETs are allowed.
+    for i in 0..TEST_RATE_LIMIT {
+        let (st, _ra, _val) = get_escrow(&h.app, &token).await;
+        assert_eq!(
+            st,
+            StatusCode::OK,
+            "GET #{} (1-indexed) within the cap must succeed, got {st}",
+            i + 1
+        );
+    }
+
+    // The (cap+1)th GET must return 429 with a Retry-After header.
+    let (st, retry_after, val) = get_escrow(&h.app, &token).await;
+    assert_eq!(
+        st,
+        StatusCode::TOO_MANY_REQUESTS,
+        "6th GET must be rate-limited, got {st} body={val:?}"
+    );
+    let ra = retry_after.expect("Retry-After header must be set on 429");
+    let ra_secs: i64 = ra.parse().expect("Retry-After must be an integer");
+    assert!(
+        ra_secs > 0 && ra_secs <= 24 * 3600,
+        "Retry-After must be in (0, 24h], got {ra_secs}"
+    );
+}
+
+// ── TDD anchor #2: pubkey binding enforced ───────────────────────────────────
+
+#[tokio::test]
+async fn pubkey_binding_enforced() {
+    let h = make_harness();
+    let owner = Keypair::new();
+    let attacker = Keypair::new();
+    let owner_pubkey = owner.pubkey().to_string();
+    let attacker_pubkey = attacker.pubkey().to_string();
+    let google_sub = "user-binding-1";
+    seed_link(&h, google_sub, &owner_pubkey);
+
+    let token =
+        mint_extension_jwt(&h.oauth_state, &owner_pubkey, Some(google_sub.to_string())).unwrap();
+
+    // PUT with the wrong pubkey_base58 — must 403 even though the JWT carries
+    // a matching google_sub (an attacker who phished the Google account can
+    // mint the JWT but cannot rebind the on-chain identity).
+    let (st, val) = put_escrow(&h.app, &token, put_body(&attacker_pubkey)).await;
+    assert_eq!(
+        st,
+        StatusCode::FORBIDDEN,
+        "PUT with mismatched pubkey must 403, got {st} body={val:?}"
+    );
+    let msg = val.get("error").and_then(|v| v.as_str()).unwrap_or("");
+    assert!(
+        msg.contains("pubkey_base58") || msg.contains("linked"),
+        "403 body should mention the binding mismatch, got {msg}"
+    );
+
+    // Sanity: the correct pubkey works.
+    let (st, _) = put_escrow(&h.app, &token, put_body(&owner_pubkey)).await;
+    assert_eq!(st, StatusCode::OK, "PUT with matching pubkey must 200");
+}
+
+// ── TDD anchor #3: server never stores plaintext (schema audit) ──────────────
+
+#[tokio::test]
+async fn server_never_stores_plaintext() {
+    // Direct schema-level audit: the migration SQL must not contain any
+    // column name that suggests plaintext key storage. This is a static
+    // check on the source-of-truth migration string, so it catches a future
+    // refactor that adds an unintended plaintext-leaking column.
+    let lower = MIGRATION_SQL.to_lowercase();
+    for forbidden in [
+        "plaintext",
+        "plaintext_key",
+        "secret_key",
+        "secret_seed",
+        " seed ",
+        "raw_key",
+        "private_key",
+        "unencrypted",
+    ] {
+        assert!(
+            !lower.contains(forbidden),
+            "migration SQL must not mention {forbidden:?} (zero-knowledge property — D9); migration: {MIGRATION_SQL}"
+        );
+    }
+    // Sanity: the migration DOES carry the opaque storage columns.
+    for required in ["ciphertext", "nonce", "kdf", "kdf_params", "pubkey_base58"] {
+        assert!(
+            lower.contains(required),
+            "migration SQL must include {required:?} column"
+        );
+    }
+}
+
+// ── Round-trip + lifecycle ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn put_then_get_round_trip_identical_bytes() {
+    let h = make_harness();
+    let kp = Keypair::new();
+    let pubkey = kp.pubkey().to_string();
+    let google_sub = "user-roundtrip-1";
+    seed_link(&h, google_sub, &pubkey);
+
+    let token = mint_extension_jwt(&h.oauth_state, &pubkey, Some(google_sub.to_string())).unwrap();
+    let body = put_body(&pubkey);
+    let (st, _) = put_escrow(&h.app, &token, body.clone()).await;
+    assert_eq!(st, StatusCode::OK);
+
+    let (st, _ra, val) = get_escrow(&h.app, &token).await;
+    assert_eq!(st, StatusCode::OK, "GET must succeed; body={val:?}");
+    assert_eq!(val["ciphertext_b64"], body["ciphertext_b64"]);
+    assert_eq!(val["nonce_b64"], body["nonce_b64"]);
+    assert_eq!(val["kdf"], body["kdf"]);
+    assert_eq!(val["kdf_params"], body["kdf_params"]);
+    assert_eq!(val["pubkey_base58"], body["pubkey_base58"]);
+}
+
+#[tokio::test]
+async fn stale_window_resets_counter() {
+    // Seed last_fetch_at to >24h ago so the rolling-window reset path fires
+    // (T15 spec calls this out). Counter should reset to 1 on the next GET
+    // and the user gets a fresh budget of TEST_RATE_LIMIT - 1 more fetches.
+    let h = make_harness();
+    let kp = Keypair::new();
+    let pubkey = kp.pubkey().to_string();
+    let google_sub = "user-stale-window-1";
+    seed_link(&h, google_sub, &pubkey);
+    let token = mint_extension_jwt(&h.oauth_state, &pubkey, Some(google_sub.to_string())).unwrap();
+
+    let (st, _) = put_escrow(&h.app, &token, put_body(&pubkey)).await;
+    assert_eq!(st, StatusCode::OK);
+
+    // Burn the entire rate-limit budget.
+    for _ in 0..TEST_RATE_LIMIT {
+        let (st, _, _) = get_escrow(&h.app, &token).await;
+        assert_eq!(st, StatusCode::OK);
+    }
+    // Next GET must 429.
+    let (st, _, _) = get_escrow(&h.app, &token).await;
+    assert_eq!(st, StatusCode::TOO_MANY_REQUESTS);
+
+    // Seed last_fetch_at to 25h ago so the next GET sees an elapsed window.
+    {
+        let store = h.mcp.store.lock().unwrap();
+        let twenty_five_h_ago = (chrono::Utc::now() - chrono::Duration::hours(25)).to_rfc3339();
+        store
+            .conn()
+            .execute(
+                "UPDATE key_escrow_blobs SET last_fetch_at = ?1 WHERE google_sub = ?2",
+                params![twenty_five_h_ago, google_sub],
+            )
+            .unwrap();
+    }
+
+    // GET must succeed and reset the counter to 1.
+    let (st, _, _) = get_escrow(&h.app, &token).await;
+    assert_eq!(
+        st,
+        StatusCode::OK,
+        "GET after 24h window elapse must succeed"
+    );
+
+    // Verify the counter is back to 1 (defense: read directly from SQLite).
+    let counter: i64 = {
+        let store = h.mcp.store.lock().unwrap();
+        store
+            .conn()
+            .query_row(
+                "SELECT fetch_count_24h FROM key_escrow_blobs WHERE google_sub = ?1",
+                params![google_sub],
+                |r| r.get::<_, i64>(0),
+            )
+            .unwrap()
+    };
+    assert_eq!(
+        counter, 1,
+        "counter must reset to 1 after stale-window GET, got {counter}"
+    );
+}
+
+#[tokio::test]
+async fn delete_removes_row_subsequent_get_404() {
+    let h = make_harness();
+    let kp = Keypair::new();
+    let pubkey = kp.pubkey().to_string();
+    let google_sub = "user-delete-1";
+    seed_link(&h, google_sub, &pubkey);
+    let token = mint_extension_jwt(&h.oauth_state, &pubkey, Some(google_sub.to_string())).unwrap();
+
+    let (st, _) = put_escrow(&h.app, &token, put_body(&pubkey)).await;
+    assert_eq!(st, StatusCode::OK);
+
+    let (st, val) = delete_escrow(&h.app, &token).await;
+    assert_eq!(st, StatusCode::OK, "DELETE must 200, got {st} body={val:?}");
+    assert_eq!(val["removed"].as_i64().unwrap_or(-1), 1);
+
+    let (st, _, _) = get_escrow(&h.app, &token).await;
+    assert_eq!(st, StatusCode::NOT_FOUND, "GET after DELETE must 404");
+
+    // Idempotent: a second DELETE returns 200 with removed=0.
+    let (st, val) = delete_escrow(&h.app, &token).await;
+    assert_eq!(st, StatusCode::OK);
+    assert_eq!(val["removed"].as_i64().unwrap_or(-1), 0);
+}
+
+#[tokio::test]
+async fn put_without_prior_google_identity_link_403() {
+    // No seed_link — the FK target row is missing. Even with a valid JWT
+    // carrying a matching `google_sub`, PUT must 403 (app-level check fires
+    // before the FK violation hits the DB).
+    let h = make_harness();
+    let kp = Keypair::new();
+    let pubkey = kp.pubkey().to_string();
+    let google_sub = "user-no-link-1";
+    let token = mint_extension_jwt(&h.oauth_state, &pubkey, Some(google_sub.to_string())).unwrap();
+    let (st, val) = put_escrow(&h.app, &token, put_body(&pubkey)).await;
+    assert_eq!(
+        st,
+        StatusCode::FORBIDDEN,
+        "PUT without link must 403, got {st} body={val:?}"
+    );
+}
+
+// ── JWT audience + auth negative tests ───────────────────────────────────────
+
+#[tokio::test]
+async fn key_escrow_rejects_mcp_aud_jwt() {
+    // A standard `aud=mcp` JWT (issued by the production OAuth flow) must
+    // NOT be accepted at the escrow endpoints — they require `aud=extension`.
+    let h = make_harness();
+    let kp = Keypair::new();
+    let pubkey = kp.pubkey().to_string();
+    let google_sub = "user-aud-1";
+    seed_link(&h, google_sub, &pubkey);
+
+    let mcp_token =
+        oauth::issue_jwt_with_google_sub(&h.oauth_state, &pubkey, Some(google_sub.to_string()))
+            .expect("issue mcp JWT");
+    let (st, _, _) = get_escrow(&h.app, &mcp_token).await;
+    assert_eq!(
+        st,
+        StatusCode::UNAUTHORIZED,
+        "aud=mcp JWT must NOT be accepted on /api/key-escrow"
+    );
+    let _ = &h.escrow_state; // suppress unused warning under cfg
+}
+
+#[tokio::test]
+async fn key_escrow_requires_google_sub_claim() {
+    let h = make_harness();
+    let kp = Keypair::new();
+    let pubkey = kp.pubkey().to_string();
+    // Mint an aud=extension JWT with NO google_sub claim — must 401.
+    let token = mint_extension_jwt(&h.oauth_state, &pubkey, None).expect("issue extension JWT");
+    let (st, _, val) = get_escrow(&h.app, &token).await;
+    assert_eq!(
+        st,
+        StatusCode::UNAUTHORIZED,
+        "JWT without google_sub must 401, got {st} body={val:?}"
+    );
+}
+
+// ── Bootstrap-ticket round-trip ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn bootstrap_ticket_round_trip_issues_extension_jwt() {
+    // Issue a ticket (with an aud=mcp JWT) → redeem → assert the response
+    // body carries an aud=extension JWT that verifies under the same secret.
+    let h = make_harness();
+    let kp = Keypair::new();
+    let pubkey = kp.pubkey().to_string();
+    let google_sub = "user-bootstrap-1";
+    seed_link(&h, google_sub, &pubkey);
+
+    let mcp_token =
+        oauth::issue_jwt_with_google_sub(&h.oauth_state, &pubkey, Some(google_sub.to_string()))
+            .expect("issue mcp JWT");
+    let issue_req = Request::builder()
+        .method("POST")
+        .uri("/api/extension-bootstrap/issue")
+        .header("content-type", "application/json")
+        .header("authorization", format!("Bearer {mcp_token}"))
+        .body(Body::from(b"{}".to_vec()))
+        .unwrap();
+    let resp = h.app.clone().oneshot(issue_req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let issue_resp: Value = serde_json::from_slice(&body_bytes).unwrap();
+    let ticket = issue_resp["ticket_id"].as_str().unwrap().to_string();
+
+    // Redeem: no auth header.
+    let redeem_req = Request::builder()
+        .method("GET")
+        .uri(format!("/api/extension-bootstrap/redeem/{ticket}"))
+        .body(Body::empty())
+        .unwrap();
+    let resp = h.app.clone().oneshot(redeem_req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body_bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let redeem_resp: Value = serde_json::from_slice(&body_bytes).unwrap();
+    assert_eq!(redeem_resp["aud"].as_str(), Some("extension"));
+    let ext_token = redeem_resp["access_token"].as_str().unwrap().to_string();
+
+    // The extension JWT must work against /api/key-escrow.
+    let (st, _) = put_escrow(&h.app, &ext_token, put_body(&pubkey)).await;
+    assert_eq!(
+        st,
+        StatusCode::OK,
+        "PUT with redeemed extension JWT must 200"
+    );
+
+    // Second redeem of the SAME ticket → 404 (single-use).
+    let redeem_req2 = Request::builder()
+        .method("GET")
+        .uri(format!("/api/extension-bootstrap/redeem/{ticket}"))
+        .body(Body::empty())
+        .unwrap();
+    let resp = h.app.clone().oneshot(redeem_req2).await.unwrap();
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "second redeem of the same ticket must 404"
+    );
+}

--- a/work/chrome-extension/decisions.md
+++ b/work/chrome-extension/decisions.md
@@ -446,3 +446,151 @@ Total: 8 oauth_google tests (4 original + 4 new) pass locally; clippy
 invocation).
 
 ---
+
+## 2026-05-11 · T15 — Server key-escrow + extension-bootstrap endpoints land; awaiting CI verify
+
+`mcp/src/escrow.rs` + `mcp/tests/key_escrow.rs` ship the server side
+of Decision 9 (encrypted key escrow). Five HTTP endpoints under
+`/api/extension-bootstrap/*` and `/api/key-escrow`:
+
+- `POST /api/extension-bootstrap/issue` — auth: `aud=mcp` Bearer JWT
+  (enforced by the existing bearer-auth middleware). Mints a UUID
+  ticket bound to `(jwt_sub, google_sub)` with 10-min TTL, LRU 10k,
+  per-user cap 3. Mirrors the existing cli-bootstrap flow.
+- `GET /api/extension-bootstrap/redeem/{ticket}` — no auth (UUID is
+  the capability, same model as cli-bootstrap; URI-allowlisted in the
+  bearer-auth middleware). Pops the ticket atomically; on success
+  returns `{access_token, aud="extension", expires_in}` where
+  `access_token` is a fresh HS256 JWT signed with the same
+  `MCP_JWT_SECRET` as the production OAuth flow. Single-use; second
+  redeem of the same ticket → 404.
+- `PUT /api/key-escrow` — auth: `aud=extension` JWT with `google_sub`,
+  verified inline. Validates `pubkey_base58` matches the linked
+  `pubkey_base58` in `google_identity_links` (binding check). Atomic
+  `INSERT ... ON CONFLICT DO UPDATE` UPSERT; resets
+  `fetch_count_24h=0` and `last_fetch_at=NULL` on every PUT.
+- `GET /api/key-escrow` — auth: same. Single critical section: reads
+  the row, checks rate limit (5 GETs / 24h rolling window per
+  `google_sub`, configurable via `KEY_ESCROW_RATE_LIMIT`),
+  atomically increments via a single SQL `UPDATE ... CASE` that does
+  both the reset-on-elapsed and bump-in-window in one statement.
+  Returns 429 with `Retry-After: <seconds_until_window_resets>` once
+  the cap is exceeded.
+- `DELETE /api/key-escrow` — auth: same. Hard delete (D9 explicit
+  revocation); idempotent (200 with `removed: 0` on second call).
+
+**Key implementation deviations + clarifications:**
+
+- **Migration lives in `mcp/`, NOT `core/`** (deviation from the T15
+  task spec). The original spec said `core/src/storage/sqlite.rs`;
+  but per CLAUDE.md and Decision 9 the OAuth/escrow tables are
+  server concerns, and T14 already set the precedent by putting
+  `google_identity_links` in `oauth/google.rs::migrate_google_identity_links`.
+  The new `escrow::migrate_key_escrow_blobs` mirrors that pattern
+  and runs at startup alongside the T14 migration (only when
+  `GOOGLE_OAUTH_CLIENT_ID` is set — the FK in `key_escrow_blobs`
+  references `google_identity_links`, so both tables move together).
+  `core/` remains untouched.
+
+- **Schema-level zero-knowledge audit.** The migration string lives
+  as `pub const MIGRATION_SQL: &str` in `mcp/src/escrow.rs` so the
+  T15 TDD anchor `server_never_stores_plaintext` can read it via the
+  library facade and assert that no plaintext-leaking column name is
+  present (`plaintext`, `secret_key`, `secret_seed`, `raw_key`,
+  `private_key`, `unencrypted`, ` seed `). The same test also
+  positively asserts presence of the opaque columns (`ciphertext`,
+  `nonce`, `kdf`, `kdf_params`, `pubkey_base58`). This is a compile-
+  time-stable invariant that catches a future refactor that adds an
+  unintended plaintext column.
+
+- **`aud=extension` JWT split.** A fresh audience separate from the
+  production `aud=mcp` audience means the bearer-auth middleware on
+  `/mcp` rejects extension JWTs cleanly — they only validate at the
+  escrow endpoints, which verify inline via `extract_extension_claims`.
+  Both JWT shapes share a signing key (the same `MCP_JWT_SECRET` /
+  HS256) so the server only needs one secret to rotate. The new
+  `OAuthState::jwt_encoding_key()` / `jwt_decoding_key()` accessors
+  expose the key to the escrow module.
+
+- **Single source of truth for `KEY_ESCROW_RATE_LIMIT`.** `Config`
+  reads the env value once at startup; `main.rs::run_http` threads it
+  through a new `ExtensionSettings` struct (sibling of
+  `GoogleOAuthSettings`). No downstream `std::env::var` re-reads —
+  matches T14's round-2 fix #2.
+
+- **Atomic counter UPDATE.** The rate-limit increment is a single SQL
+  statement, not READ-then-WRITE. Two concurrent GETs both observe
+  the SAME pre-update count and both write `count = old + 1`, so the
+  counter cannot drift under race. The CASE expression handles
+  reset-on-elapsed + in-window-bump in one go.
+
+- **No in-memory rate-limit map** — the DB row IS the per-user
+  counter. This avoids the unbounded HashMap class of issues that
+  T14 round-2 had to LRU-bound. The DB row already has a primary key
+  so memory pressure is naturally bounded.
+
+- **Pubkey binding is enforced server-side, not via FK.** The PUT
+  handler explicitly looks up `google_identity_links.pubkey_base58`
+  before UPSERT and 403s on mismatch (with a generic error message
+  that doesn't leak the linked pubkey). The FK on the schema
+  cascades on DELETE of the parent row, which is a cleanup nicety,
+  not the security boundary.
+
+- **DELETE is hard.** No soft-delete column. The user's explicit
+  revocation removes the row permanently; on next PUT the rate-limit
+  counter starts fresh from zero. Matches D9's "explicit revocation"
+  language.
+
+**Endpoint allowlist additions** in `oauth::bearer_auth_middleware`:
+
+- `/api/extension-bootstrap/redeem/` — UUID-as-capability path,
+  bypasses bearer-auth.
+- `/api/key-escrow` — verifies its own `aud=extension` JWT inline.
+
+**TDD anchors implemented (all 10 tests pass locally):**
+
+- `mcp/tests/key_escrow.rs::rate_limit_blocks_brute_force` (TDD #1):
+  burns the 5-GET budget, asserts the 6th GET returns 429 with a
+  positive `Retry-After` header capped at 24h.
+- `mcp/tests/key_escrow.rs::pubkey_binding_enforced` (TDD #2):
+  PUT with a different `pubkey_base58` than the linked
+  `google_identity_links` row → 403; PUT with the correct pubkey →
+  200.
+- `mcp/tests/key_escrow.rs::server_never_stores_plaintext` (TDD #3):
+  Schema audit against the `MIGRATION_SQL` const.
+- `put_then_get_round_trip_identical_bytes`: end-to-end byte-identical
+  round-trip.
+- `stale_window_resets_counter`: seeds `last_fetch_at` to 25h ago via
+  direct SQL, asserts the next GET succeeds and the counter resets
+  to 1.
+- `delete_removes_row_subsequent_get_404`: GET after DELETE → 404;
+  second DELETE → 200 with `removed: 0` (idempotent).
+- `put_without_prior_google_identity_link_403`: app-level binding
+  check fires before any DB FK violation.
+- `key_escrow_rejects_mcp_aud_jwt`: an `aud=mcp` JWT must not be
+  accepted on `/api/key-escrow` (audience split is enforced).
+- `key_escrow_requires_google_sub_claim`: an `aud=extension` JWT
+  without `google_sub` → 401.
+- `bootstrap_ticket_round_trip_issues_extension_jwt`: full handshake
+  → issue ticket with `aud=mcp` JWT → redeem (no auth) → get
+  `aud=extension` JWT → use that on `/api/key-escrow` → second redeem
+  of same ticket → 404.
+
+**Cargo.toml gate.** Mirrors T14: `[[test]] name = "key_escrow"`
+with `required-features = ["test-support"]` so omitting the feature
+flag produces a clear "test requires feature" message instead of
+silently `0 tests`.
+
+Task `15.md` held at `status: in_review` with `blocked_on: ci-verify`
+per D13 — flips to `done` only after the PR's CI run reports green.
+
+**Note for downstream tasks.** The extension client side (T13's
+seed-restore flow + popup) calls these endpoints with the redeemed
+`aud=extension` JWT and the WASM `argon2id_wrap` helper builds the
+PUT body. The schema is opaque to the server beyond the format
+checks in `key_escrow_put_handler` (length bounds on each field,
+non-empty ciphertext, base64-decodable nonce). When T18 (cloud sync)
+needs a per-user revocation hook, it can reuse `DELETE /api/key-escrow`
+without server changes.
+
+---

--- a/work/chrome-extension/decisions.md
+++ b/work/chrome-extension/decisions.md
@@ -594,3 +594,149 @@ needs a per-user revocation hook, it can reuse `DELETE /api/key-escrow`
 without server changes.
 
 ---
+
+## 2026-05-11 · T15 — Round-2 review fixes applied (PR #114)
+
+Three reviewer agents ran round 1 against the T15 commit
+(`73cdd8f feat(mcp): T15 — extension-bootstrap + key-escrow endpoints +
+migrations`). Reports landed at
+`work/chrome-extension/logs/working/task-15/{code-reviewer,security-auditor,test-reviewer}-round1.json`.
+Verdicts: `approve_with_nits`, `approve_with_nits`,
+`approve_with_blockers`. Two majors and two blockers; the remaining
+findings were mediums/lows/nits. All actionable findings addressed
+below.
+
+**Majors / blockers fixed**
+
+- **JWT error masking in `extract_extension_claims`** (code-reviewer
+  major; security-auditor T15-M-01). The 401 response body for an
+  invalid `aud=extension` Bearer JWT formatted the jsonwebtoken
+  internal error (`InvalidSignature`, `ExpiredSignature`,
+  `InvalidAudience`, `InvalidIssuer`) into the response — same leak
+  T14 round-2 fixed for `id_token_invalid` in `oauth/google.rs`. T15
+  reintroduced the pattern.
+  **Fix**: `tracing::warn!` logs the detail server-side; the client
+  receives the fixed string `{"error": "jwt_invalid"}`. The
+  `iss`/`aud` mismatch branch now logs the structural reason and
+  returns the same opaque token.
+- **`PRAGMA foreign_keys = ON` not set** (code-reviewer major). The
+  FK on `key_escrow_blobs(google_sub) REFERENCES google_identity_links
+  ON DELETE CASCADE` was decorative: SQLite defaults to FK OFF per
+  connection, so unlinking a Google account would never cascade.
+  **Fix**: `PRAGMA foreign_keys=ON` added to `SqliteStore::open()`
+  AND `SqliteStore::in_memory()` (the latter is what
+  `mock_state()` builds, so tests now also exercise FK enforcement).
+  This is the only `core/` touch this task requires; it's global DB
+  infrastructure, not OAuth/escrow domain.
+- **Expired-ticket per-user counter pinning** (security-auditor
+  T15-M-02). If a user issued `EXTENSION_BOOTSTRAP_PER_USER_CAP=3`
+  tickets and let them all expire (10-min TTL) without redeeming,
+  the in-memory `per_user` counter stayed at 3 — locking the user
+  out of new tickets until LRU eviction pushed those entries out
+  (which requires 10k+ unrelated tickets first). Self-DoS; also a
+  partial denial-of-service vector for a stolen `aud=mcp` JWT.
+  **Fix**: `ExtensionBootstrapTickets::insert` now sweeps
+  TTL-expired entries belonging to the inserting `jwt_sub` BEFORE
+  counting toward the cap (option (a) from the review). New test
+  `expired_tickets_do_not_pin_per_user_counter` constructs a
+  harness with `ttl_seconds=0` and asserts the 4th issue still 200s.
+- **F1: DELETE cross-user isolation untested** (test-reviewer
+  blocker). The handler scopes DELETE by the JWT claim's
+  `google_sub`, so a wrong-identity DELETE returns
+  `200 {removed: 0}` rather than 403, which is correct (idempotent
+  non-reveal) — but the invariant was never pinned by a test.
+  **Fix**: new test `delete_cross_user_isolation` PUTs as user B,
+  DELETEs with user A's JWT, asserts `removed=0`, and then reads
+  user B's row directly from SQLite to verify it survives. A
+  regression dropping the `WHERE google_sub = ?` clause from the
+  DELETE SQL would fail this test.
+- **F2: Expired bootstrap ticket → 404 untested** (test-reviewer
+  blocker). The TTL-expiry branch in `consume()` was never driven.
+  **Fix**: new test `expired_bootstrap_ticket_returns_404` builds a
+  harness with `ttl_seconds=0`, issues a ticket via the production
+  HTTP handler, and asserts redeem returns 404 with the same body
+  as the garbage-UUID case (no oracle).
+
+**Majors (test-reviewer) fixed**
+
+- **F3: 429 body error field not asserted**. The
+  `rate_limit_blocks_brute_force` test captured the 429 body but
+  never asserted its `error` field — a regression to `{"error":
+  null}` would silently pass.
+  **Fix**: the 429 body now carries the fixed token
+  `{"error": "rate_limited"}` and the test asserts on it. The
+  previous verbose message ("rate limit exceeded: too many GETs
+  in 24h window") is replaced by the opaque token; no
+  attacker-useful information was in it anyway.
+- **F4: replay-nonce test absent**. The tech-spec listed
+  "replay nonce" as a server-side test. **Deferred with reason**:
+  the escrow PUT/GET endpoints do not use a per-request nonce;
+  the AES-GCM nonce in the request body is a data-layer cipher
+  nonce, not a transport replay token. Bootstrap tickets ARE
+  single-use (covered by
+  `bootstrap_ticket_round_trip_issues_extension_jwt` second-redeem
+  → 404). Escrow PUTs are authenticated by `aud=extension` JWT
+  (idempotent under replay — repeating a PUT just rewraps the same
+  value). There is no per-request server-side nonce to test
+  replay against; the test-spec item was a draft carryover. No
+  test added; rationale recorded here.
+
+**Mediums / lows fixed (security-auditor + code-reviewer)**
+
+- **T15-L-01 / cap-constant leak**. The 429 body for per-user
+  cap exceeded ("3 active") leaked the numeric cap. **Fix**:
+  replaced with the fixed opaque token
+  `{"error": "too_many_pending_tickets"}`. Cap value logged at
+  `debug!` for operators. Test
+  `bootstrap_per_user_cap_blocks_fourth_ticket` asserts on the
+  fixed token.
+- **T15-L-03 / pubkey_base58 length cap**. PUT did not bound the
+  pubkey-string length; a 1MB payload would be stored. **Fix**:
+  added `if pubkey_base58.len() > 64 { return bad_request(...); }`.
+  Ed25519 base58 pubkeys are 43–44 chars; 64 gives safe headroom.
+- **T15-L-02 / explicit GET cross-user isolation test**. Added
+  `get_cross_user_isolation`: only user B has an escrow row, user
+  A's GET must 404 (never return B's data). The test also
+  defensively asserts that if a future regression returns 200, the
+  body must not carry user B's pubkey.
+- **Nonce upper bound 64 → 16 bytes**. The previous 64-byte cap
+  on the AES-GCM nonce was over-generous (AES-GCM-256 uses 12; some
+  AEADs use 16). **Fix**: tightened to `1..=16` bytes.
+- **`now_rfc3339` / `now_unix` skew in GET handler**. Two
+  `chrono::Utc::now()` calls captured. **Fix**: single
+  `let now = chrono::Utc::now();` derived into both
+  representations.
+- **`Retry-After` header construction failure silently dropped**.
+  **Fix**: replaced the `if let Ok(...)` with a `match` that warns
+  on error and still returns the 429 body. Behaviour is unchanged
+  in the success path; failures are now observable.
+- **F5: PUT/DELETE missing google_sub → 401**. The original
+  `key_escrow_requires_google_sub_claim` only exercised GET. **Fix**:
+  added `key_escrow_put_and_delete_require_google_sub_claim` that
+  drives the same negative path on the two write verbs.
+- **F6: linked_at INTEGER vs spec TEXT**. The T14 migration created
+  `google_identity_links.linked_at INTEGER` (unix seconds), not
+  TEXT as the T15 task spec described. The test helper `seed_link`
+  already inserted an integer; **Fix**: added a doc-comment on
+  `seed_link` clarifying T14's schema overrides the T15 spec text.
+- **F7: per-user bootstrap-ticket cap test**. New test
+  `bootstrap_per_user_cap_blocks_fourth_ticket` exercises the 3+1
+  case end-to-end via the HTTP handler.
+
+**Architectural constraint preserved**
+
+- The only `core/` change is the per-connection
+  `PRAGMA foreign_keys=ON` in `SqliteStore::{open,in_memory}`. No
+  OAuth/escrow tables, helpers, or constants moved into `core/`.
+  The dependency graph remains one-way (`mcp/` → `core/`).
+
+**Test count**
+
+`mcp/tests/key_escrow.rs` grew from 10 to 16 tests; all pass in
+0.29s. Workspace test run (`cargo test --workspace --features
+mnemonic-mcp/test-support`) green; T14 OAuth tests unchanged.
+
+Task `15.md` stays at `status: in_review` / `blocked_on: ci-verify`
+per D13 — flips to `done` only after PR #114 CI reports green.
+
+---

--- a/work/chrome-extension/tasks/15.md
+++ b/work/chrome-extension/tasks/15.md
@@ -1,5 +1,6 @@
 ---
-status: pending
+status: in_review
+blocked_on: ci-verify
 depends_on: [14]
 wave: 5
 skills: [code-writing, rust, security]


### PR DESCRIPTION
## Summary

- Adds **5 endpoints** for the chrome-extension key-escrow flow (Decision 9):
  - `POST /api/extension-bootstrap/issue` (Bearer `aud=mcp` JWT) → UUID ticket (LRU 10k, TTL 10 min, per-user cap 3). Mirrors the existing cli-bootstrap pattern.
  - `GET /api/extension-bootstrap/redeem/{ticket}` (no auth — UUID is the capability) → fresh `aud=extension` HS256 JWT signed with the same `MCP_JWT_SECRET`. Single-use; second redeem → 404.
  - `PUT /api/key-escrow` (`aud=extension` JWT with `google_sub`) → atomic UPSERT of `{ciphertext, nonce, kdf, kdf_params, pubkey_base58}`. Validates `pubkey_base58` matches the linked `google_identity_links.pubkey_base58` (403 on mismatch — closes the stolen-Google-account → swap-key attack).
  - `GET /api/key-escrow` → returns the blob. Rate-limited to `KEY_ESCROW_RATE_LIMIT` (default 5) per rolling 24h per `google_sub`. 429 + `Retry-After: <seconds>` once exceeded. Counter increment is a single SQL UPDATE (no READ-then-WRITE race).
  - `DELETE /api/key-escrow` — hard delete; idempotent.
- Adds `key_escrow_blobs` migration in `mcp/src/escrow.rs::migrate_key_escrow_blobs`. FK to `google_identity_links` with `ON DELETE CASCADE`. Only runs at startup when Google OAuth is enabled (T14's pattern).
- `KEY_ESCROW_RATE_LIMIT` env wired through `Config` → new `ExtensionSettings` struct → `run_http`. Single source of truth, no downstream `std::env::var` reads.
- `OAuthState::jwt_encoding_key()` / `jwt_decoding_key()` accessors so the escrow module can mint/verify `aud=extension` JWTs without re-implementing JWT plumbing.
- Bearer-auth middleware allowlist: `/api/extension-bootstrap/redeem/` (UUID-as-capability), `/api/key-escrow` (verifies `aud=extension` JWT inline — the production middleware only accepts `aud=mcp`).

## Architectural deviation (documented in decisions.md)

The original T15 spec said migrations live in `core/src/storage/sqlite.rs`. Per CLAUDE.md and Decision 9 (OAuth/escrow tables are server concerns; `core/` is reserved for the cross-client attestation schema), and T14's existing `oauth/google.rs::migrate_google_identity_links`, this migration lives in `mcp/src/escrow.rs` instead. `core/` is untouched.

## Security highlights

- **Zero-knowledge.** Server never decrypts. Migration SQL is exposed as `pub const MIGRATION_SQL` so `server_never_stores_plaintext` (TDD anchor #3) statically asserts no plaintext-leaking column name is ever added.
- **Pubkey binding.** `PUT` cross-checks the body's `pubkey_base58` against `google_identity_links`. Mismatch → 403 with a generic error (no leaking of the linked pubkey).
- **Atomic rate-limit counter.** Single SQL UPDATE with a CASE expression handles both "reset on elapsed window" and "bump in window" in one statement.
- **Audience split.** `aud=extension` JWTs are rejected by the global `aud=mcp` middleware on `/mcp`; extension JWTs only validate at the escrow endpoints.
- **Single-use tickets, generic 404s.** The redeem endpoint returns identical 404 bodies for "garbage UUID", "expired", and "already consumed" so an attacker probing the LRU cannot distinguish.

## Tests (10/10 pass locally, `--features test-support`)

- `rate_limit_blocks_brute_force` (TDD #1) — 5 GETs OK, 6th → 429 + Retry-After.
- `pubkey_binding_enforced` (TDD #2) — PUT with non-matching pubkey → 403.
- `server_never_stores_plaintext` (TDD #3) — schema audit on `MIGRATION_SQL`.
- `put_then_get_round_trip_identical_bytes`.
- `stale_window_resets_counter` — seeds `last_fetch_at` to 25h ago, asserts the next GET succeeds and counter resets to 1.
- `delete_removes_row_subsequent_get_404` — also covers DELETE idempotency.
- `put_without_prior_google_identity_link_403`.
- `key_escrow_rejects_mcp_aud_jwt` — `aud=mcp` JWT must not pass the escrow audience check.
- `key_escrow_requires_google_sub_claim`.
- `bootstrap_ticket_round_trip_issues_extension_jwt` — full handshake.

`Cargo.toml`: `[[test]] name = "key_escrow"` + `required-features = ["test-support"]` so omitting the feature flag emits a clear message instead of silent `0 tests`.

## Test plan

- [ ] `cargo fmt --all -- --check` clean
- [ ] `cargo clippy --workspace --all-targets --features mnemonic-mcp/test-support -- -D warnings` clean
- [ ] `cargo test -p mnemonic-mcp --features test-support --test key_escrow -- --nocapture` — 10 tests pass
- [ ] `cargo test --workspace --no-fail-fast --features mnemonic-mcp/test-support` — full suite green
- [ ] gitleaks clean (no secrets committed)

Links: D9 in [work/chrome-extension/decisions.md](work/chrome-extension/decisions.md). T14 follow-on for the `google_identity_links` schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)