### PR TITLE
chore(chrome-extension): mark T17 done; T18 in progress

### DIFF
--- a/work/chrome-extension/tasks/17.md
+++ b/work/chrome-extension/tasks/17.md
@@ -1,5 +1,5 @@
 ---
-status: in_progress
+status: done
 depends_on: [15, 16]
 wave: 5
 skills: [code-writing, security, ui]

--- a/work/chrome-extension/tasks/18.md
+++ b/work/chrome-extension/tasks/18.md
@@ -1,5 +1,5 @@
 ---
-status: pending
+status: in_progress
 depends_on: [02, 03, 05, 16, 17]
 wave: 5
 skills: [code-writing]


### PR DESCRIPTION
## Summary
Frontmatter-only orchestration update after T17 (PR #120 → `55b30be`) merged to `dev`.

- T17 → `done`
- T18 → `in_progress` (Wave D — final implementation; teammate spawned in `/private/tmp/t18-worktree`)

## Test plan
- [x] No code changes — task frontmatter only.
- [x] PR #120 already CI-green and merged.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>