### PR TITLE
feat(extension): T16 — Google sign-in client + onboarding wiring

### DIFF
--- a/packages/extension/src/auth/google-oauth.ts
+++ b/packages/extension/src/auth/google-oauth.ts
@@ -386,13 +386,45 @@ async function exchangeCodeForToken(
 
 // ── Profile extraction ──────────────────────────────────────────────────────
 
+/** Defence-in-depth caps on profile fields. The server already validates
+ *  the id_token's Google JWKS signature in T14, so legitimate values stay
+ *  well below these limits — the caps just stop a future server-side bug
+ *  from blowing up `chrome.storage.local` (10MB quota). */
+const MAX_SUB_LEN = 128;
+const MAX_EMAIL_LEN = 256;
+const MAX_NAME_LEN = 256;
+const MAX_PICTURE_URL_LEN = 1024;
+
+/** Strict-https URL validator. Rejects empty / non-https / unparseable
+ *  URLs to keep the value safe for direct use in `<img src=...>`. */
+function safePictureUrl(raw: unknown): string {
+  if (typeof raw !== "string" || raw.length === 0) return "";
+  if (raw.length > MAX_PICTURE_URL_LEN) return "";
+  try {
+    const u = new URL(raw);
+    if (u.protocol !== "https:") return "";
+    return u.toString();
+  } catch {
+    return "";
+  }
+}
+
+/** Cap a string field to `max` chars. Empty / non-string returns "". */
+function clampString(raw: unknown, max: number): string {
+  if (typeof raw !== "string") return "";
+  return raw.length > max ? raw.slice(0, max) : raw;
+}
+
 /**
  * Pull display fields out of the id_token payload (preferred) or fall
  * back to the access-token payload's `google_sub` claim.
  *
  * NEITHER token is signature-verified here — the server already validated
  * the id_token against Google's JWKS, and the access_token is HS256-signed
- * by us so any tampering would surface at the next API call.
+ * by us so any tampering would surface at the next API call. Length caps
+ * + URL-scheme validation are defence-in-depth so a future server-side
+ * bug cannot blow up `chrome.storage.local` or land an unsafe `<img
+ * src>` value in a downstream component (security-auditor round 1).
  *
  * Exported for direct testing.
  */
@@ -403,11 +435,11 @@ export function extractProfile(
   if (idToken) {
     const claims = parseJwtPayload(idToken);
     if (claims) {
-      const sub = typeof claims.sub === "string" ? claims.sub : "";
-      const email = typeof claims.email === "string" ? claims.email : "";
+      const sub = clampString(claims.sub, MAX_SUB_LEN);
+      const email = clampString(claims.email, MAX_EMAIL_LEN);
       const emailVerified = claims.email_verified === true;
-      const name = typeof claims.name === "string" ? claims.name : "";
-      const picture = typeof claims.picture === "string" ? claims.picture : "";
+      const name = clampString(claims.name, MAX_NAME_LEN);
+      const picture = safePictureUrl(claims.picture);
       if (sub) {
         return {
           sub,
@@ -421,8 +453,7 @@ export function extractProfile(
   }
   // Fallback: server JWT carries `google_sub`. No display fields here.
   const claims = parseJwtPayload(accessToken);
-  const fallbackSub =
-    typeof claims?.google_sub === "string" ? claims.google_sub : "";
+  const fallbackSub = clampString(claims?.google_sub, MAX_SUB_LEN);
   return {
     sub: fallbackSub,
     email: "",

--- a/packages/extension/src/auth/google-oauth.ts
+++ b/packages/extension/src/auth/google-oauth.ts
@@ -1,0 +1,443 @@
+// Google sign-in client. Drives RFC 7636 PKCE S256 against our server's
+// `/oauth/google/start` via `chrome.identity.launchWebAuthFlow`, then
+// redeems the returned auth code at `POST /oauth/token` for the
+// server-issued JWT (Decision 5 of `work/chrome-extension/decisions.md`).
+//
+// Key invariants:
+//
+//  1. **No Google client_secret in the extension.** The redirect URI is
+//     `chrome.identity.getRedirectURL('google')` and the server holds the
+//     Google secret. The server validates Google's id_token + binds
+//     `google_sub` to a server-minted JWT.
+//
+//  2. **State must round-trip exactly.** RFC 7636 §4.4 binds the PKCE
+//     verifier to the state value; the callback's `state` MUST equal the
+//     start request's `state` or we throw BEFORE the token-exchange POST.
+//     Drives the `pkce_state_mismatch_rejects` TDD anchor.
+//
+//  3. **PKCE inputs match the project standard.** 32 random bytes →
+//     base64url verifier (RFC 7636 §4.1, ~43 chars); SHA-256(verifier) →
+//     base64url challenge (§4.2). Mirrors `packages/sdk/src/oauth.ts`.
+//
+// `signInWithGoogle` is the single public entry point. The popup awaits
+// it; on success it persists a `Session` via `session.ts` and asks
+// `lookup.ts` whether this Google account already has a linked pubkey.
+
+import {
+  AuthError,
+  type GoogleProfile,
+  type GoogleSignInResult,
+} from "./types.js";
+
+/** Public client id label sent on `/oauth/google/start`. The server
+ *  treats this as informational; the redirect_uri is the real binding. */
+export const EXTENSION_CLIENT_ID = "mnemonic-extension";
+
+/** Default MCP server origin. Tests inject their own via `serverBaseUrl`. */
+export const DEFAULT_SERVER_ORIGIN = "https://mc.mnemonik.xyz";
+
+/** PKCE method — S256 only (server enforces, RFC 7636 §4.2). */
+const PKCE_METHOD = "S256";
+
+/** Path identifier passed to `chrome.identity.getRedirectURL`. The
+ *  resulting URL is `https://<extension-id>.chromiumapp.org/google`. */
+const REDIRECT_PATH = "google";
+
+/**
+ * Test-only seam: override the `chrome.identity` surface. Production code
+ * leaves the field undefined and the runtime resolves to the real
+ * `chrome.identity.*` APIs at call time. Centralising the indirection
+ * here avoids monkey-patching the global `chrome` object in tests.
+ */
+export interface ChromeIdentityShim {
+  getRedirectURL: (path: string) => string;
+  /** Resolves to the callback URL on success, `undefined` on
+   *  user-cancellation, OR rejects with an Error on
+   *  `chrome.runtime.lastError`. The default implementation maps the
+   *  callback-style API into this Promise shape. */
+  launchWebAuthFlow: (details: {
+    url: string;
+    interactive: boolean;
+  }) => Promise<string | undefined>;
+}
+
+export interface SignInWithGoogleInput {
+  /** Origin of the MCP server, e.g. `https://mc.mnemonik.xyz`. No
+   *  trailing slash required — the URL constructor handles both. */
+  serverBaseUrl?: string;
+  /** Test-only: override `chrome.identity.*`. Production callers leave
+   *  this unset and the runtime resolves to the real APIs. */
+  identity?: ChromeIdentityShim;
+  /** Test-only: override `fetch`. Production callers leave this unset
+   *  and the runtime uses the global `fetch`. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Drive the full Google sign-in flow.
+ *
+ * Throws an {@link AuthError} on every failure path. The popup
+ * branches on `error.message` to distinguish user-cancellation
+ * ("Google sign-in was cancelled by the user") from real failures.
+ */
+export async function signInWithGoogle(
+  input: SignInWithGoogleInput = {},
+): Promise<GoogleSignInResult> {
+  const serverBaseUrl = (input.serverBaseUrl ?? DEFAULT_SERVER_ORIGIN).replace(
+    /\/+$/u,
+    "",
+  );
+  const identity = input.identity ?? defaultIdentityShim();
+  const fetchImpl = input.fetchImpl ?? globalThis.fetch.bind(globalThis);
+
+  const verifier = generateCodeVerifier();
+  const challenge = await pkceChallenge(verifier);
+  const state = randomState();
+  const redirectUri = identity.getRedirectURL(REDIRECT_PATH);
+  if (typeof redirectUri !== "string" || redirectUri.length === 0) {
+    throw new AuthError("chrome.identity.getRedirectURL returned empty");
+  }
+
+  const startUrl = buildAuthorizeUrl({
+    serverBaseUrl,
+    challenge,
+    state,
+    redirectUri,
+  });
+
+  let responseUrl: string | undefined;
+  try {
+    responseUrl = await identity.launchWebAuthFlow({
+      url: startUrl,
+      interactive: true,
+    });
+  } catch (cause) {
+    if (cause instanceof AuthError) throw cause;
+    throw new AuthError("launchWebAuthFlow failed", { cause });
+  }
+  if (responseUrl === undefined || responseUrl === "") {
+    // chrome.identity surfaces user-cancellation by leaving responseUrl
+    // undefined. Mirror that to a distinct error message so the popup
+    // can render a silent "Sign-in cancelled" toast.
+    throw new AuthError("Google sign-in was cancelled by the user");
+  }
+
+  // Parse the chromiumapp.org callback. `chrome.identity` URL-encodes
+  // every query param, so `URL.searchParams` is the right reader.
+  let callback: URL;
+  try {
+    callback = new URL(responseUrl);
+  } catch (cause) {
+    throw new AuthError("oauth callback URL is not a valid URL", { cause });
+  }
+  const errorParam = callback.searchParams.get("error");
+  if (errorParam) {
+    throw new AuthError(`oauth: server returned error=${errorParam}`);
+  }
+  const code = callback.searchParams.get("code");
+  const returnedState = callback.searchParams.get("state");
+  if (!code) {
+    throw new AuthError("oauth: callback missing code parameter");
+  }
+  // RFC 7636 §4.4 + RFC 6749 §10.12: validate `state` BEFORE any token
+  // exchange. A mismatch indicates a CSRF or a swapped callback and the
+  // flow MUST abort silently. Constant-time comparison so a timing oracle
+  // cannot distinguish prefix-matching candidate states.
+  if (!returnedState || !constantTimeEquals(state, returnedState)) {
+    throw new AuthError("oauth: state mismatch");
+  }
+
+  const token = await exchangeCodeForToken({
+    fetchImpl,
+    serverBaseUrl,
+    code,
+    verifier,
+    redirectUri,
+  });
+
+  // Parse the id_token payload (NOT verifying signature — the server
+  // already did that against Google's JWKS). The `id_token` is optional
+  // in the server's response shape (`GoogleTokenResponse`); when missing
+  // we fall back to whatever the access-token JWT carries.
+  const profile = extractProfile(token.idToken, token.accessToken);
+  if (!profile.sub) {
+    throw new AuthError("oauth: response missing google_sub claim");
+  }
+
+  return {
+    jwt: token.accessToken,
+    googleSub: profile.sub,
+    profile,
+  };
+}
+
+// ── PKCE primitives (exported for direct unit testing) ─────────────────────
+
+/** RFC 7636 §4.1: 32 random bytes, base64url-encoded (43 chars, no pad). */
+export function generateCodeVerifier(): string {
+  const buf = new Uint8Array(32);
+  crypto.getRandomValues(buf);
+  return base64UrlEncode(buf);
+}
+
+/** RFC 7636 §4.2: `base64url(SHA-256(verifier))`. */
+export async function pkceChallenge(verifier: string): Promise<string> {
+  const bytes = new TextEncoder().encode(verifier);
+  // `crypto.subtle.digest` needs a `BufferSource` whose backing store is
+  // an `ArrayBuffer`. Slicing produces a fresh, plain ArrayBuffer that
+  // satisfies the strictest TS overload (matches the SDK pattern in
+  // `packages/sdk/src/oauth.ts`).
+  const ab = bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  ) as ArrayBuffer;
+  const digest = await crypto.subtle.digest("SHA-256", ab);
+  return base64UrlEncode(new Uint8Array(digest));
+}
+
+/** 32-byte CSRF token, base64url-encoded. Decision 5 mandates ≥32 bytes. */
+export function randomState(): string {
+  const buf = new Uint8Array(32);
+  crypto.getRandomValues(buf);
+  return base64UrlEncode(buf);
+}
+
+/** RFC 4648 §5 base64url, no padding. */
+function base64UrlEncode(bytes: Uint8Array): string {
+  let bin = "";
+  for (let i = 0; i < bytes.length; i++) {
+    bin += String.fromCharCode(bytes[i] ?? 0);
+  }
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Constant-time string equality. Used for the state comparison so a
+ * timing oracle cannot distinguish prefix-matching candidate states.
+ * Different lengths return false without leaking which prefix matched.
+ */
+export function constantTimeEquals(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+// ── URL builders ────────────────────────────────────────────────────────────
+
+export interface BuildAuthorizeUrlInput {
+  serverBaseUrl: string;
+  challenge: string;
+  state: string;
+  redirectUri: string;
+}
+
+/**
+ * Build the `<serverBaseUrl>/oauth/google/start?...` URL handed to
+ * `chrome.identity.launchWebAuthFlow`. Exported for direct testing of
+ * the redirect-URI invariant (TDD anchor
+ * `redirect_uri_uses_chrome_identity_helper`).
+ */
+export function buildAuthorizeUrl(input: BuildAuthorizeUrlInput): string {
+  const u = new URL("/oauth/google/start", input.serverBaseUrl);
+  u.searchParams.set("client_id", EXTENSION_CLIENT_ID);
+  u.searchParams.set("redirect_uri", input.redirectUri);
+  u.searchParams.set("code_challenge", input.challenge);
+  u.searchParams.set("code_challenge_method", PKCE_METHOD);
+  u.searchParams.set("state", input.state);
+  return u.toString();
+}
+
+// ── chrome.identity default shim ────────────────────────────────────────────
+
+/**
+ * Build the production `chrome.identity` shim. Adapts the callback-style
+ * `launchWebAuthFlow` API into the Promise shape the rest of this module
+ * consumes. Surfaces `chrome.runtime.lastError` as a rejected promise so
+ * the caller can branch on the AuthError message.
+ *
+ * Lookups go through `globalThis.chrome` (not the bare `chrome` global)
+ * so that hosts without the `chrome.*` namespace (e.g. the vitest node
+ * runner without our injected stub) fail loudly with a clear message.
+ */
+function defaultIdentityShim(): ChromeIdentityShim {
+  const c = (globalThis as { chrome?: typeof chrome }).chrome;
+  if (!c?.identity) {
+    throw new AuthError("chrome.identity is unavailable in this context");
+  }
+  const id = c.identity;
+  return {
+    getRedirectURL: (path) => id.getRedirectURL(path),
+    launchWebAuthFlow: (details) =>
+      new Promise<string | undefined>((resolve, reject) => {
+        try {
+          id.launchWebAuthFlow(details, (responseUrl?: string) => {
+            const lastError = c.runtime?.lastError;
+            if (lastError) {
+              reject(
+                new AuthError(
+                  `launchWebAuthFlow error: ${lastError.message ?? "unknown"}`,
+                ),
+              );
+              return;
+            }
+            resolve(responseUrl);
+          });
+        } catch (cause) {
+          reject(
+            new AuthError(
+              "chrome.identity.launchWebAuthFlow threw synchronously",
+              { cause },
+            ),
+          );
+        }
+      }),
+  };
+}
+
+// ── Token exchange ──────────────────────────────────────────────────────────
+
+interface ExchangeInput {
+  fetchImpl: typeof fetch;
+  serverBaseUrl: string;
+  code: string;
+  verifier: string;
+  redirectUri: string;
+}
+
+interface ExchangeOutput {
+  accessToken: string;
+  idToken: string | null;
+  expiresAt: string;
+}
+
+async function exchangeCodeForToken(
+  input: ExchangeInput,
+): Promise<ExchangeOutput> {
+  const tokenUrl = new URL("/oauth/token", input.serverBaseUrl).toString();
+  let response: Response;
+  try {
+    response = await input.fetchImpl(tokenUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        grant_type: "authorization_code",
+        code: input.code,
+        code_verifier: input.verifier,
+        redirect_uri: input.redirectUri,
+        client_id: EXTENSION_CLIENT_ID,
+      }),
+    });
+  } catch (cause) {
+    throw new AuthError("oauth: token endpoint unreachable", { cause });
+  }
+  if (!response.ok) {
+    throw new AuthError(
+      `oauth: token endpoint returned ${String(response.status)}`,
+    );
+  }
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (cause) {
+    throw new AuthError("oauth: token endpoint returned non-JSON body", {
+      cause,
+    });
+  }
+  if (!body || typeof body !== "object") {
+    throw new AuthError("oauth: token endpoint returned malformed body");
+  }
+  const obj = body as Record<string, unknown>;
+  const accessToken =
+    typeof obj.access_token === "string" ? obj.access_token : undefined;
+  if (!accessToken) {
+    throw new AuthError("oauth: token response missing access_token");
+  }
+  const idToken = typeof obj.id_token === "string" ? obj.id_token : null;
+  const expiresIn =
+    typeof obj.expires_in === "number" && Number.isFinite(obj.expires_in)
+      ? obj.expires_in
+      : 3600;
+  const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
+  return { accessToken, idToken, expiresAt };
+}
+
+// ── Profile extraction ──────────────────────────────────────────────────────
+
+/**
+ * Pull display fields out of the id_token payload (preferred) or fall
+ * back to the access-token payload's `google_sub` claim.
+ *
+ * NEITHER token is signature-verified here — the server already validated
+ * the id_token against Google's JWKS, and the access_token is HS256-signed
+ * by us so any tampering would surface at the next API call.
+ *
+ * Exported for direct testing.
+ */
+export function extractProfile(
+  idToken: string | null,
+  accessToken: string,
+): GoogleProfile {
+  if (idToken) {
+    const claims = parseJwtPayload(idToken);
+    if (claims) {
+      const sub = typeof claims.sub === "string" ? claims.sub : "";
+      const email = typeof claims.email === "string" ? claims.email : "";
+      const emailVerified = claims.email_verified === true;
+      const name = typeof claims.name === "string" ? claims.name : "";
+      const picture = typeof claims.picture === "string" ? claims.picture : "";
+      if (sub) {
+        return {
+          sub,
+          email,
+          email_verified: emailVerified,
+          name,
+          picture,
+        };
+      }
+    }
+  }
+  // Fallback: server JWT carries `google_sub`. No display fields here.
+  const claims = parseJwtPayload(accessToken);
+  const fallbackSub =
+    typeof claims?.google_sub === "string" ? claims.google_sub : "";
+  return {
+    sub: fallbackSub,
+    email: "",
+    email_verified: false,
+    name: "",
+    picture: "",
+  };
+}
+
+/**
+ * Decode the second segment of a JWT to a JSON object. Returns `null`
+ * for any malformed input — callers fall back to the access-token path.
+ * No signature verification (see `extractProfile` for rationale).
+ *
+ * Exported for direct testing.
+ */
+export function parseJwtPayload(jwt: string): Record<string, unknown> | null {
+  const parts = jwt.split(".");
+  if (parts.length !== 3) return null;
+  const seg = parts[1];
+  if (!seg) return null;
+  try {
+    const padded =
+      seg.replace(/-/g, "+").replace(/_/g, "/") +
+      "===".slice((seg.length + 3) % 4);
+    const bin = atob(padded);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    const text = new TextDecoder("utf-8").decode(bytes);
+    const parsed = JSON.parse(text);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}

--- a/packages/extension/src/auth/google-oauth.ts
+++ b/packages/extension/src/auth/google-oauth.ts
@@ -168,6 +168,7 @@ export async function signInWithGoogle(
     jwt: token.accessToken,
     googleSub: profile.sub,
     profile,
+    jwtExpiresAt: token.jwtExpiresAt,
   };
 }
 
@@ -310,7 +311,9 @@ interface ExchangeInput {
 interface ExchangeOutput {
   accessToken: string;
   idToken: string | null;
-  expiresAt: string;
+  /** Wall-clock ms at which the access token expires. Derived from the
+   *  server's `expires_in` (defaulting to 1h when absent). */
+  jwtExpiresAt: number;
 }
 
 async function exchangeCodeForToken(
@@ -334,8 +337,25 @@ async function exchangeCodeForToken(
     throw new AuthError("oauth: token endpoint unreachable", { cause });
   }
   if (!response.ok) {
+    // Best-effort: surface the server's `error` / `error_description`
+    // (RFC 6749 §5.2) so devs hitting `chrome://extensions` see
+    // "invalid_grant: PKCE verifier mismatch" instead of just "401".
+    // Bounded to 200 chars to keep the AuthError message reasonable.
+    let detail = "";
+    try {
+      const errBody = (await response.json()) as Record<string, unknown>;
+      const errCode = typeof errBody?.error === "string" ? errBody.error : "";
+      const errDesc =
+        typeof errBody?.error_description === "string"
+          ? errBody.error_description
+          : "";
+      const combined = [errCode, errDesc].filter(Boolean).join(": ");
+      if (combined) detail = ` — ${combined.slice(0, 200)}`;
+    } catch {
+      // Non-JSON or oversized body — ignore, fall back to bare status.
+    }
     throw new AuthError(
-      `oauth: token endpoint returned ${String(response.status)}`,
+      `oauth: token endpoint returned ${String(response.status)}${detail}`,
     );
   }
   let body: unknown;
@@ -360,8 +380,8 @@ async function exchangeCodeForToken(
     typeof obj.expires_in === "number" && Number.isFinite(obj.expires_in)
       ? obj.expires_in
       : 3600;
-  const expiresAt = new Date(Date.now() + expiresIn * 1000).toISOString();
-  return { accessToken, idToken, expiresAt };
+  const jwtExpiresAt = Date.now() + expiresIn * 1000;
+  return { accessToken, idToken, jwtExpiresAt };
 }
 
 // ── Profile extraction ──────────────────────────────────────────────────────

--- a/packages/extension/src/auth/lookup.ts
+++ b/packages/extension/src/auth/lookup.ts
@@ -1,0 +1,111 @@
+// `POST /oauth/google/lookup` client. Asks the server whether the
+// Google account behind `jwt` is already linked to an Ed25519 pubkey
+// and whether a key-escrow blob exists for it. Returns a strict TS
+// shape; the underlying server response (`mcp/src/oauth/google.rs`)
+// includes a `link_challenge` nonce when no link exists yet — T17
+// (key-escrow + link flow) consumes that directly from a separate
+// helper so this module's surface stays minimal.
+
+import { AuthError, type LookupResult } from "./types.js";
+import { DEFAULT_SERVER_ORIGIN } from "./google-oauth.js";
+
+export interface LookupOptions {
+  serverOrigin?: string;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Server response shape — mirrors `mcp/src/oauth/google.rs::LookupResponse`.
+ * Exported so T17 can reuse it for the link-challenge consumer without
+ * duplicating field names.
+ */
+export interface RawLookupResponse {
+  existing_pubkey: string | null;
+  escrow_present: boolean;
+  link_challenge?: string;
+}
+
+/**
+ * Call `POST /oauth/google/lookup` with the server-issued JWT. Maps
+ * the response into the popup-friendly `LookupResult` shape
+ * (`{existingPubkey, escrowPresent, linkChallenge}`) so the caller
+ * branches on three fields rather than parsing JSON twice.
+ *
+ * The server rate-limits to 5 calls / 24h / google_sub for first-touch
+ * lookups; the popup MUST call `lookupExisting` at most once per
+ * sign-in to stay well under the cap. T17's onboarding flow is the
+ * only intended caller.
+ */
+export async function lookupExisting(
+  jwt: string,
+  opts: LookupOptions = {},
+): Promise<LookupResult> {
+  if (typeof jwt !== "string" || jwt.length === 0) {
+    throw new AuthError("lookup: jwt is required");
+  }
+  const serverOrigin = (opts.serverOrigin ?? DEFAULT_SERVER_ORIGIN).replace(
+    /\/+$/u,
+    "",
+  );
+  const fetchImpl = opts.fetchImpl ?? globalThis.fetch.bind(globalThis);
+  const url = new URL("/oauth/google/lookup", serverOrigin).toString();
+
+  let response: Response;
+  try {
+    response = await fetchImpl(url, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${jwt}`,
+        "content-type": "application/json",
+      },
+      // No body fields — the JWT carries `google_sub` already.
+      body: "{}",
+    });
+  } catch (cause) {
+    throw new AuthError("lookup: server unreachable", { cause });
+  }
+  if (response.status === 401) {
+    throw new AuthError("lookup: server rejected JWT (401)");
+  }
+  if (response.status === 429) {
+    throw new AuthError("lookup: rate-limited (429)");
+  }
+  if (!response.ok) {
+    throw new AuthError(`lookup: server returned ${String(response.status)}`);
+  }
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch (cause) {
+    throw new AuthError("lookup: response is not valid JSON", { cause });
+  }
+  if (!body || typeof body !== "object") {
+    throw new AuthError("lookup: response is not an object");
+  }
+  const obj = body as Record<string, unknown>;
+  // `existing_pubkey` can be null (server omits it via Option<None>)
+  // or a non-empty string. Anything else is malformed.
+  const existingPubkey =
+    typeof obj.existing_pubkey === "string" && obj.existing_pubkey.length > 0
+      ? obj.existing_pubkey
+      : null;
+  if (
+    obj.existing_pubkey !== null &&
+    obj.existing_pubkey !== undefined &&
+    typeof obj.existing_pubkey !== "string"
+  ) {
+    throw new AuthError("lookup: existing_pubkey has wrong type");
+  }
+  if (typeof obj.escrow_present !== "boolean") {
+    throw new AuthError("lookup: escrow_present missing or non-boolean");
+  }
+  const escrowPresent: boolean = obj.escrow_present;
+  // `link_challenge` is set ONLY when `existing_pubkey` is null. We
+  // surface it on the typed result so T17's link-flow consumer can
+  // sign the nonce without a second HTTP call.
+  let linkChallenge: string | null = null;
+  if (typeof obj.link_challenge === "string" && obj.link_challenge.length > 0) {
+    linkChallenge = obj.link_challenge;
+  }
+  return { existingPubkey, escrowPresent, linkChallenge };
+}

--- a/packages/extension/src/auth/session.ts
+++ b/packages/extension/src/auth/session.ts
@@ -18,11 +18,14 @@ import { SESSION_STORAGE_KEY, type Session } from "./types.js";
  * tests inject an in-memory shim without monkey-patching the global
  * `chrome` object. Production callers leave the parameter undefined
  * and the runtime resolves to `chrome.storage.local`.
+ *
+ * The chrome typings allow a default-values record on `get`
+ * (`{key: defaultValue}` overload), but no caller in this codebase
+ * uses it. The narrowed signature here keeps call-sites unambiguous;
+ * widen later if a caller actually needs the defaults overload.
  */
 export interface StorageArea {
-  get: (
-    keys: string | string[] | object | null,
-  ) => Promise<Record<string, unknown>>;
+  get: (keys: string | string[]) => Promise<Record<string, unknown>>;
   set: (items: Record<string, unknown>) => Promise<void>;
   remove: (keys: string | string[]) => Promise<void>;
 }

--- a/packages/extension/src/auth/session.ts
+++ b/packages/extension/src/auth/session.ts
@@ -1,0 +1,153 @@
+// Persisted-session store. Lives on top of `chrome.storage.local` so the
+// JWT + Google profile survive popup close / service-worker restart.
+// Forward-incompatible changes to the `Session` shape MUST bump the
+// storage key (currently `session.v1`) so a half-upgraded extension
+// does not crash on read.
+//
+// Phase 1 prompts re-login on JWT expiry — refresh-token support is
+// in the backlog (Decision 5 mentions Phase 2 refresh flow). The
+// `getSession` reader returns `null` for an expired token so callers
+// can branch on freshness without re-parsing the JWT.
+
+import { SESSION_STORAGE_KEY, type Session } from "./types.js";
+
+// ── chrome.storage shim ────────────────────────────────────────────────
+
+/**
+ * Minimal subset of `chrome.storage.local` this module needs. Lets
+ * tests inject an in-memory shim without monkey-patching the global
+ * `chrome` object. Production callers leave the parameter undefined
+ * and the runtime resolves to `chrome.storage.local`.
+ */
+export interface StorageArea {
+  get: (
+    keys: string | string[] | object | null,
+  ) => Promise<Record<string, unknown>>;
+  set: (items: Record<string, unknown>) => Promise<void>;
+  remove: (keys: string | string[]) => Promise<void>;
+}
+
+function defaultStorage(): StorageArea {
+  const c = (globalThis as { chrome?: typeof chrome }).chrome;
+  if (!c?.storage?.local) {
+    throw new Error("chrome.storage.local is unavailable in this context");
+  }
+  return c.storage.local as unknown as StorageArea;
+}
+
+// ── Read / write / clear ───────────────────────────────────────────────
+
+/**
+ * Read the persisted session. Returns `null` when:
+ *
+ *   - no session has been written yet,
+ *   - the stored blob fails shape validation (e.g. partial write,
+ *     forward-incompatible schema),
+ *   - the JWT has expired (`jwtExpiresAt <= Date.now()`).
+ *
+ * Expired sessions are NOT auto-deleted from storage — that's a Phase 2
+ * concern. Returning `null` already pushes the popup onto the
+ * re-login path; leaving the row in place lets the options page render
+ * "session expired, sign in again" instead of "no identity".
+ */
+export async function getSession(
+  storage: StorageArea = defaultStorage(),
+  now: () => number = Date.now,
+): Promise<Session | null> {
+  let result: Record<string, unknown>;
+  try {
+    result = await storage.get(SESSION_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  const raw = result[SESSION_STORAGE_KEY];
+  if (!isPersistedSession(raw)) return null;
+  if (raw.jwtExpiresAt <= now()) return null;
+  return raw;
+}
+
+/**
+ * Persist a session. Overwrites any previously-stored session. Caller
+ * is responsible for computing `jwtExpiresAt` from the JWT `exp` claim
+ * (helpers below) and for setting `signedInAt`.
+ */
+export async function setSession(
+  session: Session,
+  storage: StorageArea = defaultStorage(),
+): Promise<void> {
+  if (!isPersistedSession(session)) {
+    throw new Error("session: refusing to persist malformed shape");
+  }
+  await storage.set({ [SESSION_STORAGE_KEY]: session });
+}
+
+/**
+ * Clear the persisted session. No-op when no session is present (the
+ * underlying `storage.remove` is idempotent).
+ */
+export async function clearSession(
+  storage: StorageArea = defaultStorage(),
+): Promise<void> {
+  await storage.remove(SESSION_STORAGE_KEY);
+}
+
+// ── JWT exp helper ─────────────────────────────────────────────────────
+
+/**
+ * Extract the JWT's `exp` claim (in seconds) and return it as
+ * milliseconds. Returns `null` when:
+ *
+ *   - the token does not have three dot-separated segments,
+ *   - the payload is not valid base64url-encoded JSON,
+ *   - the `exp` claim is missing or non-numeric.
+ *
+ * No signature verification — that's the server's responsibility.
+ * Caller uses the result to populate `Session.jwtExpiresAt`.
+ */
+export function jwtExpiresAtMs(jwt: string): number | null {
+  if (typeof jwt !== "string") return null;
+  const parts = jwt.split(".");
+  if (parts.length !== 3) return null;
+  const payloadRaw = parts[1];
+  if (payloadRaw === undefined || payloadRaw.length === 0) return null;
+  const padded =
+    payloadRaw.replace(/-/gu, "+").replace(/_/gu, "/") +
+    "===".slice((payloadRaw.length + 3) % 4);
+  let json: unknown;
+  try {
+    const bin = atob(padded);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    json = JSON.parse(new TextDecoder("utf-8").decode(bytes));
+  } catch {
+    return null;
+  }
+  if (!json || typeof json !== "object") return null;
+  const exp = (json as Record<string, unknown>).exp;
+  if (typeof exp !== "number" || !Number.isFinite(exp)) return null;
+  return Math.floor(exp * 1000);
+}
+
+// ── shape guard ────────────────────────────────────────────────────────
+
+function isPersistedSession(value: unknown): value is Session {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.jwt !== "string" || v.jwt.length === 0) return false;
+  if (typeof v.googleSub !== "string" || v.googleSub.length === 0) return false;
+  if (typeof v.jwtExpiresAt !== "number" || !Number.isFinite(v.jwtExpiresAt)) {
+    return false;
+  }
+  if (typeof v.signedInAt !== "number" || !Number.isFinite(v.signedInAt)) {
+    return false;
+  }
+  const profile = v.profile;
+  if (!profile || typeof profile !== "object") return false;
+  const p = profile as Record<string, unknown>;
+  if (typeof p.sub !== "string") return false;
+  if (typeof p.email !== "string") return false;
+  if (typeof p.email_verified !== "boolean") return false;
+  if (typeof p.name !== "string") return false;
+  if (typeof p.picture !== "string") return false;
+  return true;
+}

--- a/packages/extension/src/auth/session.ts
+++ b/packages/extension/src/auth/session.ts
@@ -8,6 +8,31 @@
 // in the backlog (Decision 5 mentions Phase 2 refresh flow). The
 // `getSession` reader returns `null` for an expired token so callers
 // can branch on freshness without re-parsing the JWT.
+//
+// THREAT MODEL — chrome.storage.local is NOT encrypted at rest.
+//
+// On Chrome desktop the backing store is a per-extension sqlite file under
+// `~/.../Local Extension Settings/<id>/`. Any process with filesystem
+// access to that path can read the persisted JWT in plaintext. This is
+// the chrome-extension standard: extensions do not have access to
+// CryptoKey-backed secret storage or OS keychain APIs.
+//
+// The accepted threat model for Phase 1 (per user-spec § Cloud-tier
+// privacy and § Restore-flow):
+//   - in-scope:  protecting the user-recovery passphrase (handled by T17
+//                Argon2id+AES-GCM, NOT stored in chrome.storage.local;
+//                the wrapped blob lives server-side in `key_escrow_blobs`),
+//                rate-limiting blob fetches server-side (5/24h/google_sub),
+//                MV3 CSP (no eval / no remote scripts).
+//   - out of scope: filesystem-level compromise of the user's Chrome
+//                   profile (an attacker with that level of access can
+//                   already exfiltrate the entire profile, including
+//                   cookies for every site).
+//
+// If the JWT is leaked, the attacker gains read access to the user's
+// memories (existing or future) until the JWT expires AND until the user
+// rotates their Ed25519 keypair via the recovery passphrase. Mitigation
+// is to limit JWT lifetime (server-issued, default 1h per T14).
 
 import { SESSION_STORAGE_KEY, type Session } from "./types.js";
 

--- a/packages/extension/src/auth/types.ts
+++ b/packages/extension/src/auth/types.ts
@@ -1,0 +1,121 @@
+// Shared types for the extension-side Google sign-in (T16) and downstream
+// restore / escrow flows (T17+). Kept in a dedicated file so the
+// implementation modules stay small and tests can import the surface
+// without dragging in `chrome.*` references.
+//
+// The wire shapes here track the server contracts in
+// `mcp/src/oauth/google.rs` (T14) and `mcp/src/oauth/mod.rs::TokenResponse`.
+// Anything cosmetic (UI copy, error categorisation) lives in popup glue,
+// not here.
+
+/**
+ * Decoded payload of a Google `id_token`. We only ever look at the fields
+ * the extension needs — the rest of the JWT is opaque to us. Signature
+ * verification happens **server-side**; the extension never validates the
+ * Google signature directly.
+ *
+ * `sub` is REQUIRED and load-bearing: it's the stable Google account id
+ * used as the key for `/oauth/google/lookup` and `/oauth/google/link`.
+ * Other fields fall back to empty strings when the claim is absent or
+ * non-string so the popup can render gracefully (no avatar, only email,
+ * etc.).
+ */
+export interface GoogleProfile {
+  /** Google account id (`sub` claim). Stable per-user, opaque. */
+  sub: string;
+  /** Email address. Empty string when absent. */
+  email: string;
+  /** Whether Google has verified the email. `false` when claim missing. */
+  email_verified: boolean;
+  /** Full name. Empty string when absent. */
+  name: string;
+  /** Profile picture URL. Empty string when absent. */
+  picture: string;
+}
+
+/**
+ * Successful return shape of `signInWithGoogle`.
+ *
+ * The caller (popup onboarding) immediately passes `jwt` to
+ * {@link import("./lookup.js").lookupExisting} to discover whether this
+ * Google account is already bound to a pubkey, and uses `profile` to
+ * render the welcome screen.
+ */
+export interface GoogleSignInResult {
+  /** Server-issued Bearer JWT (HS256). Carries `sub = <pubkey or
+   *  google:sub>` and `google_sub` claim per
+   *  `mcp/src/oauth/mod.rs::issue_jwt_with_google_sub`. */
+  jwt: string;
+  /** Convenience alias for `profile.sub`. */
+  googleSub: string;
+  /** Decoded `id_token` profile fields (best-effort; never trusted for
+   *  authentication — server already validated the id_token against
+   *  Google's JWKS in T14). */
+  profile: GoogleProfile;
+}
+
+/**
+ * Persisted session blob — written to `chrome.storage.local` under the
+ * key `session.v1`. The `v1` suffix is intentional: any forward-
+ * incompatible change to this shape MUST land as `session.v2` so a
+ * half-upgraded extension does not crash on read.
+ *
+ * `jwtExpiresAt` is wall-clock ms (= JWT `exp` claim * 1000). The session
+ * getter compares against `Date.now()` and surfaces `null` for expired
+ * tokens — refresh-token support is in the backlog (Decision 5
+ * mentions Phase 2 refresh flow).
+ */
+export interface Session {
+  jwt: string;
+  googleSub: string;
+  profile: GoogleProfile;
+  /** Wall-clock ms at which the JWT expires (= `exp * 1000`). */
+  jwtExpiresAt: number;
+  /** Wall-clock ms at which the session was minted. */
+  signedInAt: number;
+}
+
+/** `chrome.storage.local` key for the persisted session blob. */
+export const SESSION_STORAGE_KEY = "session.v1";
+
+/**
+ * Result of `POST /oauth/google/lookup`. Mirrors the server's
+ * `LookupResponse` (`mcp/src/oauth/google.rs`):
+ *
+ *  - `existingPubkey` is non-null when this Google account is already
+ *    linked to an Ed25519 identity. The popup branches on this: null →
+ *    "set recovery passphrase" onboarding; non-null + escrow → "welcome
+ *    back" restore; non-null + no escrow → manual import edge case.
+ *
+ *  - `escrowPresent` reports whether `key_escrow_blobs` has a row for the
+ *    Google `sub`. Distinguishes the "linked from another device but never
+ *    enabled escrow" edge case from the happy "linked + escrow" path.
+ *
+ *  - `linkChallenge` is the server-issued possession-proof nonce returned
+ *    ONLY when `existingPubkey` is null. T17 consumes it as the message
+ *    body for `POST /oauth/google/link`. Kept on the typed result so T17's
+ *    link flow doesn't need a second HTTP round-trip to fetch it.
+ */
+export interface LookupResult {
+  existingPubkey: string | null;
+  escrowPresent: boolean;
+  linkChallenge: string | null;
+}
+
+/**
+ * Branded auth error. Surfaces at the popup boundary as "Google sign-in
+ * failed: <message>"; the underlying `cause` is preserved so a developer
+ * (`chrome://extensions` → service-worker console) can chase the
+ * original `chrome.runtime.lastError` or `fetch` rejection.
+ *
+ * The class is intentionally simple — full PII redaction lives at the
+ * UI layer, not in the error itself. Callers branch on `error.message`
+ * to distinguish user-cancellation ("Google sign-in was cancelled by
+ * the user") from real failures.
+ */
+export class AuthError extends Error {
+  public override readonly name = "AuthError";
+  public constructor(message: string, options?: { cause?: unknown }) {
+    super(message, options);
+  }
+}

--- a/packages/extension/src/auth/types.ts
+++ b/packages/extension/src/auth/types.ts
@@ -52,6 +52,12 @@ export interface GoogleSignInResult {
    *  authentication — server already validated the id_token against
    *  Google's JWKS in T14). */
   profile: GoogleProfile;
+  /** Wall-clock ms at which the access token expires. Derived from the
+   *  server's `expires_in` (defaulting to 1h when absent). Callers
+   *  populate `Session.jwtExpiresAt` from this so the source of truth
+   *  for token lifetime is the server response, not a client-parsed
+   *  JWT `exp` claim. */
+  jwtExpiresAt: number;
 }
 
 /**

--- a/packages/extension/src/popup/App.tsx
+++ b/packages/extension/src/popup/App.tsx
@@ -77,10 +77,13 @@ export function App(): JSX.Element {
     setAdapter(ad);
     setSelection(sel);
     // Two paths into onboarding:
-    //   1. The user is on the Cloud tier but has no session yet (first run
-    //      or restored from a different machine).
-    //   2. The user is on Local tier — onboarding stays optional, popup
-    //      is fully usable without a session. We never force the flow.
+    //   1. First run on the Cloud tier (no session has ever been minted).
+    //   2. Cloud tier with an expired or cleared session — the user must
+    //      re-auth before continuing. `getSession` already returns null
+    //      for an expired JWT (Phase 1 has no refresh-token flow), so
+    //      both cases fall through the same `sess === null` branch.
+    //   On the Local tier onboarding stays optional, popup is fully usable
+    //   without a session. We never force the flow.
     if (t === "cloud" && sess === null) {
       setMode("onboarding");
     } else {

--- a/packages/extension/src/popup/App.tsx
+++ b/packages/extension/src/popup/App.tsx
@@ -2,6 +2,11 @@
 //   - header (IdentityBadge + StorageTierPill + Settings cog)
 //   - tab switcher (Capture / Recall / Verify)
 //   - one-time bootstrap of identity + active-tab adapter + selection
+//   - T16 first-run onboarding gate: when no persisted Google session
+//     exists, the popup mounts <Onboarding> which drives the Google
+//     sign-in PKCE flow + `lookupExisting` and branches per the user-
+//     spec scenarios. The passphrase / key-escrow effects are stubbed
+//     in `Onboarding.tsx` pending T17.
 //
 // Identity + storage tier read from `chrome.storage.local`. Heavy
 // dependencies (WASM, embedder worker, IndexedDB cosine search) sit
@@ -18,6 +23,7 @@ import {
 } from "react";
 import type { ChatAdapter } from "../runtime/chat/types.js";
 import { getRuntime, type PopupIdentity, type StorageTier } from "./runtime.js";
+import { Onboarding } from "./Onboarding.js";
 import { Capture } from "./tabs/Capture.js";
 import { Recall } from "./tabs/Recall.js";
 import { Verify } from "./tabs/Verify.js";
@@ -34,6 +40,19 @@ const TAB_LABELS: Record<Tab, string> = {
 
 const TAB_ORDER: Tab[] = ["capture", "recall", "verify"];
 
+/**
+ * High-level popup mode:
+ *   - `loading`  — first-paint bootstrap is in flight.
+ *   - `onboarding` — no persisted session; mount the T16 sign-in flow.
+ *   - `app`      — session present (or skipped via local-tier); show tabs.
+ *
+ * Session is read from `chrome.storage.local.session.v1` via the runtime
+ * facade. T16 only writes the session blob after a successful Google
+ * sign-in — local-mode never populates it, so local-only users never
+ * see the onboarding flow (they continue using the popup as before).
+ */
+type PopupMode = "loading" | "onboarding" | "app";
+
 export function App(): JSX.Element {
   const [tab, setTab] = useState<Tab>("capture");
   const [identity, setIdentity] = useState<PopupIdentity | null>(null);
@@ -41,28 +60,61 @@ export function App(): JSX.Element {
   const [adapter, setAdapter] = useState<ChatAdapter | null>(null);
   const [selection, setSelection] = useState("");
   const [tierDialogOpen, setTierDialogOpen] = useState(false);
+  const [mode, setMode] = useState<PopupMode>("loading");
   const tabRefs = useRef<Partial<Record<Tab, HTMLButtonElement | null>>>({});
 
-  useEffect(() => {
+  const bootstrap = useCallback(async (): Promise<void> => {
     const r = getRuntime();
+    const [id, t, ad, sel, sess] = await Promise.all([
+      r.loadIdentity(),
+      r.loadStorageTier(),
+      r.getActiveTabAdapter(),
+      r.getActiveTabSelection(),
+      r.session.get(),
+    ]);
+    setIdentity(id);
+    setTier(t);
+    setAdapter(ad);
+    setSelection(sel);
+    // Two paths into onboarding:
+    //   1. The user is on the Cloud tier but has no session yet (first run
+    //      or restored from a different machine).
+    //   2. The user is on Local tier — onboarding stays optional, popup
+    //      is fully usable without a session. We never force the flow.
+    if (t === "cloud" && sess === null) {
+      setMode("onboarding");
+    } else {
+      setMode("app");
+    }
+  }, []);
+
+  useEffect(() => {
     let cancelled = false;
     void (async () => {
-      const [id, t, ad, sel] = await Promise.all([
-        r.loadIdentity(),
-        r.loadStorageTier(),
-        r.getActiveTabAdapter(),
-        r.getActiveTabSelection(),
-      ]);
-      if (cancelled) return;
-      setIdentity(id);
-      setTier(t);
-      setAdapter(ad);
-      setSelection(sel);
+      await bootstrap();
+      if (cancelled) {
+        // Render guard — `bootstrap` already mutated state by here,
+        // but the effect cleanup runs synchronously so the StrictMode
+        // double-render won't see a stale `setMode`. Keeping the guard
+        // for parity with the previous useEffect shape.
+      }
     })();
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [bootstrap]);
+
+  /**
+   * Once onboarding finishes (Onboarding's `onComplete` callback fires),
+   * re-bootstrap so the App sees the freshly-persisted session and any
+   * keypair the escrow flow restored. T17's onComplete arrives after
+   * the passphrase step completes (or the user opts into the
+   * "Continue in local mode" edge case).
+   */
+  const handleOnboardingComplete = useCallback((): void => {
+    setMode("loading");
+    void bootstrap();
+  }, [bootstrap]);
 
   const openOptions = (): void => {
     try {
@@ -77,7 +129,7 @@ export function App(): JSX.Element {
   // focus to the newly-selected tab. Home/End jump to first/last.
   const handleTabKeyDown = (
     e: KeyboardEvent<HTMLButtonElement>,
-    current: Tab
+    current: Tab,
   ): void => {
     const idx = TAB_ORDER.indexOf(current);
     let next: Tab | null = null;
@@ -96,6 +148,14 @@ export function App(): JSX.Element {
       tabRefs.current[next]?.focus();
     }
   };
+
+  // T16 onboarding takes the whole popup when present — the tab UI
+  // would distract from the sign-in / passphrase flow. Returning early
+  // keeps the conditional rendering simple and means the Onboarding
+  // component owns its own <main> + aria-labels.
+  if (mode === "onboarding") {
+    return <Onboarding onComplete={handleOnboardingComplete} />;
+  }
 
   return (
     <main className="bg-background text-text-primary p-3 flex flex-col gap-3 min-h-full">
@@ -211,7 +271,7 @@ function TierDialog({ onClose }: { onClose: () => void }): JSX.Element {
         onClose();
       }
     },
-    [onClose]
+    [onClose],
   );
 
   useEffect(() => {

--- a/packages/extension/src/popup/Onboarding.tsx
+++ b/packages/extension/src/popup/Onboarding.tsx
@@ -23,6 +23,10 @@ import type {
 } from "../auth/types.js";
 import { jwtExpiresAtMs } from "../auth/session.js";
 
+/** Fallback session lifetime when neither the server response nor the JWT
+ *  carries a usable expiry. Mirrors the server's default `expires_in`. */
+const FALLBACK_SESSION_MS = 60 * 60 * 1000;
+
 /**
  * Top-level onboarding state machine. The popup mounts this when
  * `runtime.session.get()` returned `null` on first paint.
@@ -47,6 +51,11 @@ export interface OnboardingProps {
   onComplete: () => void;
 }
 
+/** Minimum passphrase length per user-spec § Scenario 1. zxcvbn strength
+ *  scoring lands in T17 alongside the real key-escrow client; T16 keeps
+ *  the simpler length-only rule so both branches agree. */
+const MIN_PASSPHRASE_LEN = 12;
+
 export function Onboarding({ onComplete }: OnboardingProps): JSX.Element {
   const [step, setStep] = useState<OnboardingStep>({ kind: "intro" });
   const [passphrase, setPassphrase] = useState("");
@@ -59,16 +68,19 @@ export function Onboarding({ onComplete }: OnboardingProps): JSX.Element {
       const signIn = await r.auth.signIn();
       const lookup = await r.auth.lookupExisting(signIn.jwt);
       // Persist a minimal session — the popup re-reads it on next open.
+      // Source of truth for token lifetime is the server's `expires_in`
+      // (already wall-clock-converted into `signIn.jwtExpiresAt`); the
+      // JWT `exp` claim is the next fallback so a hand-crafted test JWT
+      // without `expires_in` still parses; finally a 1h default keeps
+      // the session usable when both are missing (defence-in-depth).
       const session: Session = {
         jwt: signIn.jwt,
         googleSub: signIn.googleSub,
         profile: signIn.profile,
         jwtExpiresAt:
-          jwtExpiresAtMs(signIn.jwt) ??
-          // 1h fallback when the JWT lacks an `exp` claim — the server
-          // contract guarantees it, but defence-in-depth keeps the
-          // session usable.
-          Date.now() + 60 * 60 * 1000,
+          signIn.jwtExpiresAt > 0
+            ? signIn.jwtExpiresAt
+            : (jwtExpiresAtMs(signIn.jwt) ?? Date.now() + FALLBACK_SESSION_MS),
         signedInAt: Date.now(),
       };
       await r.session.set(session);
@@ -90,10 +102,10 @@ export function Onboarding({ onComplete }: OnboardingProps): JSX.Element {
   const handleSetPassphrase = async (
     signIn: GoogleSignInResult,
   ): Promise<void> => {
-    if (passphrase.length < 12) {
+    if (passphrase.length < MIN_PASSPHRASE_LEN) {
       setStep({
         kind: "error",
-        message: "passphrase must be at least 12 characters",
+        message: `passphrase must be at least ${String(MIN_PASSPHRASE_LEN)} characters`,
       });
       return;
     }
@@ -117,6 +129,17 @@ export function Onboarding({ onComplete }: OnboardingProps): JSX.Element {
   const handleWelcomeBack = async (
     signIn: GoogleSignInResult,
   ): Promise<void> => {
+    // Symmetric guard with `handleSetPassphrase` — the restore flow MUST
+    // never call the T17 stub without a passphrase the user actually
+    // typed. A bare click would otherwise surface the stub's misleading
+    // "not implemented" message instead of the right validation error.
+    if (passphrase.length < MIN_PASSPHRASE_LEN) {
+      setStep({
+        kind: "error",
+        message: `passphrase must be at least ${String(MIN_PASSPHRASE_LEN)} characters`,
+      });
+      return;
+    }
     setStep({ kind: "restoring", signIn });
     try {
       await keyEscrow.fetchAndRestoreStub({ passphrase, jwt: signIn.jwt });

--- a/packages/extension/src/popup/Onboarding.tsx
+++ b/packages/extension/src/popup/Onboarding.tsx
@@ -1,0 +1,346 @@
+// First-run onboarding flow (T16). Branches per the user-spec / task spec
+// after the Google sign-in resolves to a `LookupResult`:
+//
+//   - existing_pubkey === null         → "Set recovery passphrase" + T17
+//                                        wrap-and-upload stub.
+//   - existing_pubkey + escrow_present → "Welcome back" + passphrase prompt
+//                                        + T17 fetch-and-restore stub.
+//   - existing_pubkey + no escrow      → "Existing identity but no escrow
+//                                        on server" + manual import (T17
+//                                        follow-up).
+//
+// All key-escrow side effects are stubs in this file (`keyEscrow.*Stub`)
+// — T17 will replace them with the real Argon2id+AES-GCM pipeline. The
+// UI wiring + the server `/oauth/google/link` call are owned by T14 (the
+// link endpoint already ships) and T16 (this file).
+
+import { useState, type JSX } from "react";
+import { getRuntime } from "./runtime.js";
+import type {
+  GoogleSignInResult,
+  LookupResult,
+  Session,
+} from "../auth/types.js";
+import { jwtExpiresAtMs } from "../auth/session.js";
+
+/**
+ * Top-level onboarding state machine. The popup mounts this when
+ * `runtime.session.get()` returned `null` on first paint.
+ */
+type OnboardingStep =
+  | { kind: "intro" }
+  | { kind: "signing_in" }
+  | { kind: "set_passphrase"; signIn: GoogleSignInResult; lookup: LookupResult }
+  | { kind: "welcome_back"; signIn: GoogleSignInResult; lookup: LookupResult }
+  | {
+      kind: "no_escrow_edge";
+      signIn: GoogleSignInResult;
+      lookup: LookupResult;
+    }
+  | { kind: "wrapping"; signIn: GoogleSignInResult }
+  | { kind: "restoring"; signIn: GoogleSignInResult }
+  | { kind: "done" }
+  | { kind: "error"; message: string };
+
+export interface OnboardingProps {
+  /** Called once `done` is reached so the App can re-bootstrap. */
+  onComplete: () => void;
+}
+
+export function Onboarding({ onComplete }: OnboardingProps): JSX.Element {
+  const [step, setStep] = useState<OnboardingStep>({ kind: "intro" });
+  const [passphrase, setPassphrase] = useState("");
+
+  // ── Intro → sign-in → lookup ─────────────────────────────────────────────
+  const handleSignIn = async (): Promise<void> => {
+    setStep({ kind: "signing_in" });
+    try {
+      const r = getRuntime();
+      const signIn = await r.auth.signIn();
+      const lookup = await r.auth.lookupExisting(signIn.jwt);
+      // Persist a minimal session — the popup re-reads it on next open.
+      const session: Session = {
+        jwt: signIn.jwt,
+        googleSub: signIn.googleSub,
+        profile: signIn.profile,
+        jwtExpiresAt:
+          jwtExpiresAtMs(signIn.jwt) ??
+          // 1h fallback when the JWT lacks an `exp` claim — the server
+          // contract guarantees it, but defence-in-depth keeps the
+          // session usable.
+          Date.now() + 60 * 60 * 1000,
+        signedInAt: Date.now(),
+      };
+      await r.session.set(session);
+
+      if (lookup.existingPubkey === null) {
+        setStep({ kind: "set_passphrase", signIn, lookup });
+      } else if (lookup.escrowPresent) {
+        setStep({ kind: "welcome_back", signIn, lookup });
+      } else {
+        setStep({ kind: "no_escrow_edge", signIn, lookup });
+      }
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "sign-in failed";
+      setStep({ kind: "error", message });
+    }
+  };
+
+  // ── Branch 1: no existing pubkey → set passphrase → wrap + upload ──────
+  const handleSetPassphrase = async (
+    signIn: GoogleSignInResult,
+  ): Promise<void> => {
+    if (passphrase.length < 12) {
+      setStep({
+        kind: "error",
+        message: "passphrase must be at least 12 characters",
+      });
+      return;
+    }
+    setStep({ kind: "wrapping", signIn });
+    try {
+      // T17 stub: real implementation will Argon2id-derive a key,
+      // AES-GCM-256 wrap the freshly-generated Ed25519 secret, and POST
+      // `PUT /api/key-escrow` followed by `POST /oauth/google/link` with
+      // the possession proof. Here we only call the documented stub —
+      // T17 replaces it.
+      await keyEscrow.wrapAndUploadStub({ passphrase, jwt: signIn.jwt });
+      setStep({ kind: "done" });
+      onComplete();
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "wrap-and-upload failed";
+      setStep({ kind: "error", message });
+    }
+  };
+
+  // ── Branch 2: existing pubkey + escrow → fetch + restore ───────────────
+  const handleWelcomeBack = async (
+    signIn: GoogleSignInResult,
+  ): Promise<void> => {
+    setStep({ kind: "restoring", signIn });
+    try {
+      await keyEscrow.fetchAndRestoreStub({ passphrase, jwt: signIn.jwt });
+      setStep({ kind: "done" });
+      onComplete();
+    } catch (e) {
+      const message = e instanceof Error ? e.message : "restore failed";
+      setStep({ kind: "error", message });
+    }
+  };
+
+  // ── Render ──────────────────────────────────────────────────────────────
+
+  if (step.kind === "intro") {
+    return (
+      <Frame title="Welcome to Mnemonik">
+        <p className="text-xs text-text-muted">
+          Capture AI-chat context as verifiable memory. Sign in with Google to
+          enable cloud sync and cross-device restore. Local-only mode is
+          available from Settings after onboarding.
+        </p>
+        <button
+          type="button"
+          onClick={() => void handleSignIn()}
+          className="bg-accent-primary/20 hover:bg-accent-primary/30 text-accent-primary border border-accent-primary/50 text-xs font-mono uppercase tracking-wide py-2 rounded transition-colors"
+        >
+          Sign in with Google
+        </button>
+      </Frame>
+    );
+  }
+
+  if (step.kind === "signing_in") {
+    return (
+      <Frame title="Signing in">
+        <p className="text-xs text-text-muted">
+          Opening Google consent screen…
+        </p>
+      </Frame>
+    );
+  }
+
+  if (step.kind === "set_passphrase") {
+    return (
+      <Frame title="Set recovery passphrase">
+        <p className="text-xs text-text-muted">
+          Your passphrase encrypts your identity key. We cannot recover it for
+          you — store it in a password manager. Minimum 12 characters.
+        </p>
+        <label htmlFor="passphrase" className="sr-only">
+          Recovery passphrase
+        </label>
+        <input
+          id="passphrase"
+          type="password"
+          autoComplete="new-password"
+          value={passphrase}
+          onChange={(e) => setPassphrase(e.target.value)}
+          className="bg-black/30 border border-white/10 rounded px-2 py-1 text-xs font-mono"
+          placeholder="Recovery passphrase"
+        />
+        <button
+          type="button"
+          onClick={() => void handleSetPassphrase(step.signIn)}
+          className="bg-accent-primary/20 hover:bg-accent-primary/30 text-accent-primary border border-accent-primary/50 text-xs font-mono uppercase tracking-wide py-2 rounded transition-colors"
+        >
+          Encrypt &amp; upload
+        </button>
+      </Frame>
+    );
+  }
+
+  if (step.kind === "welcome_back") {
+    return (
+      <Frame title="Welcome back">
+        <p className="text-xs text-text-muted">
+          Identity{" "}
+          <span className="font-mono text-accent-primary">
+            {step.lookup.existingPubkey?.slice(0, 8)}…
+          </span>{" "}
+          detected. Enter your recovery passphrase to restore your keypair on
+          this device.
+        </p>
+        <label htmlFor="passphrase" className="sr-only">
+          Recovery passphrase
+        </label>
+        <input
+          id="passphrase"
+          type="password"
+          autoComplete="current-password"
+          value={passphrase}
+          onChange={(e) => setPassphrase(e.target.value)}
+          className="bg-black/30 border border-white/10 rounded px-2 py-1 text-xs font-mono"
+          placeholder="Recovery passphrase"
+        />
+        <button
+          type="button"
+          onClick={() => void handleWelcomeBack(step.signIn)}
+          className="bg-accent-primary/20 hover:bg-accent-primary/30 text-accent-primary border border-accent-primary/50 text-xs font-mono uppercase tracking-wide py-2 rounded transition-colors"
+        >
+          Restore identity
+        </button>
+      </Frame>
+    );
+  }
+
+  if (step.kind === "no_escrow_edge") {
+    return (
+      <Frame title="No escrow on server">
+        <p className="text-xs text-text-muted">
+          Your Google account is linked to identity{" "}
+          <span className="font-mono text-accent-primary">
+            {step.lookup.existingPubkey?.slice(0, 8)}…
+          </span>
+          , but we have no encrypted key blob for it. Import the keypair from
+          another device (CLI / webapp export) to continue. Manual import lands
+          in T17.
+        </p>
+        <button
+          type="button"
+          onClick={() => onComplete()}
+          className="bg-white/5 hover:bg-white/10 text-text-primary border border-white/10 text-xs font-mono uppercase tracking-wide py-2 rounded transition-colors"
+        >
+          Continue in local mode
+        </button>
+      </Frame>
+    );
+  }
+
+  if (step.kind === "wrapping") {
+    return (
+      <Frame title="Encrypting identity">
+        <p className="text-xs text-text-muted">
+          Deriving key, encrypting secret, uploading blob…
+        </p>
+      </Frame>
+    );
+  }
+
+  if (step.kind === "restoring") {
+    return (
+      <Frame title="Restoring identity">
+        <p className="text-xs text-text-muted">
+          Fetching encrypted key, deriving Argon2id key, decrypting secret…
+        </p>
+      </Frame>
+    );
+  }
+
+  if (step.kind === "error") {
+    return (
+      <Frame title="Sign-in failed">
+        <p className="text-xs text-red-400" role="alert">
+          {step.message}
+        </p>
+        <button
+          type="button"
+          onClick={() => setStep({ kind: "intro" })}
+          className="bg-white/5 hover:bg-white/10 text-text-primary border border-white/10 text-xs font-mono uppercase tracking-wide py-2 rounded transition-colors"
+        >
+          Try again
+        </button>
+      </Frame>
+    );
+  }
+
+  return (
+    <Frame title="Done">
+      <p className="text-xs text-text-muted">Loading popup…</p>
+    </Frame>
+  );
+}
+
+function Frame({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}): JSX.Element {
+  return (
+    <main className="bg-background text-text-primary p-4 flex flex-col gap-3 min-h-full">
+      <h1 className="text-sm text-accent-primary font-semibold tracking-wide">
+        {title}
+      </h1>
+      {children}
+    </main>
+  );
+}
+
+// ── T17 stubs ──────────────────────────────────────────────────────────────
+
+/**
+ * Key-escrow stubs. T17 (`packages/extension/src/auth/key-escrow.ts`)
+ * replaces these with the real implementation:
+ *
+ *   - `wrapAndUploadStub` will Argon2id-derive a 256-bit key from the
+ *     passphrase, AES-GCM-256 wrap the freshly-generated Ed25519 secret,
+ *     `PUT /api/key-escrow` with the ciphertext + KDF params, then
+ *     `POST /oauth/google/link` with a possession-proof signature over
+ *     the server-issued challenge.
+ *
+ *   - `fetchAndRestoreStub` will `GET /api/key-escrow` for the
+ *     ciphertext + KDF params, derive the same key, AES-GCM-decrypt,
+ *     and persist the recovered keypair to `chrome.storage.local`.
+ *
+ * Both are intentionally rejected here so the UI surfaces a clear
+ * "T17 follow-up" error in dev until the real implementation lands.
+ */
+const keyEscrow = {
+  async wrapAndUploadStub(_args: {
+    passphrase: string;
+    jwt: string;
+  }): Promise<void> {
+    throw new Error(
+      "key-escrow wrap-and-upload not implemented yet (T17 follow-up)",
+    );
+  },
+  async fetchAndRestoreStub(_args: {
+    passphrase: string;
+    jwt: string;
+  }): Promise<void> {
+    throw new Error(
+      "key-escrow fetch-and-restore not implemented yet (T17 follow-up)",
+    );
+  },
+};

--- a/packages/extension/src/popup/Onboarding.tsx
+++ b/packages/extension/src/popup/Onboarding.tsx
@@ -107,8 +107,17 @@ export function Onboarding({ onComplete }: OnboardingProps): JSX.Element {
         kind: "error",
         message: `passphrase must be at least ${String(MIN_PASSPHRASE_LEN)} characters`,
       });
+      // Clear before the user retries — see security-auditor SEC-MIN-3.
+      setPassphrase("");
       return;
     }
+    // Snapshot the passphrase locally so we can hand it to the T17 stub
+    // and immediately wipe the React state slot. The local `pp` is the
+    // only remaining reference; it goes out of scope as soon as the
+    // function returns. This minimises the window in which the
+    // passphrase is reachable from React DevTools / heap snapshots.
+    const pp = passphrase;
+    setPassphrase("");
     setStep({ kind: "wrapping", signIn });
     try {
       // T17 stub: real implementation will Argon2id-derive a key,
@@ -116,7 +125,7 @@ export function Onboarding({ onComplete }: OnboardingProps): JSX.Element {
       // `PUT /api/key-escrow` followed by `POST /oauth/google/link` with
       // the possession proof. Here we only call the documented stub —
       // T17 replaces it.
-      await keyEscrow.wrapAndUploadStub({ passphrase, jwt: signIn.jwt });
+      await keyEscrow.wrapAndUploadStub({ passphrase: pp, jwt: signIn.jwt });
       setStep({ kind: "done" });
       onComplete();
     } catch (e) {
@@ -138,11 +147,17 @@ export function Onboarding({ onComplete }: OnboardingProps): JSX.Element {
         kind: "error",
         message: `passphrase must be at least ${String(MIN_PASSPHRASE_LEN)} characters`,
       });
+      setPassphrase("");
       return;
     }
+    // Same snapshot-then-clear pattern as handleSetPassphrase. The
+    // passphrase MUST not linger in React state across the async T17
+    // call — see security-auditor SEC-MIN-3.
+    const pp = passphrase;
+    setPassphrase("");
     setStep({ kind: "restoring", signIn });
     try {
-      await keyEscrow.fetchAndRestoreStub({ passphrase, jwt: signIn.jwt });
+      await keyEscrow.fetchAndRestoreStub({ passphrase: pp, jwt: signIn.jwt });
       setStep({ kind: "done" });
       onComplete();
     } catch (e) {

--- a/packages/extension/src/popup/runtime.ts
+++ b/packages/extension/src/popup/runtime.ts
@@ -11,6 +11,11 @@
 
 import type { ChatTurn, ChatAdapter } from "../runtime/chat/types.js";
 import type { SearchResult, SourceMeta } from "../runtime/store/types.js";
+import type {
+  GoogleSignInResult,
+  LookupResult,
+  Session,
+} from "../auth/types.js";
 
 /** Identity loaded out of `chrome.storage.local`. `null` when the user
  *  has not completed T16 onboarding yet (popup renders a "not signed
@@ -104,6 +109,29 @@ export interface PopupRuntime {
   signRemote(args: SignMemoryArgs & SignMemoryResult): Promise<void>;
   recall(query: string, limit: number): Promise<SearchResult[]>;
   verify(args: VerifyArgs): Promise<VerifyOutcome>;
+
+  /**
+   * T16 auth surface. The popup never imports `src/auth/*` directly so
+   * the runtime stays the single seam for tests + service-worker
+   * integration. Heavy paths (`signInWithGoogle` opens
+   * `chrome.identity.launchWebAuthFlow`, `lookupExisting` POSTs to the
+   * server) sit behind dynamic imports in the default impl.
+   */
+  auth: {
+    signIn(): Promise<GoogleSignInResult>;
+    lookupExisting(jwt: string): Promise<LookupResult>;
+  };
+
+  /**
+   * T16 session-store seam. Same dynamic-import pattern as `auth`.
+   * Production code reads/writes `chrome.storage.local.session.v1` via
+   * the helpers in `src/auth/session.ts`.
+   */
+  session: {
+    get(): Promise<Session | null>;
+    set(session: Session): Promise<void>;
+    clear(): Promise<void>;
+  };
 }
 
 let current: PopupRuntime | null = null;
@@ -195,6 +223,32 @@ export function createDefaultRuntime(): PopupRuntime {
       const { getRuntimePipeline } = await import("./runtime-impl.js");
       return getRuntimePipeline().verify(args);
     },
+    auth: {
+      async signIn() {
+        // Lazy: keeps `chrome.identity.launchWebAuthFlow` and the PKCE
+        // helpers out of the popup's first-paint bundle.
+        const { signInWithGoogle } = await import("../auth/google-oauth.js");
+        return signInWithGoogle();
+      },
+      async lookupExisting(jwt: string) {
+        const { lookupExisting } = await import("../auth/lookup.js");
+        return lookupExisting(jwt);
+      },
+    },
+    session: {
+      async get() {
+        const { getSession } = await import("../auth/session.js");
+        return getSession();
+      },
+      async set(session) {
+        const { setSession } = await import("../auth/session.js");
+        return setSession(session);
+      },
+      async clear() {
+        const { clearSession } = await import("../auth/session.js");
+        return clearSession();
+      },
+    },
   };
 }
 
@@ -218,11 +272,11 @@ async function activeTabId(): Promise<number | null> {
 
 async function readChromeStorage<T>(
   area: "local" | "sync",
-  keys: string[]
+  keys: string[],
 ): Promise<Partial<T>> {
   try {
     const result = (await chrome.storage[area].get(
-      keys as unknown as string
+      keys as unknown as string,
     )) as unknown as Partial<T>;
     return result;
   } catch {

--- a/packages/extension/src/popup/runtime.ts
+++ b/packages/extension/src/popup/runtime.ts
@@ -116,6 +116,11 @@ export interface PopupRuntime {
    * integration. Heavy paths (`signInWithGoogle` opens
    * `chrome.identity.launchWebAuthFlow`, `lookupExisting` POSTs to the
    * server) sit behind dynamic imports in the default impl.
+   *
+   * Phase 1 hard-codes `DEFAULT_SERVER_ORIGIN` inside `signInWithGoogle`.
+   * Multi-environment config (e.g. options.serverUrl read from
+   * `chrome.storage.sync`) is a backlog item — when it lands, thread the
+   * URL through this seam rather than re-exporting the auth helpers.
    */
   auth: {
     signIn(): Promise<GoogleSignInResult>;

--- a/packages/extension/tests/component/popup/Capture.test.tsx
+++ b/packages/extension/tests/component/popup/Capture.test.tsx
@@ -34,6 +34,19 @@ function makeRuntime(overrides: Partial<PopupRuntime> = {}): PopupRuntime {
     signRemote: async () => undefined,
     recall: async () => [],
     verify: async () => ({ status: "not_found" }),
+    auth: {
+      signIn: async () => {
+        throw new Error("auth.signIn stub: not configured in test");
+      },
+      lookupExisting: async () => {
+        throw new Error("auth.lookupExisting stub: not configured in test");
+      },
+    },
+    session: {
+      get: async () => null,
+      set: async () => undefined,
+      clear: async () => undefined,
+    },
     ...overrides,
   };
 }
@@ -74,7 +87,7 @@ describe("Capture tab", () => {
       <Capture
         adapter={chatgptAdapter}
         prefilledSelection="captured paragraph"
-      />
+      />,
     );
 
     const tagInput = screen.getByLabelText("Tags");

--- a/packages/extension/tests/component/popup/Recall.test.tsx
+++ b/packages/extension/tests/component/popup/Recall.test.tsx
@@ -29,6 +29,19 @@ function makeRuntime(overrides: Partial<PopupRuntime> = {}): PopupRuntime {
     signRemote: async () => undefined,
     recall: async () => [],
     verify: async () => ({ status: "not_found" }),
+    auth: {
+      signIn: async () => {
+        throw new Error("auth.signIn stub: not configured in test");
+      },
+      lookupExisting: async () => {
+        throw new Error("auth.lookupExisting stub: not configured in test");
+      },
+    },
+    session: {
+      get: async () => null,
+      set: async () => undefined,
+      clear: async () => undefined,
+    },
     ...overrides,
   };
 }
@@ -109,7 +122,7 @@ describe("Recall tab", () => {
       expect(b).toBeDisabled();
     }
     expect(insertButtons[0]?.getAttribute("title") ?? "").toMatch(
-      /does not support/i
+      /does not support/i,
     );
   });
 

--- a/packages/extension/tests/component/popup/Verify.test.tsx
+++ b/packages/extension/tests/component/popup/Verify.test.tsx
@@ -14,7 +14,7 @@ import {
 } from "../../../src/popup/runtime.js";
 
 function makeRuntime(
-  verifyFn: (args: VerifyArgs) => Promise<VerifyOutcome>
+  verifyFn: (args: VerifyArgs) => Promise<VerifyOutcome>,
 ): PopupRuntime {
   return {
     loadIdentity: async () => null,
@@ -33,6 +33,19 @@ function makeRuntime(
     signRemote: async () => undefined,
     recall: async () => [],
     verify: verifyFn,
+    auth: {
+      signIn: async () => {
+        throw new Error("auth.signIn stub: not configured in test");
+      },
+      lookupExisting: async () => {
+        throw new Error("auth.lookupExisting stub: not configured in test");
+      },
+    },
+    session: {
+      get: async () => null,
+      set: async () => undefined,
+      clear: async () => undefined,
+    },
   };
 }
 

--- a/packages/extension/tests/unit/auth/google-oauth.test.ts
+++ b/packages/extension/tests/unit/auth/google-oauth.test.ts
@@ -370,6 +370,63 @@ describe("signInWithGoogle — token endpoint failure", () => {
   });
 });
 
+describe("extractProfile — security hardening (SEC-MIN-1, SEC-MIN-2)", () => {
+  // Hand-rolled b64url for hermetic tests.
+  function b64u(obj: unknown): string {
+    return btoa(JSON.stringify(obj))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  }
+  function mkIdToken(claims: Record<string, unknown>): string {
+    return [b64u({ alg: "RS256", typ: "JWT" }), b64u(claims), "sig"].join(".");
+  }
+
+  it("clamps overlong name / email / sub fields", async () => {
+    const { extractProfile } =
+      await import("../../../src/auth/google-oauth.js");
+    const oversized = "a".repeat(10_000);
+    const token = mkIdToken({
+      sub: "g-sub",
+      email: oversized,
+      name: oversized,
+      picture: "https://lh3.googleusercontent.com/p.png",
+    });
+    const profile = extractProfile(token, "header.payload.sig");
+    expect(profile.email.length).toBeLessThanOrEqual(256);
+    expect(profile.name.length).toBeLessThanOrEqual(256);
+    expect(profile.sub).toBe("g-sub");
+  });
+
+  it("rejects non-https picture URLs (defence-in-depth XSS hardening)", async () => {
+    const { extractProfile } =
+      await import("../../../src/auth/google-oauth.js");
+    const cases = [
+      "javascript:alert(1)", // classic XSS payload
+      "data:text/html,<script>alert(1)</script>", // data: URL
+      "http://example.com/p.png", // plain http
+      "not-a-url-at-all",
+      "", // empty
+    ];
+    for (const picture of cases) {
+      const token = mkIdToken({ sub: "g-sub", picture });
+      const profile = extractProfile(token, "header.payload.sig");
+      expect(profile.picture).toBe("");
+    }
+  });
+
+  it("accepts and normalises a valid https picture URL", async () => {
+    const { extractProfile } =
+      await import("../../../src/auth/google-oauth.js");
+    const token = mkIdToken({
+      sub: "g-sub",
+      picture: "https://lh3.googleusercontent.com/a/p.png",
+    });
+    const profile = extractProfile(token, "header.payload.sig");
+    expect(profile.picture).toBe("https://lh3.googleusercontent.com/a/p.png");
+  });
+});
+
 describe("signInWithGoogle — jwtExpiresAt", () => {
   it("returns wall-clock expiry derived from server's expires_in", async () => {
     installChromeMock((authorizeUrl) => {

--- a/packages/extension/tests/unit/auth/google-oauth.test.ts
+++ b/packages/extension/tests/unit/auth/google-oauth.test.ts
@@ -332,4 +332,79 @@ describe("signInWithGoogle — token endpoint failure", () => {
     expect(caught).toBeInstanceOf(AuthError);
     expect((caught as AuthError).message).toContain("401");
   });
+
+  it("surfaces RFC 6749 §5.2 error + error_description in the AuthError message", async () => {
+    installChromeMock((authorizeUrl) => {
+      const original = new URL(authorizeUrl);
+      const state = original.searchParams.get("state") ?? "";
+      const cb = new URL(REDIRECT_SENTINEL);
+      cb.searchParams.set("code", "ok-code");
+      cb.searchParams.set("state", state);
+      return cb.toString();
+    });
+    installFetchMock(
+      () =>
+        new Response(
+          JSON.stringify({
+            error: "invalid_grant",
+            error_description: "PKCE verifier mismatch",
+          }),
+          {
+            status: 400,
+            headers: { "content-type": "application/json" },
+          },
+        ),
+    );
+
+    let caught: unknown = undefined;
+    try {
+      await signInWithGoogle({ serverBaseUrl: "https://mc.test" });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(AuthError);
+    const msg = (caught as AuthError).message;
+    expect(msg).toContain("400");
+    expect(msg).toContain("invalid_grant");
+    expect(msg).toContain("PKCE verifier mismatch");
+  });
+});
+
+describe("signInWithGoogle — jwtExpiresAt", () => {
+  it("returns wall-clock expiry derived from server's expires_in", async () => {
+    installChromeMock((authorizeUrl) => {
+      const original = new URL(authorizeUrl);
+      const state = original.searchParams.get("state") ?? "";
+      const cb = new URL(REDIRECT_SENTINEL);
+      cb.searchParams.set("code", "ok-code");
+      cb.searchParams.set("state", state);
+      return cb.toString();
+    });
+    installFetchMock(
+      () =>
+        new Response(
+          JSON.stringify({
+            access_token: fakeAccessToken(),
+            id_token: fakeIdToken({ sub: "google-sub-12345" }),
+            token_type: "Bearer",
+            // Pick a distinctive value so we can assert it travelled
+            // through `signInWithGoogle` rather than the 1h default.
+            expires_in: 1234,
+            scope: "mcp",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+
+    const before = Date.now();
+    const result = await signInWithGoogle({
+      serverBaseUrl: "https://mc.test",
+    });
+    const after = Date.now();
+    // Expiry must be roughly `now + 1234s`. Allow a wide window for
+    // CI clock jitter — the point is to prove the value is NOT the 1h
+    // (3600s) default.
+    expect(result.jwtExpiresAt).toBeGreaterThanOrEqual(before + 1234 * 1000);
+    expect(result.jwtExpiresAt).toBeLessThanOrEqual(after + 1234 * 1000 + 100);
+  });
 });

--- a/packages/extension/tests/unit/auth/google-oauth.test.ts
+++ b/packages/extension/tests/unit/auth/google-oauth.test.ts
@@ -1,0 +1,335 @@
+// T16 D13-binding TDD anchors for the Google sign-in client.
+//
+// Both anchors must pass under `bun test` (D13 + tech-spec). The chrome.*
+// surface is hand-stubbed via `globalThis.chrome` so the tests are runtime-
+// agnostic (no jsdom dependency, no fetch polyfill assumptions).
+//
+// Anchor 1: `pkce_state_mismatch_rejects` — a tampered callback URL whose
+//   `state` does NOT match the value the client sent must throw BEFORE the
+//   POST `/oauth/token` exchange happens (RFC 7636 §4.4 / RFC 6749 §10.12).
+//
+// Anchor 2: `redirect_uri_uses_chrome_identity_helper` — the URL handed to
+//   `chrome.identity.launchWebAuthFlow` must carry exactly
+//   `chrome.identity.getRedirectURL('google')` as `redirect_uri` (D5: the
+//   server is the only party that needs to know how to talk to Google;
+//   the extension only ever uses the chromiumapp.org deeplink).
+
+// Uses vitest imports — works under vitest natively and under `bun test`
+// via bun's vitest-compat shim (Decision 11 of the repo CI policy makes
+// `bun test` the uniform JS-runner; vitest is the local-dev test command).
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { signInWithGoogle } from "../../../src/auth/google-oauth.js";
+import { AuthError } from "../../../src/auth/types.js";
+
+// ── Test doubles ─────────────────────────────────────────────────────────────
+
+interface ChromeIdentityStub {
+  getRedirectURL: (path: string) => string;
+  launchWebAuthFlow: (
+    details: { url: string; interactive: boolean },
+    cb: (responseUrl?: string) => void,
+  ) => void;
+}
+
+interface ChromeStub {
+  identity: ChromeIdentityStub;
+  runtime?: { lastError?: { message: string } | undefined };
+}
+
+const REDIRECT_SENTINEL = "https://test-extension-id.chromiumapp.org/google";
+
+let originalChrome: unknown;
+let originalFetch: typeof globalThis.fetch | undefined;
+let fetchCalls: { url: string; init?: RequestInit }[] = [];
+
+function installChromeMock(
+  launchHandler: (url: string) => string | undefined,
+): { capturedUrl: { value: string | null } } {
+  const captured: { value: string | null } = { value: null };
+  const stub: ChromeStub = {
+    identity: {
+      getRedirectURL: (_path: string) => REDIRECT_SENTINEL,
+      launchWebAuthFlow: (details, cb) => {
+        captured.value = details.url;
+        const responseUrl = launchHandler(details.url);
+        // Mirror chrome.identity behaviour: callback may receive undefined
+        // (user cancelled) which sets chrome.runtime.lastError. Tests that
+        // want the success path return a string redirect URL.
+        if (responseUrl === undefined) {
+          stub.runtime = {
+            lastError: { message: "user_cancelled" },
+          };
+        }
+        cb(responseUrl);
+      },
+    },
+    runtime: { lastError: undefined },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = stub;
+  return { capturedUrl: captured };
+}
+
+function installFetchMock(
+  handler: (url: string, init?: RequestInit) => Response,
+): void {
+  fetchCalls = [];
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    // `exactOptionalPropertyTypes` rejects `{ init: undefined }`; only
+    // include the key when the caller actually supplied an init.
+    const entry: { url: string; init?: RequestInit } = { url };
+    if (init !== undefined) entry.init = init;
+    fetchCalls.push(entry);
+    return Promise.resolve(handler(url, init));
+  }) as typeof globalThis.fetch;
+}
+
+// Build a minimally valid base64url-encoded JWT segment so the token
+// exchange happy path can decode it without needing a real signer.
+function b64url(obj: unknown): string {
+  const json = JSON.stringify(obj);
+  const b64 = btoa(json);
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function fakeIdToken(claims: Record<string, unknown>): string {
+  const header = b64url({ alg: "RS256", typ: "JWT" });
+  const payload = b64url(claims);
+  // Signature is irrelevant — the server already validated it, the
+  // extension only parses claims.
+  return `${header}.${payload}.sig`;
+}
+
+function fakeAccessToken(): string {
+  // Server-issued JWT (HS256). We never verify it client-side; the
+  // popup just stores it.
+  return [
+    b64url({ alg: "HS256", typ: "JWT" }),
+    b64url({
+      sub: "pub_base58_user",
+      google_sub: "google-sub-12345",
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    }),
+    "sig",
+  ].join(".");
+}
+
+beforeEach(() => {
+  originalChrome = (globalThis as { chrome?: unknown }).chrome;
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).chrome = originalChrome;
+  if (originalFetch) globalThis.fetch = originalFetch;
+});
+
+// ── Anchor 1: state mismatch rejects ─────────────────────────────────────────
+
+describe("signInWithGoogle — pkce_state_mismatch_rejects", () => {
+  it("throws an OAuthError with code 'state_mismatch' before any token POST", async () => {
+    let tokenExchangeCalled = false;
+
+    installChromeMock((authorizeUrl) => {
+      // Server-side flow would echo back our `state`; instead we forge a
+      // bogus value to simulate a CSRF / leaked-code attack.
+      const original = new URL(authorizeUrl);
+      const _ = original.searchParams.get("state"); // intentionally unused
+      const cb = new URL(REDIRECT_SENTINEL);
+      cb.searchParams.set("code", "server-issued-code");
+      cb.searchParams.set("state", "ATTACKER-CONTROLLED-STATE");
+      return cb.toString();
+    });
+
+    installFetchMock(() => {
+      tokenExchangeCalled = true;
+      return new Response(
+        JSON.stringify({
+          access_token: fakeAccessToken(),
+          id_token: fakeIdToken({ sub: "google-sub-12345" }),
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "mcp",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    let caught: unknown = undefined;
+    try {
+      await signInWithGoogle({ serverBaseUrl: "https://mc.test" });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(AuthError);
+    expect((caught as AuthError).message).toContain("state mismatch");
+    // The critical RFC 7636 §4.4 guarantee: no token exchange happened.
+    expect(tokenExchangeCalled).toBe(false);
+    expect(fetchCalls.length).toBe(0);
+  });
+});
+
+// ── Anchor 2: redirect_uri uses chrome.identity helper ──────────────────────
+
+describe("signInWithGoogle — redirect_uri_uses_chrome_identity_helper", () => {
+  it("passes exactly chrome.identity.getRedirectURL('google') to launchWebAuthFlow", async () => {
+    const { capturedUrl } = installChromeMock((authorizeUrl) => {
+      // Echo state through; happy path so we observe the real URL.
+      const original = new URL(authorizeUrl);
+      const state = original.searchParams.get("state") ?? "";
+      const cb = new URL(REDIRECT_SENTINEL);
+      cb.searchParams.set("code", "server-issued-code");
+      cb.searchParams.set("state", state);
+      return cb.toString();
+    });
+
+    installFetchMock(
+      () =>
+        new Response(
+          JSON.stringify({
+            access_token: fakeAccessToken(),
+            id_token: fakeIdToken({
+              sub: "google-sub-12345",
+              email: "alice@example.com",
+              name: "Alice",
+              picture: "https://example.com/p.png",
+            }),
+            token_type: "Bearer",
+            expires_in: 3600,
+            scope: "mcp",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+
+    const result = await signInWithGoogle({ serverBaseUrl: "https://mc.test" });
+
+    expect(capturedUrl.value).not.toBeNull();
+    const url = new URL(capturedUrl.value as string);
+    expect(url.searchParams.get("redirect_uri")).toBe(REDIRECT_SENTINEL);
+
+    // The token exchange POST must also carry the IDENTICAL redirect_uri
+    // (RFC 6749 §4.1.3 — defeat swap-redirect on a leaked code).
+    expect(fetchCalls.length).toBe(1);
+    const tokenCall = fetchCalls[0];
+    expect(tokenCall).toBeDefined();
+    const body = JSON.parse(String(tokenCall?.init?.body ?? "{}"));
+    expect(body.redirect_uri).toBe(REDIRECT_SENTINEL);
+    expect(typeof body.code).toBe("string");
+    expect(typeof body.code_verifier).toBe("string");
+
+    // Sanity: returned shape matches the public contract.
+    expect(typeof result.jwt).toBe("string");
+    expect(result.googleSub).toBe("google-sub-12345");
+    expect(result.profile.email).toBe("alice@example.com");
+    expect(result.profile.name).toBe("Alice");
+  });
+});
+
+// ── Supporting coverage (PKCE shape, user-cancellation) ─────────────────────
+
+describe("signInWithGoogle — PKCE wire shape", () => {
+  it("sends S256 challenge derived from the verifier", async () => {
+    let challengeFromUrl: string | null = null;
+    let verifierFromBody: string | null = null;
+
+    installChromeMock((authorizeUrl) => {
+      const original = new URL(authorizeUrl);
+      challengeFromUrl = original.searchParams.get("code_challenge");
+      const state = original.searchParams.get("state") ?? "";
+      expect(original.searchParams.get("code_challenge_method")).toBe("S256");
+      const cb = new URL(REDIRECT_SENTINEL);
+      cb.searchParams.set("code", "ok-code");
+      cb.searchParams.set("state", state);
+      return cb.toString();
+    });
+
+    installFetchMock((_url, init) => {
+      const body = JSON.parse(String(init?.body ?? "{}"));
+      verifierFromBody = body.code_verifier;
+      return new Response(
+        JSON.stringify({
+          access_token: fakeAccessToken(),
+          id_token: fakeIdToken({ sub: "google-sub-12345" }),
+          token_type: "Bearer",
+          expires_in: 3600,
+          scope: "mcp",
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    });
+
+    await signInWithGoogle({ serverBaseUrl: "https://mc.test" });
+
+    expect(challengeFromUrl).not.toBeNull();
+    expect(verifierFromBody).not.toBeNull();
+    // The two `expect(...).not.toBeNull()` lines above guarantee the
+    // assignments fired; assert via `unknown` cast to satisfy
+    // `noImplicitAny`-style strictness without `as string` on a `null`.
+    const verifier = verifierFromBody as unknown as string;
+    const challenge = challengeFromUrl as unknown as string;
+    // Verifier must be base64url, no padding (RFC 7636 §4.1).
+    expect(verifier).toMatch(/^[A-Za-z0-9_-]+$/);
+    // Challenge must be 43 chars (base64url-no-pad of a 32-byte SHA-256).
+    expect(challenge.length).toBe(43);
+
+    // Verify the challenge actually equals SHA-256(verifier) — proves the
+    // client did the PKCE derivation, not just stuffed a random string.
+    const enc = new TextEncoder().encode(verifier);
+    const digest = await crypto.subtle.digest("SHA-256", enc);
+    const expected = btoa(String.fromCharCode(...new Uint8Array(digest)))
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+    expect(challengeFromUrl).toBe(expected);
+  });
+});
+
+describe("signInWithGoogle — user cancellation", () => {
+  it("throws OAuthError with code 'user_cancelled' when launchWebAuthFlow returns undefined", async () => {
+    installChromeMock(() => undefined);
+    installFetchMock(() => new Response("never reached", { status: 500 }));
+
+    let caught: unknown = undefined;
+    try {
+      await signInWithGoogle({ serverBaseUrl: "https://mc.test" });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(AuthError);
+    expect((caught as AuthError).message.toLowerCase()).toContain("cancel");
+    expect(fetchCalls.length).toBe(0);
+  });
+});
+
+describe("signInWithGoogle — token endpoint failure", () => {
+  it("throws OAuthError with code 'token_exchange_failed' on non-2xx", async () => {
+    installChromeMock((authorizeUrl) => {
+      const original = new URL(authorizeUrl);
+      const state = original.searchParams.get("state") ?? "";
+      const cb = new URL(REDIRECT_SENTINEL);
+      cb.searchParams.set("code", "ok-code");
+      cb.searchParams.set("state", state);
+      return cb.toString();
+    });
+    installFetchMock(
+      () =>
+        new Response(JSON.stringify({ error: "invalid_grant" }), {
+          status: 401,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+
+    let caught: unknown = undefined;
+    try {
+      await signInWithGoogle({ serverBaseUrl: "https://mc.test" });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(AuthError);
+    expect((caught as AuthError).message).toContain("401");
+  });
+});

--- a/packages/extension/tests/unit/auth/lookup.test.ts
+++ b/packages/extension/tests/unit/auth/lookup.test.ts
@@ -1,0 +1,215 @@
+// Lookup tests — exercise the four documented branches of
+// `POST /oauth/google/lookup` (`mcp/src/oauth/google.rs`):
+//
+//   1. existing pubkey + escrow_present → restore-on-new-device path,
+//   2. existing pubkey + no escrow      → manual-import edge case,
+//   3. no existing pubkey               → first-link path (link_challenge
+//                                          present),
+//   4. server 500                        → surfaces as `AuthError`.
+//
+// Plus rate-limit (429), missing JWT, and malformed-body coverage.
+
+// Uses vitest imports — works under vitest natively and under `bun test`
+// via bun's vitest-compat shim (Decision 11 of the repo CI policy).
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { lookupExisting } from "../../../src/auth/lookup.js";
+import { AuthError } from "../../../src/auth/types.js";
+
+let originalFetch: typeof globalThis.fetch | undefined;
+let fetchCalls: { url: string; init?: RequestInit }[] = [];
+
+function installFetchMock(
+  handler: (url: string, init?: RequestInit) => Response,
+): void {
+  fetchCalls = [];
+  globalThis.fetch = ((input: RequestInfo | URL, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    // `exactOptionalPropertyTypes` rejects `{ init: undefined }`.
+    const entry: { url: string; init?: RequestInit } = { url };
+    if (init !== undefined) entry.init = init;
+    fetchCalls.push(entry);
+    return Promise.resolve(handler(url, init));
+  }) as typeof globalThis.fetch;
+}
+
+beforeEach(() => {
+  originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+  if (originalFetch) globalThis.fetch = originalFetch;
+});
+
+const FAKE_JWT = "header.payload.signature";
+
+describe("lookupExisting — happy path: existing pubkey + escrow", () => {
+  it("returns the pubkey + escrowPresent=true and posts to /oauth/google/lookup with the bearer JWT", async () => {
+    installFetchMock(
+      () =>
+        new Response(
+          JSON.stringify({
+            existing_pubkey: "H8x_existing_pubkey_base58",
+            escrow_present: true,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    const result = await lookupExisting(FAKE_JWT, {
+      serverOrigin: "https://mc.test",
+    });
+    expect(result.existingPubkey).toBe("H8x_existing_pubkey_base58");
+    expect(result.escrowPresent).toBe(true);
+    // No link_challenge expected on the existing-pubkey path.
+    expect(result.linkChallenge).toBeNull();
+
+    expect(fetchCalls.length).toBe(1);
+    const call = fetchCalls[0];
+    expect(call?.url).toBe("https://mc.test/oauth/google/lookup");
+    const headers = call?.init?.headers as Record<string, string>;
+    expect(headers.authorization).toBe(`Bearer ${FAKE_JWT}`);
+    expect(call?.init?.method).toBe("POST");
+  });
+});
+
+describe("lookupExisting — first-link path: no existing pubkey", () => {
+  it("returns existingPubkey=null, escrowPresent=false, and surfaces link_challenge", async () => {
+    installFetchMock(
+      () =>
+        new Response(
+          JSON.stringify({
+            existing_pubkey: null,
+            escrow_present: false,
+            link_challenge: "base64-nonce==",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    const result = await lookupExisting(FAKE_JWT, {
+      serverOrigin: "https://mc.test",
+    });
+    expect(result.existingPubkey).toBeNull();
+    expect(result.escrowPresent).toBe(false);
+    expect(result.linkChallenge).toBe("base64-nonce==");
+  });
+});
+
+describe("lookupExisting — edge case: existing pubkey but no escrow", () => {
+  it("returns existingPubkey set, escrowPresent=false, no link_challenge", async () => {
+    installFetchMock(
+      () =>
+        new Response(
+          JSON.stringify({
+            existing_pubkey: "H8x_existing_pubkey_base58",
+            escrow_present: false,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+    );
+    const result = await lookupExisting(FAKE_JWT, {
+      serverOrigin: "https://mc.test",
+    });
+    expect(result.existingPubkey).toBe("H8x_existing_pubkey_base58");
+    expect(result.escrowPresent).toBe(false);
+    expect(result.linkChallenge).toBeNull();
+  });
+});
+
+describe("lookupExisting — server 500", () => {
+  it("throws AuthError surfacing the status code", async () => {
+    installFetchMock(
+      () =>
+        new Response(JSON.stringify({ error: "internal error" }), {
+          status: 500,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    let caught: unknown = undefined;
+    try {
+      await lookupExisting(FAKE_JWT, { serverOrigin: "https://mc.test" });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(AuthError);
+    expect((caught as AuthError).message).toContain("500");
+  });
+});
+
+describe("lookupExisting — server 429 rate-limit", () => {
+  it("throws AuthError flagged with the rate-limit status", async () => {
+    installFetchMock(
+      () =>
+        new Response(JSON.stringify({ error: "rate limit" }), {
+          status: 429,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    let caught: unknown = undefined;
+    try {
+      await lookupExisting(FAKE_JWT, { serverOrigin: "https://mc.test" });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(AuthError);
+    expect((caught as AuthError).message.toLowerCase()).toContain("rate-limit");
+  });
+});
+
+describe("lookupExisting — server 401 unauthorized", () => {
+  it("throws AuthError flagged with 401", async () => {
+    installFetchMock(() => new Response("", { status: 401 }));
+    let caught: unknown = undefined;
+    try {
+      await lookupExisting(FAKE_JWT, { serverOrigin: "https://mc.test" });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(AuthError);
+    expect((caught as AuthError).message).toContain("401");
+  });
+});
+
+describe("lookupExisting — input validation", () => {
+  it("throws when jwt is empty", async () => {
+    installFetchMock(() => new Response("never reached", { status: 500 }));
+    let caught: unknown = undefined;
+    try {
+      await lookupExisting("", { serverOrigin: "https://mc.test" });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(AuthError);
+    // No request should have been issued.
+    expect(fetchCalls.length).toBe(0);
+  });
+});
+
+describe("lookupExisting — malformed response shape", () => {
+  it("throws AuthError when escrow_present is missing", async () => {
+    installFetchMock(
+      () =>
+        new Response(JSON.stringify({ existing_pubkey: "x" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    let caught: unknown = undefined;
+    try {
+      await lookupExisting(FAKE_JWT, { serverOrigin: "https://mc.test" });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(AuthError);
+    expect((caught as AuthError).message).toContain("escrow_present");
+  });
+
+  it("throws AuthError when response is not JSON", async () => {
+    installFetchMock(() => new Response("not json at all", { status: 200 }));
+    let caught: unknown = undefined;
+    try {
+      await lookupExisting(FAKE_JWT, { serverOrigin: "https://mc.test" });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(AuthError);
+  });
+});

--- a/packages/extension/tests/unit/auth/session.test.ts
+++ b/packages/extension/tests/unit/auth/session.test.ts
@@ -1,0 +1,182 @@
+// Session-store tests — exercise the get / set / clear round-trip
+// against an in-memory storage shim. Also covers the JWT-expiry helper
+// (`jwtExpiresAtMs`) and the auto-expiry semantics of `getSession`.
+
+// Uses vitest imports — works under vitest natively and under `bun test`
+// via bun's vitest-compat shim (Decision 11 of the repo CI policy).
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getSession,
+  setSession,
+  clearSession,
+  jwtExpiresAtMs,
+  type StorageArea,
+} from "../../../src/auth/session.js";
+import { SESSION_STORAGE_KEY, type Session } from "../../../src/auth/types.js";
+
+// ── In-memory chrome.storage.local shim ─────────────────────────────────────
+
+function makeFakeStorage(): StorageArea & {
+  inspect: () => Record<string, unknown>;
+} {
+  let backing: Record<string, unknown> = {};
+  return {
+    async get(keys) {
+      const out: Record<string, unknown> = {};
+      const list =
+        typeof keys === "string"
+          ? [keys]
+          : Array.isArray(keys)
+            ? keys
+            : keys
+              ? Object.keys(keys)
+              : Object.keys(backing);
+      for (const k of list) {
+        if (k in backing) out[k] = backing[k];
+      }
+      return out;
+    },
+    async set(items) {
+      backing = { ...backing, ...items };
+    },
+    async remove(keys) {
+      const list = typeof keys === "string" ? [keys] : keys;
+      for (const k of list) delete backing[k];
+    },
+    inspect: () => backing,
+  };
+}
+
+const VALID_SESSION: Session = {
+  jwt: "header.payload.signature",
+  googleSub: "google-sub-12345",
+  jwtExpiresAt: Date.now() + 60 * 60 * 1000,
+  signedInAt: Date.now(),
+  profile: {
+    sub: "google-sub-12345",
+    email: "alice@example.com",
+    email_verified: true,
+    name: "Alice",
+    picture: "https://example.com/p.png",
+  },
+};
+
+let storage: ReturnType<typeof makeFakeStorage>;
+
+beforeEach(() => {
+  storage = makeFakeStorage();
+});
+
+describe("session — round-trip", () => {
+  it("getSession returns null when nothing has been written", async () => {
+    const result = await getSession(storage);
+    expect(result).toBeNull();
+  });
+
+  it("setSession writes the blob under session.v1, getSession reads it back", async () => {
+    await setSession(VALID_SESSION, storage);
+    const stored = storage.inspect();
+    expect(stored[SESSION_STORAGE_KEY]).toBeDefined();
+    const result = await getSession(storage);
+    expect(result).not.toBeNull();
+    expect(result?.jwt).toBe(VALID_SESSION.jwt);
+    expect(result?.googleSub).toBe(VALID_SESSION.googleSub);
+    expect(result?.profile.email).toBe("alice@example.com");
+  });
+
+  it("clearSession removes the persisted blob", async () => {
+    await setSession(VALID_SESSION, storage);
+    await clearSession(storage);
+    const stored = storage.inspect();
+    expect(stored[SESSION_STORAGE_KEY]).toBeUndefined();
+    const result = await getSession(storage);
+    expect(result).toBeNull();
+  });
+
+  it("clearSession is idempotent on an empty store", async () => {
+    // Should not throw — chrome.storage.local.remove is itself idempotent.
+    await clearSession(storage);
+    expect(storage.inspect()).toEqual({});
+  });
+});
+
+describe("session — auto-expiry on read", () => {
+  it("getSession returns null for an expired JWT", async () => {
+    const expired: Session = {
+      ...VALID_SESSION,
+      jwtExpiresAt: Date.now() - 1, // already in the past
+    };
+    await setSession(expired, storage);
+    // Real-clock now() will see jwtExpiresAt < Date.now() → null.
+    const result = await getSession(storage);
+    expect(result).toBeNull();
+  });
+
+  it("getSession respects an injected `now()` source", async () => {
+    const future = Date.now() + 60 * 60 * 1000;
+    await setSession({ ...VALID_SESSION, jwtExpiresAt: future }, storage);
+    // Inject a clock that's already past the expiry.
+    const result = await getSession(storage, () => future + 1);
+    expect(result).toBeNull();
+  });
+});
+
+describe("session — shape validation", () => {
+  it("getSession returns null when stored blob has missing fields (forward-compat)", async () => {
+    await storage.set({
+      [SESSION_STORAGE_KEY]: { jwt: "x", googleSub: "y" }, // missing the rest
+    });
+    const result = await getSession(storage);
+    expect(result).toBeNull();
+  });
+
+  it("setSession refuses to persist a malformed shape", async () => {
+    let caught: unknown = undefined;
+    try {
+      // Deliberately drop required fields. Cast through unknown to keep
+      // production-code constraints (no `as any`).
+      await setSession({ jwt: "x" } as unknown as Session, storage);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(Error);
+    // Nothing should have been written.
+    expect(storage.inspect()[SESSION_STORAGE_KEY]).toBeUndefined();
+  });
+});
+
+describe("jwtExpiresAtMs", () => {
+  function b64url(obj: unknown): string {
+    const json = JSON.stringify(obj);
+    return btoa(json)
+      .replace(/\+/g, "-")
+      .replace(/\//g, "_")
+      .replace(/=+$/, "");
+  }
+
+  it("returns ms from the exp claim when present", () => {
+    const expSec = Math.floor(Date.now() / 1000) + 3600;
+    const jwt = [
+      b64url({ alg: "HS256", typ: "JWT" }),
+      b64url({ sub: "x", exp: expSec, iat: expSec - 3600 }),
+      "sig",
+    ].join(".");
+    const result = jwtExpiresAtMs(jwt);
+    expect(result).toBe(expSec * 1000);
+  });
+
+  it("returns null for a malformed JWT", () => {
+    expect(jwtExpiresAtMs("not.a.real.token")).toBeNull();
+    expect(jwtExpiresAtMs("only-one-segment")).toBeNull();
+    expect(jwtExpiresAtMs("")).toBeNull();
+  });
+
+  it("returns null when the exp claim is missing or non-numeric", () => {
+    const jwt = [
+      b64url({ alg: "HS256", typ: "JWT" }),
+      b64url({ sub: "x" }), // no exp
+      "sig",
+    ].join(".");
+    expect(jwtExpiresAtMs(jwt)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- PKCE flow via `chrome.identity.launchWebAuthFlow` against the T14 `/oauth/google/start` + `/oauth/token` endpoints
- Session storage in `chrome.storage.local.session.v1` (`getSession` / `setSession` / `clearSession` + `jwtExpiresAtMs` helper)
- `POST /oauth/google/lookup` client returning `{existingPubkey, escrowPresent, linkChallenge}` for onboarding branching
- Onboarding screen with three branches per Decision 5 / user-spec scenarios:
  - no existing pubkey -> set recovery passphrase (T17 wrap-and-upload stub)
  - existing pubkey + escrow_present -> welcome back (T17 fetch-and-restore stub)
  - existing pubkey + no escrow -> manual import edge case (T17 follow-up)
- Both D13 TDD anchors implemented and passing:
  - `pkce_state_mismatch_rejects` — RFC 7636 §4.4 binding (constant-time state compare before token exchange)
  - `redirect_uri_uses_chrome_identity_helper` — D5 (no client_secret in the extension)
- T17 key-escrow stubs (`wrapAndUploadStub`, `fetchAndRestoreStub`) throw with clear "T17 follow-up" messages

## Test plan
- [ ] CI green on the PR
- [ ] Manual sign-in against staging server (post-merge)
- [ ] Onboarding branches render correctly with each lookup outcome (no-pubkey, welcome-back, no-escrow)
- [ ] Session survives popup close + service-worker restart

Closes T16 from `work/chrome-extension/tasks/16.md`.

Pre-existing failures unchanged on this branch (also fail on `origin/dev`):
- `tests/unit/sign/cose.test.ts` — missing `core/pkg-web` WASM artifact
- `vitest.config.ts` TS error — dual `vite` versions in `node_modules` (vitest's nested copy)
- `vite build` — missing `src/assets/icon-16.png` (manifest icons not yet added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)