### PR TITLE
feat(extension): T18 — cloud-tier sync via deferred-signing flow

### DIFF
--- a/packages/extension/src/background/cloud-sync.ts
+++ b/packages/extension/src/background/cloud-sync.ts
@@ -1,0 +1,308 @@
+// Alarm-driven drain of the cloud-sync queue. Invoked from the MV3
+// service worker on every `cloud-sync-retry` alarm tick (5-min cadence
+// per T10) and on the explicit `ui:flush-pending` gesture from the
+// popup.
+//
+// **Contract:** read `pending_uploads` rows from `IndexedDbStore` →
+// for each, run `CloudClient.signRemote(...)` → on success write the
+// returned `solana_tx` + `arweave_tx` onto the local row + `dequeue`
+// → on `PermanentSyncError` mark the row `sync_failed_permanent` and
+// dequeue (drop out of the alarm-retry loop while keeping the local
+// COSE envelope so the user can re-issue manually) → on
+// `ReauthRequiredError` stop the drain and tell the SW to emit
+// `mnemonik:re-auth-required` → on `TransientSyncError` leave the row
+// in the queue for the next tick.
+//
+// **IDB discipline:** `IndexedDbStore` opens a fresh transaction per
+// call. We do NOT share an `IDBDatabase` cursor across awaits — each
+// `saveAttestation` / `dequeue` is its own short transaction. This
+// mirrors the !Send rusqlite discipline from the server.
+
+import type { IndexedDbStore } from "../runtime/store/indexeddb.js";
+import type { AttestationRow } from "../runtime/store/types.js";
+import {
+  PermanentSyncError,
+  ReauthRequiredError,
+  TransientSyncError,
+} from "../runtime/sync/cloud-client.js";
+import type { SignRemoteResult } from "../runtime/sync/types.js";
+
+/** CustomEvent name dispatched on `globalThis` when a 401 surfaces.
+ *  Popup + options page subscribe to this and route the user back to
+ *  the T16 Google sign-in flow. Tests assert against this constant so
+ *  the wire spelling stays stable across refactors. */
+export const REAUTH_EVENT_NAME = "mnemonik:re-auth-required";
+
+/** Optional listener for sync failures the SW surfaces to the popup. */
+export type SyncEventListener = (event: SyncEvent) => void;
+
+export type SyncEvent =
+  | { type: "re-auth-required"; attestation_id: string }
+  | {
+      type: "permanent-failure";
+      attestation_id: string;
+      status: number;
+      message: string;
+    };
+
+/**
+ * Minimal client surface the drain depends on. Lets tests inject a
+ * fake without standing up a `fetch` mock. `CloudClient` satisfies
+ * this structurally.
+ */
+export interface CloudSignClient {
+  signRemote(
+    args: { content: string; tags: string[] },
+    signer: { cose_bytes: Uint8Array; signer_pubkey: string },
+  ): Promise<SignRemoteResult>;
+}
+
+export interface DrainDeps {
+  /** Backing store. The drain pulls rows out, never holds a cursor
+   *  across awaits — IDB `!Send` discipline (see file header). */
+  store: IndexedDbStore;
+  /** Cloud client built per-drain — keeps the JWT freshness window
+   *  tight. `null` short-circuits the drain (e.g. no session yet);
+   *  equivalent to "queue stays untouched". */
+  cloudClient: CloudSignClient | null;
+  /** Optional event sink. The SW wires this to
+   *  `chrome.runtime.sendMessage` / `globalThis.dispatchEvent`.
+   *  Defaults to a no-op so the popup can call `drainPendingUploads`
+   *  directly when it wants explicit control. */
+  emit?: SyncEventListener;
+}
+
+export interface DrainResult {
+  /** Rows the drain attempted to upload. */
+  attempted: number;
+  /** Rows that uploaded successfully (queue row removed, local row
+   *  updated with solana_tx + arweave_tx). */
+  flushed: number;
+  /** Distinct categorised errors observed this tick. */
+  errors: Array<{
+    attestation_id: string;
+    kind: "transient" | "permanent" | "reauth" | "missing-row";
+    message: string;
+  }>;
+}
+
+/** SW-facing return shape. Matches the deps signature installed in
+ *  T10 so the service-worker alarm handler is unchanged. */
+export interface FlushPendingResult {
+  attempted: number;
+  flushed: number;
+}
+
+/**
+ * SW-facing deps for `flushPending`. The SW alarm handler composes
+ * this per tick from its own deps (storeFactory + cloudClientProvider
+ * + emitSyncEvent), and the `ui:flush-pending` handler reuses the
+ * same shape so explicit-drain gestures produce the same observable
+ * behaviour as the automatic tick.
+ */
+export interface FlushPendingDeps {
+  store: IndexedDbStore;
+  /** Pre-built `CloudClient` (or any `CloudSignClient`). `null` when
+   *  there is no current session — the drain reports the queue depth
+   *  and returns without touching anything. */
+  cloudClient: CloudSignClient | null;
+  /** Optional event sink. Production wiring forwards to
+   *  `chrome.runtime.sendMessage` so the popup can react to 401 /
+   *  permanent-failure events. */
+  emit?: SyncEventListener;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// SW-facing entrypoint
+// ────────────────────────────────────────────────────────────────────────
+
+/**
+ * SW-facing drain entrypoint. Thin adapter over
+ * `drainPendingUploads`: forwards every dep, plus auto-dispatches
+ * the `mnemonik:re-auth-required` CustomEvent on `globalThis` when
+ * the drain observes a 401 (in addition to forwarding the typed
+ * event through `deps.emit`). Returns the projected `{attempted,
+ * flushed}` snapshot the SW logs.
+ *
+ * Never throws — every error is surfaced via the returned counts
+ * + `deps.emit`. The SW alarm `.catch` is purely defensive.
+ */
+export async function flushPending(
+  deps: FlushPendingDeps,
+): Promise<FlushPendingResult> {
+  const result = await drainPendingUploads({
+    store: deps.store,
+    cloudClient: deps.cloudClient,
+    emit: (event) => {
+      if (event.type === "re-auth-required") dispatchReauthEvent();
+      deps.emit?.(event);
+    },
+  });
+  return { attempted: result.attempted, flushed: result.flushed };
+}
+
+/**
+ * Drain the `pending_uploads` queue. Idempotent: rerunning after a
+ * partial failure resumes where the previous tick left off.
+ *
+ * Stop conditions:
+ *   - Empty queue → returns `{attempted: 0, flushed: 0, errors: []}`.
+ *   - `cloudClient` is `null` (no session) → reports the queue depth
+ *     so the SW can log "waiting for sign-in" without crashing.
+ *   - 401 on any row → drain stops; remaining rows stay queued.
+ *
+ * Never throws — every error is captured as an entry in `errors[]`.
+ */
+export async function drainPendingUploads(
+  deps: DrainDeps,
+): Promise<DrainResult> {
+  const result: DrainResult = { attempted: 0, flushed: 0, errors: [] };
+  const pending = await deps.store.listPending();
+  if (pending.length === 0) return result;
+  if (deps.cloudClient === null) {
+    result.attempted = pending.length;
+    return result;
+  }
+
+  for (const row of pending) {
+    result.attempted += 1;
+    // Fresh per-row look-up so a tx aborted by a previous iteration
+    // does not poison this one. IDB discipline: short transactions
+    // only; never hold one across the `await` for the network call.
+    const attestation = await deps.store.findById(row.attestation_id);
+    if (!attestation) {
+      // The queue references an attestation that no longer exists in
+      // the store (e.g. user deleted it). Drop the queue entry so we
+      // don't spin on it forever.
+      await deps.store.dequeue(row.attestation_id);
+      result.errors.push({
+        attestation_id: row.attestation_id,
+        kind: "missing-row",
+        message: "attestation row vanished; dequeued",
+      });
+      continue;
+    }
+    try {
+      const upload = await deps.cloudClient.signRemote(
+        {
+          content: attestation.content,
+          tags: [...attestation.tags],
+          ...(attestation.source_meta
+            ? { source_meta: attestation.source_meta }
+            : {}),
+        },
+        {
+          cose_bytes: attestation.cose_bytes,
+          signer_pubkey: attestation.signer_pubkey,
+        },
+      );
+      // Persist the cloud-side tx ids onto the existing row. Keep
+      // `attestation_id` stable — the server may return its own UUID
+      // but the local store has been keying off the client-derived id
+      // since T11; rewriting it would break Recall + Verify rows that
+      // already reference it from `lineage_edges`. The tx ids are
+      // exactly what D2 asks the drain to write back.
+      const updated: AttestationRow = {
+        ...attestation,
+        solana_tx: upload.solana_tx,
+        arweave_tx: upload.arweave_tx,
+      };
+      // Clear any prior `sync_failed_permanent` flag — a successful
+      // retry supersedes a previous permanent-failure stamp.
+      if (updated.sync_failed_permanent) {
+        delete updated.sync_failed_permanent;
+      }
+      await deps.store.saveAttestation(updated);
+      await deps.store.dequeue(row.attestation_id);
+      result.flushed += 1;
+    } catch (err) {
+      if (err instanceof ReauthRequiredError) {
+        deps.emit?.({
+          type: "re-auth-required",
+          attestation_id: row.attestation_id,
+        });
+        result.errors.push({
+          attestation_id: row.attestation_id,
+          kind: "reauth",
+          message: err.message,
+        });
+        // Halt — every subsequent row would hit the same 401.
+        return result;
+      }
+      if (err instanceof PermanentSyncError) {
+        // Mark the row permanently failed so the popup can render the
+        // "sync failed — recreate this memory" hint; also dequeue so
+        // the alarm doesn't churn on it.
+        await markPermanentFailure(deps.store, attestation);
+        await deps.store.dequeue(row.attestation_id);
+        deps.emit?.({
+          type: "permanent-failure",
+          attestation_id: row.attestation_id,
+          status: err.status,
+          message: err.message,
+        });
+        result.errors.push({
+          attestation_id: row.attestation_id,
+          kind: "permanent",
+          message: err.message,
+        });
+        continue;
+      }
+      if (err instanceof TransientSyncError) {
+        result.errors.push({
+          attestation_id: row.attestation_id,
+          kind: "transient",
+          message: err.message,
+        });
+        // Leave the row queued; the next alarm tick retries.
+        continue;
+      }
+      // Unknown error type — treat as transient so we don't lose
+      // data, but tag explicitly in the log. Caught here rather than
+      // re-thrown so a single bad row doesn't abort the whole drain.
+      const message = err instanceof Error ? err.message : String(err);
+      result.errors.push({
+        attestation_id: row.attestation_id,
+        kind: "transient",
+        message: `unexpected error: ${message}`,
+      });
+    }
+  }
+  return result;
+}
+
+// ────────────────────────────────────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────────────────────────────────────
+
+/** Stamp the row `sync_failed_permanent = true`. Idempotent. */
+async function markPermanentFailure(
+  store: IndexedDbStore,
+  row: AttestationRow,
+): Promise<void> {
+  if (row.sync_failed_permanent === true) return;
+  const updated: AttestationRow = { ...row, sync_failed_permanent: true };
+  await store.saveAttestation(updated);
+}
+
+/**
+ * Dispatch the `mnemonik:re-auth-required` CustomEvent on `globalThis`.
+ * Best-effort: silently no-ops if the host environment lacks
+ * `dispatchEvent` / `CustomEvent` (e.g. an isolated SW context). The
+ * popup + options page register listeners; the SW alarm handler
+ * fans this out to any open extension page.
+ */
+function dispatchReauthEvent(): void {
+  const g = globalThis as {
+    dispatchEvent?: (e: Event) => boolean;
+    CustomEvent?: typeof CustomEvent;
+  };
+  if (typeof g.dispatchEvent !== "function") return;
+  const Ctor = g.CustomEvent;
+  if (typeof Ctor !== "function") return;
+  try {
+    g.dispatchEvent(new Ctor(REAUTH_EVENT_NAME));
+  } catch {
+    // Hostile / read-only globals — non-fatal.
+  }
+}

--- a/packages/extension/src/background/service-worker.ts
+++ b/packages/extension/src/background/service-worker.ts
@@ -18,7 +18,12 @@
 //     `parseMsg` from `src/messages.ts`.
 
 import { IndexedDbStore } from "../runtime/store/indexeddb.js";
-import { flushPending } from "../runtime/sync/cloud-client.js";
+import { CloudClient } from "../runtime/sync/cloud-client.js";
+import {
+  flushPending,
+  type FlushPendingDeps,
+  type SyncEvent,
+} from "./cloud-sync.js";
 import { parseMsg, type Msg, type SaveSelectionPayload } from "../messages.js";
 
 /** Context-menu item id — keep stable; `chrome.contextMenus.create`
@@ -59,6 +64,16 @@ export interface ServiceWorkerDeps {
   /** Indirection so the alarm-drain test can spy without polluting the
    *  module-level binding. */
   flushPending: typeof flushPending;
+  /** Build a cloud client for one alarm tick — returns `null` when
+   *  there is no current session (the drain short-circuits in that
+   *  case and leaves the queue untouched). Defaults to reading
+   *  `session.v1` out of `chrome.storage.local`. */
+  cloudClientProvider?: () => Promise<CloudClient | null>;
+  /** Sink the alarm-drain calls when it observes a sync event (401 /
+   *  permanent failure). The default production wiring forwards to
+   *  `chrome.runtime.sendMessage` so the popup can react. T18
+   *  routes `re-auth-required` here. */
+  emitSyncEvent?: (event: SyncEvent) => void;
   /** ISO-8601 clock — defaults to `() => new Date().toISOString()`;
    *  swappable for deterministic tests. */
   now: () => string;
@@ -70,8 +85,56 @@ function defaultDeps(): ServiceWorkerDeps {
     chrome,
     storeFactory: () => new IndexedDbStore(),
     flushPending,
+    cloudClientProvider: defaultCloudClientProvider,
+    emitSyncEvent: defaultEmitSyncEvent,
     now: () => new Date().toISOString(),
   };
+}
+
+/**
+ * Default `cloudClientProvider`. Reads the persisted T16 session
+ * out of `chrome.storage.local`; returns `null` when no session is
+ * present (or when the JWT has expired — `getSession` already
+ * gates on `jwtExpiresAt`). Lazy-imports `auth/session.js` so the
+ * SW boot path stays free of the JWT helpers when no alarm has
+ * fired yet.
+ */
+async function defaultCloudClientProvider(): Promise<CloudClient | null> {
+  try {
+    const { getSession } = await import("../auth/session.js");
+    const session = await getSession();
+    if (!session) return null;
+    return new CloudClient({ jwt: session.jwt });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(
+      "[mnemonik] cloud-client provider failed; skipping drain:",
+      message,
+    );
+    return null;
+  }
+}
+
+/**
+ * Default `emitSyncEvent`. Forwards to the popup via
+ * `chrome.runtime.sendMessage`. The popup listens for
+ * `ui:re-auth-required` and routes back to the T16 sign-in flow.
+ * Wrapped in try/catch because `sendMessage` rejects when no popup
+ * is open — that's expected and not an error.
+ */
+function defaultEmitSyncEvent(event: SyncEvent): void {
+  try {
+    void chrome.runtime
+      .sendMessage({
+        type: "ui:sync-event",
+        payload: event,
+      })
+      .catch(() => {
+        // No popup open / no listener registered — silently ignore.
+      });
+  } catch {
+    // chrome.runtime unavailable (tests / cold-boot path).
+  }
 }
 
 /**
@@ -141,7 +204,7 @@ export function installServiceWorker(deps: ServiceWorkerDeps): void {
     (
       raw: unknown,
       sender: chrome.runtime.MessageSender,
-      sendResponse: (response: unknown) => void
+      sendResponse: (response: unknown) => void,
     ) => {
       const msg = parseMsg(raw);
       if (msg === null) {
@@ -163,7 +226,7 @@ export function installServiceWorker(deps: ServiceWorkerDeps): void {
           "[mnemonik] rejected message from unauthorised sender",
           msg.type,
           sender.id,
-          sender.url ?? sender.tab?.url ?? "<no url>"
+          sender.url ?? sender.tab?.url ?? "<no url>",
         );
         sendResponse({ ok: false, error: "unauthorized-sender" });
         return false;
@@ -177,7 +240,7 @@ export function installServiceWorker(deps: ServiceWorkerDeps): void {
           sendResponse({ ok: false, error: message });
         });
       return true;
-    }
+    },
   );
 
   // ── alarms: drain cloud-sync queue ───────────────────────────────────
@@ -188,22 +251,47 @@ export function installServiceWorker(deps: ServiceWorkerDeps): void {
     // IndexedDB queue. T18 will inherit this contract.
     if (cloudSyncInFlight) {
       console.warn(
-        "[mnemonik] cloud-sync-retry skipped: previous flush still in flight"
+        "[mnemonik] cloud-sync-retry skipped: previous flush still in flight",
       );
       return;
     }
     cloudSyncInFlight = true;
     const store = deps.storeFactory();
-    void deps
-      .flushPending({ store })
+    void runFlush(deps, store)
       .catch((err: unknown) => {
         const message = err instanceof Error ? err.message : String(err);
         console.warn("[mnemonik] flushPending failed:", message);
       })
       .finally(() => {
+        // CRITICAL: reset the guard in `finally` so a thrown error in
+        // any leg of the drain doesn't permanently wedge the alarm
+        // (next tick would skip with "previous flush still in
+        // flight"). Inherited from the T10 round-2 hardening.
         cloudSyncInFlight = false;
       });
   });
+}
+
+/**
+ * Compose the per-tick `FlushPendingDeps` and call `deps.flushPending`.
+ * Resolves the cloud client lazily so we don't burn a JWT decode on
+ * empty queues. Shared by the alarm handler and the explicit
+ * `ui:flush-pending` UI gesture so both paths emit `re-auth-required`
+ * the same way.
+ */
+async function runFlush(
+  deps: ServiceWorkerDeps,
+  store: IndexedDbStore,
+): Promise<unknown> {
+  const cloudClient = deps.cloudClientProvider
+    ? await deps.cloudClientProvider()
+    : null;
+  const args: FlushPendingDeps = {
+    store,
+    cloudClient,
+    ...(deps.emitSyncEvent ? { emit: deps.emitSyncEvent } : {}),
+  };
+  return deps.flushPending(args);
 }
 
 /**
@@ -222,7 +310,7 @@ export function installServiceWorker(deps: ServiceWorkerDeps): void {
 function isAuthorisedSender(
   cr: typeof chrome,
   sender: chrome.runtime.MessageSender,
-  msg: Msg
+  msg: Msg,
 ): boolean {
   // Our own extension id must match. `chrome.runtime.id` is the
   // canonical source of truth at runtime. If sender.id is set, it
@@ -252,7 +340,7 @@ function isAuthorisedSender(
     const tabUrl = sender.tab?.url ?? sender.url;
     if (typeof tabUrl !== "string") return false;
     return ALLOWED_TAB_ORIGINS.some((origin) =>
-      tabUrl.startsWith(origin + "/")
+      tabUrl.startsWith(origin + "/"),
     );
   }
 
@@ -292,7 +380,7 @@ async function handleMsg(deps: ServiceWorkerDeps, msg: Msg): Promise<unknown> {
   switch (msg.type) {
     case "ui:flush-pending": {
       const store = deps.storeFactory();
-      return deps.flushPending({ store });
+      return runFlush(deps, store);
     }
     case "ui:sign-memory":
       // T11 / T18: delegate to runtime/sign + runtime/store. The SW

--- a/packages/extension/src/popup/App.tsx
+++ b/packages/extension/src/popup/App.tsx
@@ -119,6 +119,59 @@ export function App(): JSX.Element {
     void bootstrap();
   }, [bootstrap]);
 
+  /**
+   * T18 re-auth gate. The cloud-sync drain dispatches
+   * `mnemonik:re-auth-required` on `globalThis` and emits a
+   * `ui:sync-event` over `chrome.runtime.sendMessage` when it sees a
+   * 401 on `/mcp` or `/api/sign-callback`. Both surfaces converge
+   * here: clear the cached session and force-mount onboarding so the
+   * user is routed back through the T16 sign-in flow. Without this
+   * the drain silently halts and the user cannot recover from the
+   * popup. Closes code-review round-1 finding T18-C-MAJOR-01.
+   */
+  useEffect(() => {
+    const forceReauth = (): void => {
+      void getRuntime()
+        .session.clear()
+        .catch(() => {
+          // Best-effort — even if the clear fails, flipping to
+          // onboarding will re-read the session and (since the JWT
+          // is likely expired anyway) `getSession` will return null.
+        })
+        .finally(() => {
+          setMode("onboarding");
+        });
+    };
+    const onCustom = (): void => forceReauth();
+    const onRuntimeMessage = (raw: unknown): void => {
+      if (typeof raw !== "object" || raw === null) return;
+      const msg = raw as { type?: unknown; payload?: unknown };
+      if (msg.type !== "ui:sync-event") return;
+      const payload = msg.payload;
+      if (typeof payload !== "object" || payload === null) return;
+      if ((payload as { type?: unknown }).type === "re-auth-required") {
+        forceReauth();
+      }
+    };
+    const g = globalThis as {
+      addEventListener?: (n: string, h: EventListener) => void;
+      removeEventListener?: (n: string, h: EventListener) => void;
+    };
+    g.addEventListener?.(
+      "mnemonik:re-auth-required",
+      onCustom as EventListener,
+    );
+    const cr = (globalThis as { chrome?: typeof chrome }).chrome;
+    cr?.runtime?.onMessage?.addListener(onRuntimeMessage);
+    return () => {
+      g.removeEventListener?.(
+        "mnemonik:re-auth-required",
+        onCustom as EventListener,
+      );
+      cr?.runtime?.onMessage?.removeListener?.(onRuntimeMessage);
+    };
+  }, []);
+
   const openOptions = (): void => {
     try {
       chrome.runtime.openOptionsPage();

--- a/packages/extension/src/popup/runtime.ts
+++ b/packages/extension/src/popup/runtime.ts
@@ -280,23 +280,81 @@ export function createDefaultRuntime(): PopupRuntime {
       return getRuntimePipeline().signMemory(args);
     },
     async signRemote(args) {
-      // T18: Cloud-tier push. We re-use the cloudSync facade so the
-      // dynamic-import / session lookup lives in one place. On Local
-      // tier the popup never calls this; on Cloud tier this enqueues
-      // a `pending_uploads` row if no session is bound and is a no-op
-      // otherwise (the alarm drain handles the actual upload).
-      // Currently we just enqueue — the COSE bytes were signed in
-      // `signMemory`, so the alarm-drain has everything it needs.
-      // Explicit network attempt happens on the next alarm tick or on
-      // the user's manual flush gesture from the popup.
+      // T18: Cloud-tier push. Task spec: attempt the live POST /mcp +
+      // POST /api/sign-callback immediately, falling back to the
+      // pending_uploads queue only on transient failure (network /
+      // 5xx) or absent session. The alarm drain handles the queue.
+      // Closes code-review round-1 finding T18-C-MAJOR-02.
       try {
         const { IndexedDbStore } =
           await import("../runtime/store/indexeddb.js");
         const store = new IndexedDbStore();
+        // Always enqueue first so a crash between the live attempt
+        // and its dequeue (browser tab close, popup dismiss) doesn't
+        // strand the row outside the queue. The CloudClient's
+        // happy path will `dequeue` immediately after the server
+        // returns a 200; on failure the row stays for the alarm.
         await store.enqueue(args.attestation_id);
       } catch {
-        // Best-effort — if IDB is unavailable the alarm drain will
-        // simply have nothing to do.
+        // Best-effort enqueue. If IDB itself is unavailable, the
+        // live push below will still try; failing both is fine.
+      }
+      try {
+        const result = await this.cloudSync.signRemote(args);
+        // null = no session bound — leave the row enqueued, the
+        // user's next sign-in will pick it up on the alarm tick.
+        // Non-null = success; cloudSync.signRemote already wrote
+        // the tx ids back and dequeued. Nothing more to do.
+        void result;
+      } catch (err) {
+        const cc = await import("../runtime/sync/cloud-client.js");
+        if (err instanceof cc.ReauthRequiredError) {
+          // Surface re-auth as a global event so the popup's App.tsx
+          // can flip into onboarding mode. Leave the row queued so
+          // the next alarm tick (after re-auth) retries it.
+          const g = globalThis as {
+            dispatchEvent?: (e: Event) => boolean;
+            CustomEvent?: typeof CustomEvent;
+          };
+          if (
+            typeof g.dispatchEvent === "function" &&
+            typeof g.CustomEvent === "function"
+          ) {
+            try {
+              g.dispatchEvent(new g.CustomEvent("mnemonik:re-auth-required"));
+            } catch {
+              // Read-only globals — non-fatal.
+            }
+          }
+          return;
+        }
+        if (err instanceof cc.PermanentSyncError) {
+          // Mark permanently failed locally so the popup can render
+          // the "sync failed" hint. Dequeue so the alarm doesn't
+          // churn. Mirror what `drainPendingUploads` does on the
+          // background side.
+          try {
+            const { IndexedDbStore } =
+              await import("../runtime/store/indexeddb.js");
+            const store = new IndexedDbStore();
+            const row = await store.findById(args.attestation_id);
+            if (row) {
+              await store.saveAttestation({
+                ...row,
+                sync_failed_permanent: true,
+              });
+            }
+            await store.dequeue(args.attestation_id);
+          } catch {
+            // Best-effort cleanup.
+          }
+          // Re-throw so the caller (Capture.tsx) can surface a toast.
+          throw err;
+        }
+        // TransientSyncError or unknown: leave the row queued. The
+        // alarm drain will retry on the next tick. We don't re-throw
+        // so the Capture happy-path UX isn't blocked by a transient
+        // upstream hiccup — the user sees the local sign succeed.
       }
     },
     async recall(query, limit) {

--- a/packages/extension/src/popup/runtime.ts
+++ b/packages/extension/src/popup/runtime.ts
@@ -17,6 +17,16 @@ import type {
   Session,
 } from "../auth/types.js";
 import type { EscrowBlob } from "../auth/key-escrow.js";
+import type {
+  RecallRemoteHit,
+  VerifyRemoteResult,
+} from "../runtime/sync/cloud-client.js";
+
+/** Re-export of `RecallRemoteHit` so popup callers depend on the
+ *  facade rather than reaching into `runtime/sync/cloud-client.ts`. */
+export type CloudRecallHit = RecallRemoteHit;
+/** Same re-export pattern for the verify-result discriminated union. */
+export type CloudVerifyOutcome = VerifyRemoteResult;
 
 /** Identity loaded out of `chrome.storage.local`. `null` when the user
  *  has not completed T16 onboarding yet (popup renders a "not signed
@@ -140,6 +150,26 @@ export interface PopupRuntime {
   };
 
   /**
+   * T18 cloud-sync seam. Popup tabs (Recall in Cloud mode, future
+   * Verify-in-Cloud) route through this facade rather than importing
+   * `runtime/sync/cloud-client.ts` directly. The concrete impl
+   * dynamic-imports the client lazily so the popup's first-paint
+   * bundle stays under the size-limit budget — only Recall in Cloud
+   * mode pays the network-client cost.
+   *
+   * All three methods return `null` when there is no JWT-bearing
+   * session yet; callers branch on that to render "sign in to see
+   * cloud results" without throwing.
+   */
+  cloudSync: {
+    signRemote(
+      args: SignMemoryArgs & SignMemoryResult,
+    ): Promise<{ solana_tx: string; arweave_tx: string } | null>;
+    recallRemote(query: string, k: number): Promise<CloudRecallHit[] | null>;
+    verifyRemote(attestationId: string): Promise<CloudVerifyOutcome | null>;
+  };
+
+  /**
    * T17 key-escrow seam. Popup onboarding components route through this
    * facade rather than importing `src/auth/key-escrow.ts` directly, so
    * tests have a single mock seam. The concrete impl dynamic-imports
@@ -249,10 +279,25 @@ export function createDefaultRuntime(): PopupRuntime {
       const { getRuntimePipeline } = await import("./runtime-impl.js");
       return getRuntimePipeline().signMemory(args);
     },
-    async signRemote() {
-      // T18 wires the cloud client. Local-tier and pre-T18 builds are
-      // both fine to no-op here.
-      return;
+    async signRemote(args) {
+      // T18: Cloud-tier push. We re-use the cloudSync facade so the
+      // dynamic-import / session lookup lives in one place. On Local
+      // tier the popup never calls this; on Cloud tier this enqueues
+      // a `pending_uploads` row if no session is bound and is a no-op
+      // otherwise (the alarm drain handles the actual upload).
+      // Currently we just enqueue — the COSE bytes were signed in
+      // `signMemory`, so the alarm-drain has everything it needs.
+      // Explicit network attempt happens on the next alarm tick or on
+      // the user's manual flush gesture from the popup.
+      try {
+        const { IndexedDbStore } =
+          await import("../runtime/store/indexeddb.js");
+        const store = new IndexedDbStore();
+        await store.enqueue(args.attestation_id);
+      } catch {
+        // Best-effort — if IDB is unavailable the alarm drain will
+        // simply have nothing to do.
+      }
     },
     async recall(query, limit) {
       const { getRuntimePipeline } = await import("./runtime-impl.js");
@@ -286,6 +331,52 @@ export function createDefaultRuntime(): PopupRuntime {
       async clear() {
         const { clearSession } = await import("../auth/session.js");
         return clearSession();
+      },
+    },
+    cloudSync: {
+      async signRemote(args) {
+        // Synchronous push path. Tabs that want immediate cloud
+        // confirmation (rather than waiting for the alarm-drain
+        // tick) call this. Returns `null` when there is no session;
+        // throws typed errors otherwise so the caller can branch.
+        const client = await buildCloudClient();
+        if (!client) return null;
+        const { signer_pubkey } = args;
+        // Re-load the COSE bytes off the local row — the popup
+        // already persisted them in `signMemory`, so we don't have
+        // to ship them across the messaging boundary again.
+        const { IndexedDbStore } =
+          await import("../runtime/store/indexeddb.js");
+        const store = new IndexedDbStore();
+        const row = await store.findById(args.attestation_id);
+        if (!row) return null;
+        const out = await client.signRemote(
+          {
+            content: row.content,
+            tags: [...row.tags],
+            ...(row.source_meta ? { source_meta: row.source_meta } : {}),
+          },
+          { cose_bytes: row.cose_bytes, signer_pubkey },
+        );
+        // Persist the tx ids back onto the row so subsequent Recall
+        // calls render them. Mirrors what the alarm-drain does.
+        await store.saveAttestation({
+          ...row,
+          solana_tx: out.solana_tx,
+          arweave_tx: out.arweave_tx,
+        });
+        await store.dequeue(args.attestation_id);
+        return { solana_tx: out.solana_tx, arweave_tx: out.arweave_tx };
+      },
+      async recallRemote(query, k) {
+        const client = await buildCloudClient();
+        if (!client) return null;
+        return client.recallRemote(query, k);
+      },
+      async verifyRemote(attestationId) {
+        const client = await buildCloudClient();
+        if (!client) return null;
+        return client.verifyRemote(attestationId);
       },
     },
     keyEscrow: {
@@ -328,6 +419,24 @@ export function createDefaultRuntime(): PopupRuntime {
       },
     },
   };
+}
+
+// ── cloud-sync helper ───────────────────────────────────────────────────────
+
+/**
+ * Build a `CloudClient` from the persisted session. Returns `null`
+ * when no session is bound — callers branch on that to render
+ * "sign in to see cloud results" without throwing. Dynamic-imports
+ * to keep the popup's first-paint bundle free of `fetch` setup.
+ */
+async function buildCloudClient(): Promise<
+  import("../runtime/sync/cloud-client.js").CloudClient | null
+> {
+  const { getSession } = await import("../auth/session.js");
+  const session = await getSession();
+  if (!session) return null;
+  const { CloudClient } = await import("../runtime/sync/cloud-client.js");
+  return new CloudClient({ jwt: session.jwt });
 }
 
 // ── chrome.* helpers (test-friendly) ────────────────────────────────────────

--- a/packages/extension/src/popup/tabs/Recall.tsx
+++ b/packages/extension/src/popup/tabs/Recall.tsx
@@ -3,10 +3,21 @@
 // identity. "Insert into chat" is disabled when the active-tab adapter
 // reports `supportsInsert: false` (T11 TDD anchor #2). "Copy markdown"
 // + "Open" are always available.
+//
+// T18: Cloud-tier Recall merges local + cloud results. We always run
+// the local search (offline-first); when the storage tier is `cloud`
+// we additionally call `cloudSync.recallRemote`, dedupe by
+// `attestation_id`, prefer the side with the higher similarity, and
+// fold in cloud-side `solana_tx` / `arweave_tx` when the local row
+// hasn't been drained yet. Local-tier behaviour is unchanged.
 
-import { useState, type JSX } from "react";
+import { useEffect, useState, type JSX } from "react";
 import type { ChatAdapter } from "../../runtime/chat/types.js";
-import { getRuntime } from "../runtime.js";
+import {
+  getRuntime,
+  type CloudRecallHit,
+  type StorageTier,
+} from "../runtime.js";
 import type { SearchResult } from "../../runtime/store/types.js";
 
 export interface RecallProps {
@@ -20,11 +31,31 @@ export function Recall(props: RecallProps): JSX.Element {
   const [busy, setBusy] = useState(false);
   const [hasSearched, setHasSearched] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [storageTier, setStorageTier] = useState<StorageTier>("local");
 
   // Adapters declare insert support via a `supportsInsert: boolean`
   // flag (BLK-1 fix). Minifier-safe — no `Function.prototype.toString`
   // introspection.
   const insertSupported = Boolean(adapter?.supportsInsert);
+
+  // Pull the active storage tier once on mount so Cloud-mode Recall
+  // can run the merge step. Tier changes during the popup's lifetime
+  // are rare (the T12 settings page closes the popup on change), but
+  // re-reading per search would race the IndexedDB open path.
+  useEffect(() => {
+    let alive = true;
+    void getRuntime()
+      .loadStorageTier()
+      .then((tier) => {
+        if (alive) setStorageTier(tier);
+      })
+      .catch(() => {
+        // Defaults to local — non-fatal if storage read fails.
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
 
   const handleSearch = async (): Promise<void> => {
     setError(null);
@@ -36,8 +67,28 @@ export function Recall(props: RecallProps): JSX.Element {
     }
     setBusy(true);
     try {
-      const hits = await getRuntime().recall(trimmed, 5);
-      setResults(hits);
+      const runtime = getRuntime();
+      // Local search always runs (offline-first). Cloud merge layers
+      // on top when the tier is `cloud` AND the user has a session.
+      const localPromise = runtime.recall(trimmed, 5);
+      const cloudPromise: Promise<CloudRecallHit[] | null> =
+        storageTier === "cloud"
+          ? runtime.cloudSync.recallRemote(trimmed, 5).catch((e: unknown) => {
+              // Cloud failure must NOT block local results — the
+              // tech-spec's offline-first guarantee is the whole
+              // point. Surface the error but keep going.
+              console.warn(
+                "[mnemonik] cloud recall failed:",
+                e instanceof Error ? e.message : String(e),
+              );
+              return null;
+            })
+          : Promise.resolve(null);
+      const [localHits, cloudHits] = await Promise.all([
+        localPromise,
+        cloudPromise,
+      ]);
+      setResults(mergeRecallHits(localHits, cloudHits, 5));
       setHasSearched(true);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
@@ -60,7 +111,7 @@ export function Recall(props: RecallProps): JSX.Element {
       setError(
         e instanceof Error
           ? `Insert failed — ${e.message}. Reload the chat tab and try again.`
-          : "Insert failed — reload the chat tab and try again."
+          : "Insert failed — reload the chat tab and try again.",
       );
     }
   };
@@ -151,7 +202,7 @@ export function Recall(props: RecallProps): JSX.Element {
               </button>
               <a
                 href={`https://mnemonik.xyz/m/${encodeURIComponent(
-                  r.attestation_id
+                  r.attestation_id,
                 )}`}
                 target="_blank"
                 rel="noreferrer noopener"
@@ -192,4 +243,75 @@ function toMarkdown(r: SearchResult): string {
 function truncateMiddle(value: string, head: number, tail: number): string {
   if (value.length <= head + tail + 1) return value;
   return `${value.slice(0, head)}…${value.slice(-tail)}`;
+}
+
+/**
+ * Merge local and cloud recall hits per the T18 spec:
+ *
+ *   1. Dedupe by `attestation_id`.
+ *   2. When the same id appears on both sides, keep the higher
+ *      similarity score (cloud and local can disagree because cloud
+ *      runs server-side cosine search on the canonical embedding
+ *      vs. local TurboQuant-decompressed embeddings).
+ *   3. Prefer cloud-side `solana_tx` / `arweave_tx` when the local
+ *      row still carries synthetic `local:` ids — the cloud row has
+ *      been anchored on-chain.
+ *   4. Re-rank descending by score; truncate to `limit`.
+ *
+ * Local-only entries pass through unchanged. Cloud-only entries are
+ * projected into the `SearchResult` shape so the existing renderer
+ * works without a discriminated union.
+ */
+export function mergeRecallHits(
+  local: SearchResult[],
+  cloud: CloudRecallHit[] | null,
+  limit: number,
+): SearchResult[] {
+  if (!cloud || cloud.length === 0) {
+    return local.slice(0, limit);
+  }
+  const byId = new Map<string, SearchResult>();
+  for (const r of local) {
+    byId.set(r.attestation_id, r);
+  }
+  for (const c of cloud) {
+    if (!c.attestation_id) continue;
+    const existing = byId.get(c.attestation_id);
+    if (existing) {
+      const better = c.similarity > existing.relevance_score;
+      // Prefer cloud-side tx ids when local still carries synthetic
+      // `local:` prefixes — the cloud row has been anchored.
+      const solana_tx =
+        existing.solana_tx.startsWith("local:") && c.solana_tx
+          ? c.solana_tx
+          : existing.solana_tx;
+      const arweave_tx =
+        existing.arweave_tx.startsWith("local:") && c.arweave_tx
+          ? c.arweave_tx
+          : existing.arweave_tx;
+      byId.set(c.attestation_id, {
+        ...existing,
+        relevance_score: better ? c.similarity : existing.relevance_score,
+        solana_tx,
+        arweave_tx,
+      });
+    } else {
+      byId.set(c.attestation_id, {
+        attestation_id: c.attestation_id,
+        content: c.content,
+        // Cloud-only entries don't carry a content_hash today — render
+        // with an empty hash; the popup's Verify tab re-fetches the
+        // full row when the user clicks Open.
+        content_hash: "",
+        tags: c.tags ?? [],
+        solana_tx: c.solana_tx ?? "",
+        arweave_tx: c.arweave_tx ?? "",
+        created_at: c.signed_at ?? "",
+        relevance_score: c.similarity,
+      });
+    }
+  }
+  return Array.from(byId.values())
+    .sort((a, b) => b.relevance_score - a.relevance_score)
+    .slice(0, limit);
 }

--- a/packages/extension/src/runtime/store/indexeddb.ts
+++ b/packages/extension/src/runtime/store/indexeddb.ts
@@ -78,6 +78,18 @@ export class IndexedDbStore {
   }
 
   /**
+   * Direct primary-key lookup for `attestation_id`. Used by the
+   * T18 cloud-sync drain to fetch the full row that a `pending_uploads`
+   * entry references. Returns `undefined` when the row was deleted
+   * out from under the queue — caller dequeues to break the loop.
+   */
+  async findById(attestationId: string): Promise<AttestationRow | undefined> {
+    if (!attestationId) return undefined;
+    const db = await this.db();
+    return db.get("attestations", attestationId);
+  }
+
+  /**
    * Look up by either solana_tx or arweave_tx. Scans because neither
    * field has a unique index (cloud-mode rows can carry distinct values
    * yet share `local:<hash>` shapes for offline-first writes).
@@ -165,11 +177,7 @@ export class IndexedDbStore {
   /** Returns `[parent_id, depth]` pairs ordered by insertion. */
   async getEdges(childId: string): Promise<Array<[string, number]>> {
     const db = await this.db();
-    const rows = await db.getAllFromIndex(
-      "lineage_edges",
-      "by_child",
-      childId,
-    );
+    const rows = await db.getAllFromIndex("lineage_edges", "by_child", childId);
     return rows.map((r) => [r.parent_id, r.depth]);
   }
 

--- a/packages/extension/src/runtime/store/types.ts
+++ b/packages/extension/src/runtime/store/types.ts
@@ -31,6 +31,17 @@ export interface AttestationRow {
   arweave_tx: string;
   /** Optional capture-context metadata for the popup recall view. */
   source_meta?: SourceMeta;
+  /**
+   * Set by the T18 cloud-sync drain when the server rejects this row
+   * with a non-recoverable 4xx (e.g. 410 expired correlation_id, 400
+   * malformed payload). The row stays in `attestations` so the user
+   * sees a "sync failed — recreate this memory" hint in the popup;
+   * `pending_uploads` is dequeued so the alarm-drain stops retrying.
+   *
+   * Optional + nullable; absence means "never attempted or transiently
+   * failing". 401 does NOT set this — re-auth is recoverable.
+   */
+  sync_failed_permanent?: boolean;
 }
 
 /** Attached when the row was captured from a supported AI-chat platform. */

--- a/packages/extension/src/runtime/sync/cloud-client.ts
+++ b/packages/extension/src/runtime/sync/cloud-client.ts
@@ -1,45 +1,395 @@
-// Cloud-tier sync client — placeholder owned by T18 (cloud-tier sync via
-// deferred signing). The service worker (T10) imports `flushPending` so
-// the alarm-driven drain has a stable call site before T18 lands.
+// Cloud-tier thin client. Wraps the hosted MCP HTTP surface so the
+// extension can ship locally-signed COSE bundles to the server's
+// deferred-signing endpoint, and pull cloud-side recall/verify
+// results. D2 of the tech-spec: cloud = thin client to hosted-`full`;
+// no new storage formats, no server-side key material — the COSE
+// bytes are signed locally and the server only persists + anchors.
 //
-// T18 will:
-//   1. Iterate `IndexedDbStore.listPending()` in FIFO order.
-//   2. Load the corresponding `AttestationRow` from `attestations`.
-//   3. POST the COSE_Sign1 envelope to `/mcp` `mnemonic_sign_memory`
-//      (deferred-signing flow) and then `/api/sign-callback`.
-//   4. On success: update the row with the returned solana_tx / arweave_tx
-//      and `dequeue(attestation_id)`.
-//   5. On transient failure: leave the row enqueued; the next alarm tick
-//      retries with exponential back-off bounded at 1h.
+// **Surface (T18):**
+//   - `signRemote(args)`  → POST /mcp `mnemonic_sign_memory` then
+//                            POST /api/sign-callback. Returns the
+//                            anchor identifiers the queue drain
+//                            writes back onto the local row.
+//   - `recallRemote(q,k)` → POST /mcp `mnemonic_recall`. Used by the
+//                            popup's Cloud-tier Recall merge.
+//   - `verifyRemote(id)`  → POST /mcp `mnemonic_verify`. Used by the
+//                            Verify tab in Cloud mode.
 //
-// Until then, this stub is a no-op so the SW build stays green and the
-// alarm-drain unit test has a spy target.
+// **Error contract (typed so the alarm-drain can branch on type):**
+//   - `ReauthRequiredError`  — 401 from any leg. The drain MUST stop
+//                              and emit `re-auth-required` to the
+//                              popup; the user is sent back to the
+//                              T16 sign-in flow.
+//   - `PermanentSyncError`   — 4xx (not 401). The row should be marked
+//                              `sync_failed_permanent` and surfaced —
+//                              retrying will never succeed.
+//   - `TransientSyncError`   — 5xx or network failure. The drain
+//                              leaves the row in `pending_uploads`;
+//                              the next alarm tick retries.
+//
+// **Auth (D9 reminder):** the JWT goes to `/mcp` for tool dispatch.
+// `/api/sign-callback` does NOT take a Bearer — capability auth via
+// `correlation_id` + signature chain (matches `packages/sdk`).
 
-import type { IndexedDbStore } from "../store/indexeddb.js";
+import type { SignerLike, SignRemoteArgs, SignRemoteResult } from "./types.js";
 
-export interface FlushPendingDeps {
-  /** Backing store, supplied so tests can inject a fake. */
-  store: IndexedDbStore;
+/** 401 sentinel — drain MUST stop and the popup MUST re-prompt sign-in. */
+export class ReauthRequiredError extends Error {
+  public override readonly name = "ReauthRequiredError";
+  public constructor(message = "cloud-sync requires re-authentication") {
+    super(message);
+  }
 }
 
-export interface FlushPendingResult {
-  /** Rows the call attempted to drain. */
-  attempted: number;
-  /** Rows successfully uploaded and dequeued. */
-  flushed: number;
+/** 4xx (non-401) — the row is rejected for good. Caller marks it
+ *  `sync_failed_permanent` and stops retrying. */
+export class PermanentSyncError extends Error {
+  public override readonly name = "PermanentSyncError";
+  public readonly status: number;
+  public constructor(message: string, status: number) {
+    super(message);
+    this.status = status;
+  }
 }
 
-/**
- * Drain the cloud-sync queue. **Stub** — T18 owns the real implementation.
- *
- * The shape (`Promise<FlushPendingResult>` + injectable deps) is the
- * contract T18 is expected to honour so the SW caller stays unchanged.
- */
-export async function flushPending(
-  deps: FlushPendingDeps
-): Promise<FlushPendingResult> {
-  const pending = await deps.store.listPending();
-  // T18: actually POST to MCP server and dequeue on success. For now we
-  // just report the queue depth so the alarm logs something useful.
-  return { attempted: pending.length, flushed: 0 };
+/** 5xx or transport failure — the alarm-drain leaves the row in the
+ *  queue and retries on the next tick (5-min cadence per T10). */
+export class TransientSyncError extends Error {
+  public override readonly name = "TransientSyncError";
+  public readonly status: number | null;
+  public constructor(message: string, status: number | null = null) {
+    super(message);
+    this.status = status;
+  }
 }
+
+/** Hosted MCP origin. Phase 1 hard-code matches `auth/google-oauth.ts`;
+ *  a future options-page seam will read this from `chrome.storage.sync`. */
+export const DEFAULT_CLOUD_ORIGIN = "https://mc.mnemonik.xyz";
+
+/** Construction-time deps so tests can inject `fetch` + `now`. */
+export interface CloudClientOptions {
+  /** Bearer JWT for `/mcp` calls. `/api/sign-callback` deliberately
+   *  goes unauthenticated — capability auth via correlation_id. */
+  jwt: string;
+  /** Base origin. Trailing slashes are stripped. */
+  baseUrl?: string;
+  /** Override `globalThis.fetch` — required for unit tests. */
+  fetch?: typeof fetch;
+}
+
+export interface RecallRemoteHit {
+  attestation_id: string;
+  content: string;
+  similarity: number;
+  tags?: string[];
+  signed_at?: string;
+  solana_tx?: string;
+  arweave_tx?: string;
+}
+
+export type VerifyRemoteResult =
+  | {
+      status: "verified";
+      signer: string;
+      arweave_tx?: string;
+      solana_tx?: string;
+    }
+  | { status: "tampered"; signer: string; reason: string }
+  | { status: "not_found" };
+
+/** Thin wrapper over the hosted MCP surface. Construction is cheap —
+ *  no network I/O. Each call is self-contained so the SW can build
+ *  per-tick instances without leaking transactions across awaits. */
+export class CloudClient {
+  private readonly jwt: string;
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+
+  public constructor(opts: CloudClientOptions) {
+    if (!opts.jwt) {
+      throw new Error("CloudClient: jwt is required");
+    }
+    this.jwt = opts.jwt;
+    this.baseUrl = (opts.baseUrl ?? DEFAULT_CLOUD_ORIGIN).replace(/\/+$/, "");
+    this.fetchImpl = opts.fetch ?? globalThis.fetch.bind(globalThis);
+  }
+
+  /**
+   * Deferred-signing flow per D2.
+   *
+   *   1. `POST /mcp` `mnemonic_sign_memory` (Bearer JWT) →
+   *      `{correlation_id, expires_in}`.
+   *   2. `POST /api/sign-callback` (NO Bearer — capability auth) with
+   *      `{correlation_id, cose_signed_bytes (b64), signer_pubkey}` →
+   *      `{attestation_id, solana_tx, arweave_tx, ...}`.
+   *
+   * Returns the three identifiers the alarm-drain writes back onto
+   * the local `AttestationRow`. Throws one of the three typed errors
+   * above so the caller can branch without string parsing.
+   */
+  public async signRemote(
+    args: SignRemoteArgs,
+    signer: SignerLike,
+  ): Promise<SignRemoteResult> {
+    const openBody = {
+      content: args.content,
+      ...(args.tags.length > 0 ? { tags: args.tags } : {}),
+      ...(args.source_meta ? { source_meta: args.source_meta } : {}),
+    };
+    const open = await this.rpc<{
+      correlation_id?: unknown;
+      expires_in?: unknown;
+    }>("mnemonic_sign_memory", openBody);
+    const correlationId =
+      typeof open.correlation_id === "string" ? open.correlation_id : null;
+    if (!correlationId) {
+      throw new PermanentSyncError(
+        "mnemonic_sign_memory did not return correlation_id",
+        500,
+      );
+    }
+
+    // `signer.cose_bytes` was produced locally during the original
+    // `signMemory` call and is already canonical-CBOR + COSE_Sign1.
+    // We re-use it verbatim — the server validates it against the
+    // pending bundle's stored content hash.
+    const callbackUrl = `${this.baseUrl}/api/sign-callback`;
+    const res = await this.fetchOr(callbackUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        correlation_id: correlationId,
+        cose_signed_bytes: bytesToBase64(signer.cose_bytes),
+        signer_pubkey: signer.signer_pubkey,
+      }),
+    });
+    if (res.status === 401) {
+      throw new ReauthRequiredError("sign-callback rejected with 401");
+    }
+    if (res.status === 410 || res.status === 409) {
+      // 410: pending entry expired (server LRU dropped it). Treat
+      // as permanent — the row's correlation_id is now invalid.
+      throw new PermanentSyncError(
+        `sign-callback consumed/expired (HTTP ${res.status})`,
+        res.status,
+      );
+    }
+    if (res.status >= 500) {
+      throw new TransientSyncError(
+        `sign-callback failed: HTTP ${res.status}`,
+        res.status,
+      );
+    }
+    if (!res.ok) {
+      throw new PermanentSyncError(
+        `sign-callback rejected: HTTP ${res.status}`,
+        res.status,
+      );
+    }
+    const body = (await safeJson(res)) as Record<string, unknown>;
+    const attestationId =
+      typeof body.attestation_id === "string" ? body.attestation_id : null;
+    if (!attestationId) {
+      throw new PermanentSyncError("sign-callback omitted attestation_id", 500);
+    }
+    return {
+      attestation_id: attestationId,
+      solana_tx: typeof body.solana_tx === "string" ? body.solana_tx : "",
+      arweave_tx: typeof body.arweave_tx === "string" ? body.arweave_tx : "",
+    };
+  }
+
+  /** Cloud-side recall. Returns the wire shape `RecallRemoteHit[]`. */
+  public async recallRemote(
+    query: string,
+    k: number,
+  ): Promise<RecallRemoteHit[]> {
+    const trimmed = query.trim();
+    if (trimmed === "" || k <= 0) return [];
+    const result = await this.rpc<{
+      hits?: unknown;
+      results?: unknown;
+    }>("mnemonic_recall", { query: trimmed, top_k: k });
+    const arr = Array.isArray(result.hits)
+      ? result.hits
+      : Array.isArray(result.results)
+        ? result.results
+        : [];
+    const out: RecallRemoteHit[] = [];
+    for (const h of arr) {
+      if (typeof h !== "object" || h === null) continue;
+      const r = h as Record<string, unknown>;
+      const id = typeof r.attestation_id === "string" ? r.attestation_id : "";
+      if (!id) continue;
+      const hit: RecallRemoteHit = {
+        attestation_id: id,
+        content: typeof r.content === "string" ? r.content : "",
+        similarity: typeof r.similarity === "number" ? r.similarity : 0,
+      };
+      if (Array.isArray(r.tags)) {
+        hit.tags = r.tags.filter((t): t is string => typeof t === "string");
+      }
+      if (typeof r.signed_at === "string") hit.signed_at = r.signed_at;
+      if (typeof r.solana_tx === "string") hit.solana_tx = r.solana_tx;
+      if (typeof r.arweave_tx === "string") hit.arweave_tx = r.arweave_tx;
+      out.push(hit);
+    }
+    return out;
+  }
+
+  /** Cloud-side verify. Returns a discriminated union mirroring the
+   *  SDK's `VerifyResult` (snake_case for in-extension consumers). */
+  public async verifyRemote(
+    attestationId: string,
+  ): Promise<VerifyRemoteResult> {
+    if (!attestationId) return { status: "not_found" };
+    const result = await this.rpc<Record<string, unknown>>("mnemonic_verify", {
+      attestation_id: attestationId,
+    });
+    const status =
+      typeof result.status === "string" ? result.status : "not_found";
+    if (status === "verified") {
+      const out: VerifyRemoteResult = {
+        status: "verified",
+        signer: typeof result.signer === "string" ? result.signer : "",
+      };
+      if (typeof result.arweave_tx === "string") {
+        out.arweave_tx = result.arweave_tx;
+      }
+      if (typeof result.solana_tx === "string") {
+        out.solana_tx = result.solana_tx;
+      }
+      return out;
+    }
+    if (status === "tampered") {
+      return {
+        status: "tampered",
+        signer: typeof result.signer === "string" ? result.signer : "",
+        reason: typeof result.reason === "string" ? result.reason : "unknown",
+      };
+    }
+    return { status: "not_found" };
+  }
+
+  // ── internals ────────────────────────────────────────────────────────
+
+  /**
+   * Single JSON-RPC `tools/call` to `/mcp`. Returns the unwrapped
+   * tool result object. Throws typed errors so the alarm-drain can
+   * branch on `instanceof`.
+   *
+   * Note: MCP `tools/call` results sometimes arrive wrapped in
+   * `{content: [{type:'text', text:'<JSON>'}]}` (canonical MCP wire
+   * format). Mirror the SDK's `extractToolResult` shim so the call
+   * site reads a plain record either way.
+   */
+  private async rpc<T extends Record<string, unknown>>(
+    name: string,
+    args: Record<string, unknown>,
+  ): Promise<T> {
+    const url = `${this.baseUrl}/mcp`;
+    const body = {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name, arguments: args },
+    };
+    const res = await this.fetchOr(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json",
+        Authorization: `Bearer ${this.jwt}`,
+      },
+      body: JSON.stringify(body),
+    });
+    if (res.status === 401) {
+      throw new ReauthRequiredError(`${name} rejected with 401`);
+    }
+    if (res.status >= 500) {
+      throw new TransientSyncError(
+        `${name} failed: HTTP ${res.status}`,
+        res.status,
+      );
+    }
+    if (!res.ok) {
+      throw new PermanentSyncError(
+        `${name} rejected: HTTP ${res.status}`,
+        res.status,
+      );
+    }
+    const parsed = (await safeJson(res)) as Record<string, unknown>;
+    if (parsed.error && typeof parsed.error === "object") {
+      const errObj = parsed.error as Record<string, unknown>;
+      const code = typeof errObj.code === "number" ? errObj.code : null;
+      const msg = typeof errObj.message === "string" ? errObj.message : name;
+      if (code === 401) throw new ReauthRequiredError(msg);
+      if (code !== null && code >= 500) {
+        throw new TransientSyncError(msg, code);
+      }
+      throw new PermanentSyncError(msg, code ?? 400);
+    }
+    return extractToolResult<T>(parsed.result);
+  }
+
+  /** `fetch` wrapper that rewrites network errors as
+   *  `TransientSyncError` (so the SW handler doesn't have to
+   *  duplicate the try/catch). */
+  private async fetchOr(url: string, init: RequestInit): Promise<Response> {
+    try {
+      return await this.fetchImpl(url, init);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      throw new TransientSyncError(`network error: ${msg}`);
+    }
+  }
+}
+
+// ── helpers ────────────────────────────────────────────────────────────
+
+function extractToolResult<T extends Record<string, unknown>>(
+  result: unknown,
+): T {
+  if (result === null || typeof result !== "object") return {} as T;
+  const r = result as Record<string, unknown>;
+  // MCP `tools/call` canonical envelope.
+  if (Array.isArray(r.content) && r.content.length > 0) {
+    const first = r.content[0];
+    if (
+      first !== null &&
+      typeof first === "object" &&
+      typeof (first as { text?: unknown }).text === "string"
+    ) {
+      try {
+        return JSON.parse((first as { text: string }).text) as T;
+      } catch {
+        return {} as T;
+      }
+    }
+  }
+  return r as T;
+}
+
+async function safeJson(res: Response): Promise<unknown> {
+  try {
+    return await res.json();
+  } catch {
+    return {};
+  }
+}
+
+/** Encode bytes as standard-alphabet, padded base64. Chunked to avoid
+ *  call-stack limits on very large arrays (>~64KB). */
+function bytesToBase64(bytes: Uint8Array): string {
+  let s = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    s += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(s);
+}
+
+// `flushPending` (the SW-facing entrypoint) now lives in
+// `src/background/cloud-sync.ts` next to the drain logic. The SW
+// imports from there directly.

--- a/packages/extension/src/runtime/sync/cloud-client.ts
+++ b/packages/extension/src/runtime/sync/cloud-client.ts
@@ -141,8 +141,14 @@ export class CloudClient {
       correlation_id?: unknown;
       expires_in?: unknown;
     }>("mnemonic_sign_memory", openBody);
+    // Reject empty strings explicitly — a malformed server response
+    // that returns `correlation_id: ""` would otherwise sail past the
+    // `typeof === 'string'` guard and burn a sign-callback round-trip
+    // only to come back as a confusing 410. Code-review round-1 T18-C-02.
     const correlationId =
-      typeof open.correlation_id === "string" ? open.correlation_id : null;
+      typeof open.correlation_id === "string" && open.correlation_id.length > 0
+        ? open.correlation_id
+        : null;
     if (!correlationId) {
       throw new PermanentSyncError(
         "mnemonic_sign_memory did not return correlation_id",
@@ -328,7 +334,14 @@ export class CloudClient {
       if (code !== null && code >= 500) {
         throw new TransientSyncError(msg, code);
       }
-      throw new PermanentSyncError(msg, code ?? 400);
+      if (code !== null) {
+        throw new PermanentSyncError(msg, code);
+      }
+      // No JSON-RPC error code at all — the wire is malformed. Treat
+      // as TransientSyncError so the alarm retries rather than
+      // stamping `sync_failed_permanent` on a row that may succeed
+      // on the next tick. Closes code-review round-1 nit T18-C-07.
+      throw new TransientSyncError(`${msg} (no rpc error code)`, res.status);
     }
     return extractToolResult<T>(parsed.result);
   }

--- a/packages/extension/src/runtime/sync/types.ts
+++ b/packages/extension/src/runtime/sync/types.ts
@@ -1,0 +1,33 @@
+// Internal types shared across the cloud-sync surface (cloud-client +
+// cloud-sync drain). Keeping these in a dedicated module lets the
+// service-worker and popup runtime depend on the shapes without
+// pulling the CloudClient implementation (and `fetch` references) into
+// their first-paint bundles.
+
+import type { SourceMeta } from "../store/types.js";
+
+/** Args required by `CloudClient.signRemote`. Mirrors the
+ *  `attestation_row` fields the alarm-drain reads off `IndexedDbStore`. */
+export interface SignRemoteArgs {
+  /** Plaintext memory — D9: cloud-mode users opt into server-visible
+   *  content; this is the intended trust boundary. */
+  content: string;
+  tags: string[];
+  source_meta?: SourceMeta;
+}
+
+/** Minimal cryptographic-material projection of `AttestationRow`.
+ *  The COSE bytes were produced locally during the original
+ *  `signMemory`; we re-use them verbatim — D2 forbids the server from
+ *  ever holding key material. */
+export interface SignerLike {
+  cose_bytes: Uint8Array;
+  signer_pubkey: string;
+}
+
+/** Triple the alarm-drain writes back onto the local row on success. */
+export interface SignRemoteResult {
+  attestation_id: string;
+  solana_tx: string;
+  arweave_tx: string;
+}

--- a/packages/extension/tests/component/popup/Capture.test.tsx
+++ b/packages/extension/tests/component/popup/Capture.test.tsx
@@ -47,6 +47,14 @@ function makeRuntime(overrides: Partial<PopupRuntime> = {}): PopupRuntime {
       set: async () => undefined,
       clear: async () => undefined,
     },
+    cloudSync: {
+      // T18 stub: tests default to Local tier so these never fire.
+      // Specific tests override `cloudSync` to assert the Cloud-tier
+      // merge in Recall.
+      signRemote: async () => null,
+      recallRemote: async () => null,
+      verifyRemote: async () => null,
+    },
     keyEscrow: {
       wrap: async () => {
         throw new Error("keyEscrow.wrap stub: not configured in test");

--- a/packages/extension/tests/component/popup/Recall.test.tsx
+++ b/packages/extension/tests/component/popup/Recall.test.tsx
@@ -6,8 +6,12 @@
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
-import { Recall } from "../../../src/popup/tabs/Recall.js";
-import { setRuntime, type PopupRuntime } from "../../../src/popup/runtime.js";
+import { Recall, mergeRecallHits } from "../../../src/popup/tabs/Recall.js";
+import {
+  setRuntime,
+  type CloudRecallHit,
+  type PopupRuntime,
+} from "../../../src/popup/runtime.js";
 import type { ChatAdapter } from "../../../src/runtime/chat/types.js";
 import type { SearchResult } from "../../../src/runtime/store/types.js";
 
@@ -314,5 +318,186 @@ describe("Recall tab", () => {
     await waitFor(() => expect(recall).toHaveBeenCalled());
     // Cloud recall must NOT have been called.
     expect(recallRemote).not.toHaveBeenCalled();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// mergeRecallHits — pure-function unit tests (code-reviewer C-5)
+// ────────────────────────────────────────────────────────────────────────
+
+function localHit(over: Partial<SearchResult>): SearchResult {
+  return {
+    attestation_id: over.attestation_id ?? "att",
+    content: over.content ?? "local content",
+    content_hash: over.content_hash ?? "0".repeat(64),
+    tags: over.tags ?? [],
+    solana_tx: over.solana_tx ?? "local:x",
+    arweave_tx: over.arweave_tx ?? "local:x",
+    created_at: over.created_at ?? "2026-05-10T00:00:00Z",
+    relevance_score: over.relevance_score ?? 0.5,
+  };
+}
+
+function cloudHit(over: Partial<CloudRecallHit>): CloudRecallHit {
+  return {
+    attestation_id: over.attestation_id ?? "att",
+    content: over.content ?? "cloud content",
+    similarity: over.similarity ?? 0.5,
+    ...(over.tags !== undefined ? { tags: over.tags } : {}),
+    ...(over.signed_at !== undefined ? { signed_at: over.signed_at } : {}),
+    ...(over.solana_tx !== undefined ? { solana_tx: over.solana_tx } : {}),
+    ...(over.arweave_tx !== undefined ? { arweave_tx: over.arweave_tx } : {}),
+  };
+}
+
+describe("mergeRecallHits (pure)", () => {
+  it("returns local slice unchanged when cloud is null", () => {
+    const local = [
+      localHit({ attestation_id: "a", relevance_score: 0.9 }),
+      localHit({ attestation_id: "b", relevance_score: 0.7 }),
+    ];
+    expect(mergeRecallHits(local, null, 5)).toEqual(local);
+  });
+
+  it("returns local slice unchanged when cloud is empty", () => {
+    const local = [localHit({ attestation_id: "a", relevance_score: 0.9 })];
+    expect(mergeRecallHits(local, [], 5)).toEqual(local);
+  });
+
+  it("truncates the result list to limit", () => {
+    const local = [
+      localHit({ attestation_id: "a", relevance_score: 0.9 }),
+      localHit({ attestation_id: "b", relevance_score: 0.8 }),
+      localHit({ attestation_id: "c", relevance_score: 0.7 }),
+    ];
+    const out = mergeRecallHits(local, null, 2);
+    expect(out).toHaveLength(2);
+    expect(out.map((r) => r.attestation_id)).toEqual(["a", "b"]);
+  });
+
+  it("dedupes same-id rows, keeping the higher score when cloud wins", () => {
+    const local = [localHit({ attestation_id: "a", relevance_score: 0.5 })];
+    const cloud = [cloudHit({ attestation_id: "a", similarity: 0.9 })];
+    const out = mergeRecallHits(local, cloud, 5);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.relevance_score).toBe(0.9);
+  });
+
+  it("dedupes same-id rows, keeping the higher score when local wins", () => {
+    const local = [localHit({ attestation_id: "a", relevance_score: 0.9 })];
+    const cloud = [cloudHit({ attestation_id: "a", similarity: 0.4 })];
+    const out = mergeRecallHits(local, cloud, 5);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.relevance_score).toBe(0.9);
+  });
+
+  it("folds cloud tx ids over synthetic local: ids for same-id rows", () => {
+    const local = [
+      localHit({
+        attestation_id: "a",
+        relevance_score: 0.5,
+        solana_tx: "local:a",
+        arweave_tx: "local:a",
+      }),
+    ];
+    const cloud = [
+      cloudHit({
+        attestation_id: "a",
+        similarity: 0.6,
+        solana_tx: "RealSol",
+        arweave_tx: "RealAr",
+      }),
+    ];
+    const out = mergeRecallHits(local, cloud, 5);
+    expect(out[0]?.solana_tx).toBe("RealSol");
+    expect(out[0]?.arweave_tx).toBe("RealAr");
+  });
+
+  it("keeps real local tx ids when cloud has different real ones (Phase 1 — see decisions.md backlog)", () => {
+    // Local row has been drained at least once already (real tx ids).
+    // A future cloud-side rotation would return different ids; the
+    // current merge rule keeps the local value. This documents the
+    // Phase 1 behaviour; T18-C-05 / decisions.md tracks Phase 2.
+    const local = [
+      localHit({
+        attestation_id: "a",
+        relevance_score: 0.5,
+        solana_tx: "OldRealSol",
+        arweave_tx: "OldRealAr",
+      }),
+    ];
+    const cloud = [
+      cloudHit({
+        attestation_id: "a",
+        similarity: 0.6,
+        solana_tx: "NewRealSol",
+        arweave_tx: "NewRealAr",
+      }),
+    ];
+    const out = mergeRecallHits(local, cloud, 5);
+    expect(out[0]?.solana_tx).toBe("OldRealSol");
+    expect(out[0]?.arweave_tx).toBe("OldRealAr");
+  });
+
+  it("does not fold cloud tx ids when cloud omits them", () => {
+    // Local row has synthetic ids; cloud hit has no tx fields. Merge
+    // must keep the local placeholders rather than write an empty
+    // string (which would break the popup's `local:` heuristic).
+    const local = [
+      localHit({
+        attestation_id: "a",
+        relevance_score: 0.5,
+        solana_tx: "local:a",
+        arweave_tx: "local:a",
+      }),
+    ];
+    const cloud = [cloudHit({ attestation_id: "a", similarity: 0.6 })];
+    const out = mergeRecallHits(local, cloud, 5);
+    expect(out[0]?.solana_tx).toBe("local:a");
+    expect(out[0]?.arweave_tx).toBe("local:a");
+  });
+
+  it("includes cloud-only entries projected into SearchResult shape", () => {
+    const cloud = [
+      cloudHit({
+        attestation_id: "cloud-only",
+        content: "only on server",
+        similarity: 0.7,
+        tags: ["t1"],
+        signed_at: "2026-05-11T00:00:00Z",
+        solana_tx: "Sol",
+        arweave_tx: "Ar",
+      }),
+    ];
+    const out = mergeRecallHits([], cloud, 5);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toEqual({
+      attestation_id: "cloud-only",
+      content: "only on server",
+      content_hash: "",
+      tags: ["t1"],
+      solana_tx: "Sol",
+      arweave_tx: "Ar",
+      created_at: "2026-05-11T00:00:00Z",
+      relevance_score: 0.7,
+    });
+  });
+
+  it("re-sorts merged rows by score descending", () => {
+    const local = [
+      localHit({ attestation_id: "low", relevance_score: 0.2 }),
+      localHit({ attestation_id: "high", relevance_score: 0.9 }),
+    ];
+    const cloud = [cloudHit({ attestation_id: "mid", similarity: 0.5 })];
+    const out = mergeRecallHits(local, cloud, 5);
+    expect(out.map((r) => r.attestation_id)).toEqual(["high", "mid", "low"]);
+  });
+
+  it("drops cloud hits with empty attestation_id (defensive against malformed server response)", () => {
+    const local = [localHit({ attestation_id: "a", relevance_score: 0.9 })];
+    const cloud = [cloudHit({ attestation_id: "", similarity: 0.5 })];
+    const out = mergeRecallHits(local, cloud, 5);
+    expect(out).toHaveLength(1);
+    expect(out[0]?.attestation_id).toBe("a");
   });
 });

--- a/packages/extension/tests/component/popup/Recall.test.tsx
+++ b/packages/extension/tests/component/popup/Recall.test.tsx
@@ -42,6 +42,13 @@ function makeRuntime(overrides: Partial<PopupRuntime> = {}): PopupRuntime {
       set: async () => undefined,
       clear: async () => undefined,
     },
+    cloudSync: {
+      // T18 stub: tests default to Local tier so these never fire.
+      // Cloud-tier specific tests override `cloudSync.recallRemote`.
+      signRemote: async () => null,
+      recallRemote: async () => null,
+      verifyRemote: async () => null,
+    },
     keyEscrow: {
       wrap: async () => {
         throw new Error("keyEscrow.wrap stub: not configured in test");
@@ -179,5 +186,133 @@ describe("Recall tab", () => {
     for (const b of insertButtons) {
       expect(b).not.toBeDisabled();
     }
+  });
+
+  it("Cloud-tier: merges local IndexedDB hits with mnemonic_recall hits, dedupes by attestation_id", async () => {
+    // T18 Cloud-tier Recall merge: storage tier is "cloud", local
+    // returns one of two hits, cloud returns the same id (higher
+    // score) plus a brand-new id. The rendered list MUST contain
+    // both ids in score order, with the duplicate counted once.
+    const recall = vi.fn().mockResolvedValue([results[0]]); // local: 0.92
+    const recallRemote = vi.fn().mockResolvedValue([
+      // Same id as local[0] but with a higher cloud-side score — the
+      // merge keeps the higher of the two.
+      {
+        attestation_id: "att_aaa111",
+        content: "First match — keep going",
+        similarity: 0.97,
+        tags: ["source:chatgpt", "alpha"],
+        signed_at: "2026-05-10T00:00:00Z",
+        solana_tx: "RealSolTx1",
+        arweave_tx: "RealArTx1",
+      },
+      // Brand-new id that only exists on the cloud side.
+      {
+        attestation_id: "att_ccc333",
+        content: "Cloud-only memory",
+        similarity: 0.55,
+        tags: ["source:gemini"],
+        signed_at: "2026-05-11T00:00:00Z",
+      },
+    ]);
+    const loadStorageTier = vi.fn().mockResolvedValue("cloud" as const);
+    setRuntime(
+      makeRuntime({
+        recall,
+        loadStorageTier,
+        cloudSync: {
+          signRemote: async () => null,
+          recallRemote,
+          verifyRemote: async () => null,
+        },
+      }),
+    );
+
+    render(<Recall adapter={chatgptLikeAdapter} />);
+    // Wait for the tier-resolving useEffect to settle before issuing
+    // the search — otherwise the click can race the async state
+    // commit and the component stays in "local" tier for this click.
+    await waitFor(() => expect(loadStorageTier).toHaveBeenCalled());
+    // One more microtask for the React state commit to propagate.
+    await new Promise((r) => setTimeout(r, 0));
+
+    fireEvent.change(screen.getByLabelText("Recall query"), {
+      target: { value: "match" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /find/i }));
+
+    // Both calls fire — local first, cloud in parallel.
+    await waitFor(() => expect(recall).toHaveBeenCalled());
+    await waitFor(() => expect(recallRemote).toHaveBeenCalledWith("match", 5));
+
+    // The merged list contains exactly 2 distinct rows (att_aaa111
+    // and att_ccc333 — the duplicate id was deduped).
+    // Higher cloud score wins for the duplicate row.
+    await screen.findByText(/0.970/);
+    // Cloud-only entry rendered.
+    await screen.findByText(/Cloud-only memory/);
+    const list = await screen.findByLabelText("Recall results");
+    const items = list.querySelectorAll("li");
+    expect(items.length).toBe(2);
+  });
+
+  it("Cloud-tier: cloud failure does not block local results (offline-first)", async () => {
+    // The tech-spec's offline-first guarantee: a cloud-side failure
+    // (5xx, network drop, malformed JSON) must NEVER block the local
+    // results path. The component swallows the cloud error and
+    // renders local hits as if Cloud tier were Local.
+    const recall = vi.fn().mockResolvedValue(results);
+    const recallRemote = vi.fn().mockRejectedValue(new Error("503 upstream"));
+    setRuntime(
+      makeRuntime({
+        recall,
+        loadStorageTier: async () => "cloud" as const,
+        cloudSync: {
+          signRemote: async () => null,
+          recallRemote,
+          verifyRemote: async () => null,
+        },
+      }),
+    );
+
+    render(<Recall adapter={chatgptLikeAdapter} />);
+    fireEvent.change(screen.getByLabelText("Recall query"), {
+      target: { value: "match" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /find/i }));
+
+    // Local results still render unaffected.
+    await screen.findByText(/0.920/);
+    await screen.findByText(/0.710/);
+    // The component swallowed the cloud error — no error banner.
+    expect(screen.queryByText(/503/)).toBeNull();
+  });
+
+  it("Local-tier: skips cloudSync.recallRemote entirely (offline-first default)", async () => {
+    const recall = vi.fn().mockResolvedValue(results);
+    const recallRemote = vi.fn();
+    setRuntime(
+      makeRuntime({
+        recall,
+        // Default tier is "local" but be explicit so a regression
+        // that flips the default to "cloud" trips this.
+        loadStorageTier: async () => "local" as const,
+        cloudSync: {
+          signRemote: async () => null,
+          recallRemote,
+          verifyRemote: async () => null,
+        },
+      }),
+    );
+
+    render(<Recall adapter={chatgptLikeAdapter} />);
+    fireEvent.change(screen.getByLabelText("Recall query"), {
+      target: { value: "x" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /find/i }));
+
+    await waitFor(() => expect(recall).toHaveBeenCalled());
+    // Cloud recall must NOT have been called.
+    expect(recallRemote).not.toHaveBeenCalled();
   });
 });

--- a/packages/extension/tests/component/popup/Verify.test.tsx
+++ b/packages/extension/tests/component/popup/Verify.test.tsx
@@ -46,6 +46,12 @@ function makeRuntime(
       set: async () => undefined,
       clear: async () => undefined,
     },
+    cloudSync: {
+      // T18 stub: Verify tab tests default to Local tier.
+      signRemote: async () => null,
+      recallRemote: async () => null,
+      verifyRemote: async () => null,
+    },
     keyEscrow: {
       wrap: async () => {
         throw new Error("keyEscrow.wrap stub: not configured in test");

--- a/packages/extension/tests/unit/background/cloud-sync.test.ts
+++ b/packages/extension/tests/unit/background/cloud-sync.test.ts
@@ -21,6 +21,8 @@ import { describe, it, expect, vi } from "vitest";
 
 import {
   drainPendingUploads,
+  flushPending,
+  REAUTH_EVENT_NAME,
   type CloudSignClient,
   type SyncEvent,
 } from "../../../src/background/cloud-sync.js";
@@ -277,5 +279,130 @@ describe("drainPendingUploads · missing row", () => {
     });
     expect(await store.listPending()).toEqual([]);
     expect(client.calls).toHaveLength(0);
+  });
+});
+
+// Regression for test-reviewer F3: source_meta MUST round-trip
+// through the drain into signRemote args. The drain spreads
+// row.source_meta conditionally; a regression that drops the spread
+// would silently keep the cloud row's source attribution empty.
+describe("drainPendingUploads · forwards source_meta", () => {
+  it("passes through source_meta when the local row carries one", async () => {
+    const store = new IndexedDbStore({ dbName: freshDbName("source-meta") });
+    const rowWithMeta: AttestationRow = makeRow("att-meta", {
+      source_meta: {
+        platform: "chatgpt",
+        model: "gpt-4o",
+        chat_id: "ch-abc",
+        url: "https://chatgpt.com/c/ch-abc",
+      },
+    });
+    await store.saveAttestation(rowWithMeta);
+    await store.enqueue(rowWithMeta.attestation_id);
+
+    // Capture the full args object on the client side so we can
+    // assert source_meta arrived intact.
+    const captured: Array<Record<string, unknown>> = [];
+    const client: CloudSignClient = {
+      async signRemote(args) {
+        // Spread the whole `args` so we don't drop optional fields:
+        // the assertion below reads `source_meta` off the record.
+        captured.push({ ...(args as unknown as Record<string, unknown>) });
+        return {
+          attestation_id: "srv-1",
+          solana_tx: "Sol-meta",
+          arweave_tx: "Ar-meta",
+        };
+      },
+    };
+
+    const result = await drainPendingUploads({ store, cloudClient: client });
+    expect(result.flushed).toBe(1);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]?.["source_meta"]).toEqual({
+      platform: "chatgpt",
+      model: "gpt-4o",
+      chat_id: "ch-abc",
+      url: "https://chatgpt.com/c/ch-abc",
+    });
+  });
+
+  it("omits source_meta when the row has none (does not ship undefined)", async () => {
+    const store = new IndexedDbStore({ dbName: freshDbName("no-meta") });
+    // Default makeRow has no source_meta.
+    await seedQueue(store, ["att-x"]);
+    const captured: Array<Record<string, unknown>> = [];
+    const client: CloudSignClient = {
+      async signRemote(args) {
+        captured.push({ ...args });
+        return { attestation_id: "srv", solana_tx: "S", arweave_tx: "A" };
+      },
+    };
+    await drainPendingUploads({ store, cloudClient: client });
+    expect(captured).toHaveLength(1);
+    // Must not include the key at all (D9 hygiene: no implicit
+    // `undefined` fields traveling over JSON).
+    expect(
+      Object.prototype.hasOwnProperty.call(captured[0], "source_meta"),
+    ).toBe(false);
+  });
+});
+
+// Regression for test-reviewer F1: `flushPending` (the SW-facing
+// wrapper) dispatches a `mnemonik:re-auth-required` CustomEvent on
+// `globalThis` when the drain observes a 401. Previously only the
+// `emit` callback was covered; the CustomEvent dispatch path had
+// zero direct coverage.
+describe("flushPending · re-auth CustomEvent dispatch", () => {
+  it("fires mnemonik:re-auth-required on globalThis when the drain sees 401", async () => {
+    const store = new IndexedDbStore({ dbName: freshDbName("flush-reauth") });
+    await seedQueue(store, ["att-1"]);
+
+    const client: CloudSignClient = {
+      async signRemote() {
+        throw new ReauthRequiredError("expired");
+      },
+    };
+
+    // Capture the CustomEvent — jsdom provides `addEventListener` on
+    // globalThis, so we can subscribe in-process.
+    const events: string[] = [];
+    const listener = (e: Event): void => {
+      events.push(e.type);
+    };
+    const g = globalThis as {
+      addEventListener: (n: string, h: EventListener) => void;
+      removeEventListener: (n: string, h: EventListener) => void;
+    };
+    g.addEventListener(REAUTH_EVENT_NAME, listener as EventListener);
+    try {
+      const result = await flushPending({ store, cloudClient: client });
+      expect(result.attempted).toBe(1);
+      expect(result.flushed).toBe(0);
+    } finally {
+      g.removeEventListener(REAUTH_EVENT_NAME, listener as EventListener);
+    }
+    expect(events).toEqual([REAUTH_EVENT_NAME]);
+  });
+
+  it("also forwards re-auth via the deps.emit callback (both signals fire)", async () => {
+    const store = new IndexedDbStore({ dbName: freshDbName("flush-both") });
+    await seedQueue(store, ["att-1"]);
+
+    const client: CloudSignClient = {
+      async signRemote() {
+        throw new ReauthRequiredError("expired");
+      },
+    };
+    const emitted: SyncEvent[] = [];
+    const result = await flushPending({
+      store,
+      cloudClient: client,
+      emit: (e) => emitted.push(e),
+    });
+    expect(result.attempted).toBe(1);
+    expect(emitted).toEqual([
+      { type: "re-auth-required", attestation_id: "att-1" },
+    ]);
   });
 });

--- a/packages/extension/tests/unit/background/cloud-sync.test.ts
+++ b/packages/extension/tests/unit/background/cloud-sync.test.ts
@@ -1,0 +1,281 @@
+// T18 — cloud-sync drain unit tests.
+//
+// D13 anchor: `alarm_drains_queue_on_reconnect`. Seeds 3 rows into
+// the `pending_uploads` queue + the backing `attestations` store,
+// drives `drainPendingUploads` with a fake `CloudSignClient` that
+// returns success for every row, and asserts:
+//   - the queue is empty after the drain,
+//   - every row was updated with the returned `solana_tx` +
+//     `arweave_tx`,
+//   - the drain reports `attempted = 3, flushed = 3`.
+//
+// Extra coverage:
+//   - `null` cloud client short-circuits (queue stays).
+//   - `ReauthRequiredError` halts the drain mid-batch + emits
+//     `re-auth-required` for the row that hit 401.
+//   - `PermanentSyncError` stamps `sync_failed_permanent` + dequeues.
+//   - `TransientSyncError` leaves the row queued and continues.
+
+import "fake-indexeddb/auto";
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  drainPendingUploads,
+  type CloudSignClient,
+  type SyncEvent,
+} from "../../../src/background/cloud-sync.js";
+import {
+  PermanentSyncError,
+  ReauthRequiredError,
+  TransientSyncError,
+} from "../../../src/runtime/sync/cloud-client.js";
+import { IndexedDbStore } from "../../../src/runtime/store/indexeddb.js";
+import type { AttestationRow } from "../../../src/runtime/store/types.js";
+
+let dbCounter = 0;
+function freshDbName(label: string): string {
+  dbCounter += 1;
+  return `mnemonik-cs-${label}-${dbCounter}-${Math.random().toString(36).slice(2)}`;
+}
+
+function makeRow(
+  id: string,
+  overrides: Partial<AttestationRow> = {},
+): AttestationRow {
+  return {
+    attestation_id: id,
+    content: `content-${id}`,
+    content_hash: "0".repeat(64),
+    tags: ["source:chatgpt"],
+    embedding: new Float32Array([1, 0, 0, 0]),
+    cose_bytes: new Uint8Array([0x84, 0x01]),
+    created_at: "2026-05-11T00:00:00Z",
+    signer_pubkey: "SignerA",
+    owner_pubkey: "OwnerA",
+    solana_tx: `local:${id}`,
+    arweave_tx: `local:${id}`,
+    ...overrides,
+  };
+}
+
+/** Build a fake CloudSignClient that records calls and dispenses a
+ *  scripted result (or thrown error) per call. */
+function makeClient(
+  results: Array<
+    | { ok: true; solana_tx: string; arweave_tx: string }
+    | { ok: false; err: Error }
+  >,
+): CloudSignClient & {
+  calls: Array<{ content: string; signer_pubkey: string }>;
+} {
+  const calls: Array<{ content: string; signer_pubkey: string }> = [];
+  const client: CloudSignClient = {
+    async signRemote(args, signer) {
+      calls.push({
+        content: args.content,
+        signer_pubkey: signer.signer_pubkey,
+      });
+      const next = results.shift();
+      if (!next)
+        throw new Error("test: no scripted result for signRemote call");
+      if (!next.ok) throw next.err;
+      return {
+        attestation_id: `srv-${calls.length}`,
+        solana_tx: next.solana_tx,
+        arweave_tx: next.arweave_tx,
+      };
+    },
+  };
+  return Object.assign(client, { calls });
+}
+
+async function seedQueue(store: IndexedDbStore, ids: string[]): Promise<void> {
+  for (const id of ids) {
+    await store.saveAttestation(makeRow(id));
+    await store.enqueue(id);
+  }
+}
+
+describe("drainPendingUploads · empty queue", () => {
+  it("returns zeros without touching the cloud client", async () => {
+    const store = new IndexedDbStore({ dbName: freshDbName("empty") });
+    const client = makeClient([]);
+    const result = await drainPendingUploads({ store, cloudClient: client });
+    expect(result).toEqual({ attempted: 0, flushed: 0, errors: [] });
+    expect(client.calls).toHaveLength(0);
+  });
+});
+
+describe("drainPendingUploads · null client (no session)", () => {
+  it("reports queue depth and leaves the queue intact", async () => {
+    const store = new IndexedDbStore({ dbName: freshDbName("null") });
+    await seedQueue(store, ["a", "b"]);
+    const result = await drainPendingUploads({ store, cloudClient: null });
+    expect(result).toEqual({ attempted: 2, flushed: 0, errors: [] });
+    const pending = await store.listPending();
+    expect(pending.map((p) => p.attestation_id).sort()).toEqual(["a", "b"]);
+  });
+});
+
+describe("drainPendingUploads · alarm_drains_queue_on_reconnect (D13 anchor)", () => {
+  it("drains 3 queued rows and writes solana_tx + arweave_tx onto each row", async () => {
+    const store = new IndexedDbStore({ dbName: freshDbName("drain3") });
+    await seedQueue(store, ["att-1", "att-2", "att-3"]);
+
+    const client = makeClient([
+      { ok: true, solana_tx: "Sol-1", arweave_tx: "Ar-1" },
+      { ok: true, solana_tx: "Sol-2", arweave_tx: "Ar-2" },
+      { ok: true, solana_tx: "Sol-3", arweave_tx: "Ar-3" },
+    ]);
+
+    const result = await drainPendingUploads({ store, cloudClient: client });
+
+    expect(result).toMatchObject({ attempted: 3, flushed: 3 });
+    expect(result.errors).toEqual([]);
+
+    // Queue empty.
+    const pending = await store.listPending();
+    expect(pending).toEqual([]);
+
+    // Every row updated.
+    const a1 = await store.findById("att-1");
+    const a2 = await store.findById("att-2");
+    const a3 = await store.findById("att-3");
+    expect(a1?.solana_tx).toBe("Sol-1");
+    expect(a1?.arweave_tx).toBe("Ar-1");
+    expect(a2?.solana_tx).toBe("Sol-2");
+    expect(a2?.arweave_tx).toBe("Ar-2");
+    expect(a3?.solana_tx).toBe("Sol-3");
+    expect(a3?.arweave_tx).toBe("Ar-3");
+
+    // Drain visited each row exactly once in FIFO order.
+    expect(client.calls.map((c) => c.content)).toEqual([
+      "content-att-1",
+      "content-att-2",
+      "content-att-3",
+    ]);
+  });
+});
+
+describe("drainPendingUploads · 401 halts the drain and emits re-auth-required", () => {
+  it("stops mid-batch and emits the event for the failing row only", async () => {
+    const store = new IndexedDbStore({ dbName: freshDbName("reauth") });
+    await seedQueue(store, ["att-1", "att-2", "att-3"]);
+    const events: SyncEvent[] = [];
+
+    const client = makeClient([
+      { ok: true, solana_tx: "Sol-1", arweave_tx: "Ar-1" },
+      { ok: false, err: new ReauthRequiredError("expired") },
+      // The 3rd row is never reached because the drain halts.
+    ]);
+
+    const result = await drainPendingUploads({
+      store,
+      cloudClient: client,
+      emit: (event) => events.push(event),
+    });
+
+    expect(result.attempted).toBe(2);
+    expect(result.flushed).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toMatchObject({
+      attestation_id: "att-2",
+      kind: "reauth",
+    });
+
+    // The 2nd + 3rd rows stay queued.
+    const pending = await store.listPending();
+    expect(pending.map((p) => p.attestation_id).sort()).toEqual([
+      "att-2",
+      "att-3",
+    ]);
+
+    // Only one event emitted, for the row that observed 401.
+    expect(events).toEqual([
+      { type: "re-auth-required", attestation_id: "att-2" },
+    ]);
+  });
+});
+
+describe("drainPendingUploads · permanent failure", () => {
+  it("stamps sync_failed_permanent on the row + dequeues it", async () => {
+    const store = new IndexedDbStore({ dbName: freshDbName("perm") });
+    await seedQueue(store, ["att-1"]);
+    const events: SyncEvent[] = [];
+
+    const client = makeClient([
+      { ok: false, err: new PermanentSyncError("expired correlation_id", 410) },
+    ]);
+
+    const result = await drainPendingUploads({
+      store,
+      cloudClient: client,
+      emit: (event) => events.push(event),
+    });
+
+    expect(result.attempted).toBe(1);
+    expect(result.flushed).toBe(0);
+    expect(result.errors[0]?.kind).toBe("permanent");
+
+    // Queue empty (permanent failure dequeues so we don't churn).
+    const pending = await store.listPending();
+    expect(pending).toEqual([]);
+
+    // Row stamped.
+    const row = await store.findById("att-1");
+    expect(row?.sync_failed_permanent).toBe(true);
+
+    // Emit fired with HTTP status forwarded.
+    expect(events).toEqual([
+      {
+        type: "permanent-failure",
+        attestation_id: "att-1",
+        status: 410,
+        message: "expired correlation_id",
+      },
+    ]);
+  });
+});
+
+describe("drainPendingUploads · transient failure", () => {
+  it("leaves the row queued and continues with the next one", async () => {
+    const store = new IndexedDbStore({ dbName: freshDbName("transient") });
+    await seedQueue(store, ["att-1", "att-2"]);
+
+    const client = makeClient([
+      { ok: false, err: new TransientSyncError("503 upstream", 503) },
+      { ok: true, solana_tx: "Sol-2", arweave_tx: "Ar-2" },
+    ]);
+
+    const result = await drainPendingUploads({ store, cloudClient: client });
+
+    expect(result.attempted).toBe(2);
+    expect(result.flushed).toBe(1);
+    expect(result.errors[0]?.kind).toBe("transient");
+
+    // att-1 stays queued; att-2 was flushed.
+    const pending = await store.listPending();
+    expect(pending.map((p) => p.attestation_id)).toEqual(["att-1"]);
+    expect((await store.findById("att-2"))?.solana_tx).toBe("Sol-2");
+  });
+});
+
+describe("drainPendingUploads · missing row", () => {
+  it("dequeues queue entries whose attestation_id was deleted from the store", async () => {
+    const store = new IndexedDbStore({ dbName: freshDbName("missing") });
+    // Enqueue without ever saving the row.
+    await store.enqueue("ghost-id");
+    const client = makeClient([]);
+
+    const result = await drainPendingUploads({ store, cloudClient: client });
+
+    expect(result.attempted).toBe(1);
+    expect(result.flushed).toBe(0);
+    expect(result.errors[0]).toMatchObject({
+      attestation_id: "ghost-id",
+      kind: "missing-row",
+    });
+    expect(await store.listPending()).toEqual([]);
+    expect(client.calls).toHaveLength(0);
+  });
+});

--- a/packages/extension/tests/unit/runtime/sync/cloud-client.test.ts
+++ b/packages/extension/tests/unit/runtime/sync/cloud-client.test.ts
@@ -23,13 +23,23 @@
 //   - `recallRemote` returns parsed hits.
 //   - `verifyRemote` discriminated union.
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import {
   CloudClient,
   PermanentSyncError,
   ReauthRequiredError,
   TransientSyncError,
 } from "../../../../src/runtime/sync/cloud-client.js";
+
+// Defensive: reset spy state between tests so a future contributor
+// adding `vi.spyOn(globalThis, 'fetch')` at top-scope can't leak into
+// adjacent tests. Test-reviewer round-1 finding T18-T-01.
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 const BASE = "https://mc.example.test";
 const JWT = "header.payload.sig";
@@ -209,6 +219,54 @@ describe("CloudClient · offline_enqueues_for_later (D13 anchor)", () => {
   });
 });
 
+describe("CloudClient · server-contract violations", () => {
+  // Regression for T18-C-02: a server response with an empty-string
+  // `correlation_id` is treated as a permanent failure rather than
+  // silently shipped to /api/sign-callback (which would come back
+  // as 410 and obscure the actual server bug).
+  it("throws PermanentSyncError when /mcp returns correlation_id: ''", async () => {
+    const fetchImpl = queuedFetch([
+      jsonResponse(200, {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { correlation_id: "", expires_in: 300 },
+      }),
+    ]);
+    const client = new CloudClient({
+      jwt: JWT,
+      baseUrl: BASE,
+      fetch: fetchImpl,
+    });
+    await expect(
+      client.signRemote(
+        { content: "x", tags: [] },
+        { cose_bytes: COSE_BYTES, signer_pubkey: SIGNER_PUBKEY },
+      ),
+    ).rejects.toBeInstanceOf(PermanentSyncError);
+  });
+
+  it("throws PermanentSyncError when /mcp omits correlation_id entirely", async () => {
+    const fetchImpl = queuedFetch([
+      jsonResponse(200, {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { expires_in: 300 },
+      }),
+    ]);
+    const client = new CloudClient({
+      jwt: JWT,
+      baseUrl: BASE,
+      fetch: fetchImpl,
+    });
+    await expect(
+      client.signRemote(
+        { content: "x", tags: [] },
+        { cose_bytes: COSE_BYTES, signer_pubkey: SIGNER_PUBKEY },
+      ),
+    ).rejects.toBeInstanceOf(PermanentSyncError);
+  });
+});
+
 describe("CloudClient · typed errors", () => {
   it("throws ReauthRequiredError on 401 from /mcp", async () => {
     const fetchImpl = queuedFetch([
@@ -375,6 +433,20 @@ describe("CloudClient · recallRemote", () => {
     });
     expect(await client.recallRemote("", 5)).toEqual([]);
     expect(await client.recallRemote("  ", 5)).toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  // Regression for test-reviewer F4: k<=0 must short-circuit
+  // symmetrically with the empty-query branch (no fetch, [] result).
+  it("returns [] for k <= 0 without hitting the network", async () => {
+    const fetchImpl = vi.fn();
+    const client = new CloudClient({
+      jwt: JWT,
+      baseUrl: BASE,
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+    expect(await client.recallRemote("query", 0)).toEqual([]);
+    expect(await client.recallRemote("query", -1)).toEqual([]);
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 });

--- a/packages/extension/tests/unit/runtime/sync/cloud-client.test.ts
+++ b/packages/extension/tests/unit/runtime/sync/cloud-client.test.ts
@@ -1,0 +1,445 @@
+// T18 — CloudClient unit tests. D13 anchors that MUST stay binding:
+//
+//   1. `deferred_signing_flow` — drives `signRemote` end-to-end with
+//      mocked fetch for `POST /mcp` (mnemonic_sign_memory) +
+//      `POST /api/sign-callback`. Asserts:
+//        - correlation_id round-trips between the two calls,
+//        - the callback body carries `cose_signed_bytes_b64` +
+//          `signer_pubkey_base58`,
+//        - the returned `{attestation_id, solana_tx, arweave_tx}`
+//          mirrors the server payload.
+//
+//   2. `offline_enqueues_for_later` — `fetch` rejects with a network
+//      error. The client maps it to `TransientSyncError`; the
+//      service-worker drain then leaves the row in `pending_uploads`
+//      for the next alarm tick. This test asserts the typed-error
+//      branch is hit (the queue-side persistence is exercised in
+//      `cloud-sync.test.ts`).
+//
+// Additional coverage:
+//   - 401 surfaces `ReauthRequiredError`.
+//   - 4xx (not 401) surfaces `PermanentSyncError`.
+//   - 5xx surfaces `TransientSyncError`.
+//   - `recallRemote` returns parsed hits.
+//   - `verifyRemote` discriminated union.
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  CloudClient,
+  PermanentSyncError,
+  ReauthRequiredError,
+  TransientSyncError,
+} from "../../../../src/runtime/sync/cloud-client.js";
+
+const BASE = "https://mc.example.test";
+const JWT = "header.payload.sig";
+const SIGNER_PUBKEY = "Bsigner1111111111111111111111111111111111";
+const COSE_BYTES = new Uint8Array([0x84, 0x01, 0x02, 0x03, 0xff]);
+
+/** Build a minimal `fetch` mock whose response queue is driven by the
+ *  caller. Each call shifts one response off `queue`. Throws if the
+ *  queue runs dry — the test should always set the response count to
+ *  match the expected number of fetch calls. */
+function queuedFetch(
+  queue: Array<Response | Promise<Response> | Error>,
+): typeof fetch {
+  const impl = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const next = queue.shift();
+    if (next === undefined) {
+      throw new Error(
+        `fetch called more times than queued (url=${String(input)})`,
+      );
+    }
+    if (next instanceof Error) throw next;
+    return next instanceof Promise ? await next : next;
+  });
+  return impl as unknown as typeof fetch;
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("CloudClient · construction", () => {
+  it("throws when no jwt is supplied", () => {
+    expect(() => new CloudClient({ jwt: "" })).toThrow(/jwt is required/);
+  });
+});
+
+describe("CloudClient · deferred_signing_flow (D13 anchor)", () => {
+  it("posts the correlation_id from /mcp into /api/sign-callback and returns the tx ids", async () => {
+    const fetchCalls: Array<{ url: string; init?: RequestInit }> = [];
+    const correlationId = "corr-abc-123";
+    const responses: Response[] = [
+      // 1) /mcp mnemonic_sign_memory
+      jsonResponse(200, {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { correlation_id: correlationId, expires_in: 300 },
+      }),
+      // 2) /api/sign-callback
+      jsonResponse(200, {
+        status: "signed",
+        attestation_id: "att-server-uuid-1",
+        content_hash: "deadbeef".repeat(8),
+        solana_tx: "SoLaNa1111111111111111",
+        arweave_tx: "ArWeAvE1111111111111111",
+        solana_explorer_url: "https://solscan.io/tx/SoLaNa1111111111111111",
+        arweave_url: "https://arweave.net/ArWeAvE1111111111111111",
+      }),
+    ];
+    const fetchImpl = vi.fn(
+      async (url: RequestInfo | URL, init?: RequestInit) => {
+        fetchCalls.push({ url: String(url), ...(init ? { init } : {}) });
+        const r = responses.shift();
+        if (!r) throw new Error("unexpected fetch");
+        return r;
+      },
+    );
+
+    const client = new CloudClient({
+      jwt: JWT,
+      baseUrl: BASE,
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+
+    const result = await client.signRemote(
+      {
+        content: "hello cloud",
+        tags: ["t1", "t2"],
+        source_meta: { platform: "chatgpt" },
+      },
+      { cose_bytes: COSE_BYTES, signer_pubkey: SIGNER_PUBKEY },
+    );
+
+    expect(result).toEqual({
+      attestation_id: "att-server-uuid-1",
+      solana_tx: "SoLaNa1111111111111111",
+      arweave_tx: "ArWeAvE1111111111111111",
+    });
+
+    // 1st fetch — /mcp tools/call with Bearer JWT.
+    expect(fetchCalls[0]?.url).toBe(`${BASE}/mcp`);
+    const mcpHeaders = (fetchCalls[0]?.init?.headers ?? {}) as Record<
+      string,
+      string
+    >;
+    expect(mcpHeaders.Authorization).toBe(`Bearer ${JWT}`);
+    const mcpBody = JSON.parse(String(fetchCalls[0]?.init?.body));
+    expect(mcpBody).toMatchObject({
+      jsonrpc: "2.0",
+      method: "tools/call",
+      params: {
+        name: "mnemonic_sign_memory",
+        arguments: {
+          content: "hello cloud",
+          tags: ["t1", "t2"],
+          source_meta: { platform: "chatgpt" },
+        },
+      },
+    });
+
+    // 2nd fetch — /api/sign-callback with correlation_id + b64 COSE +
+    // signer_pubkey, NO Bearer JWT (capability auth per D2/D9).
+    expect(fetchCalls[1]?.url).toBe(`${BASE}/api/sign-callback`);
+    const cbHeaders = (fetchCalls[1]?.init?.headers ?? {}) as Record<
+      string,
+      string
+    >;
+    expect(cbHeaders.Authorization).toBeUndefined();
+    const cbBody = JSON.parse(String(fetchCalls[1]?.init?.body));
+    expect(cbBody.correlation_id).toBe(correlationId);
+    expect(cbBody.signer_pubkey).toBe(SIGNER_PUBKEY);
+    // Base64 decode the cose bytes and verify they round-trip.
+    const decoded = Uint8Array.from(atob(cbBody.cose_signed_bytes), (c) =>
+      c.charCodeAt(0),
+    );
+    expect(Array.from(decoded)).toEqual(Array.from(COSE_BYTES));
+  });
+});
+
+describe("CloudClient · offline_enqueues_for_later (D13 anchor)", () => {
+  it("maps a network rejection on /mcp to TransientSyncError so the drain leaves the row queued", async () => {
+    const fetchImpl = queuedFetch([
+      Object.assign(new Error("fetch failed"), { name: "TypeError" }),
+    ]);
+    const client = new CloudClient({
+      jwt: JWT,
+      baseUrl: BASE,
+      fetch: fetchImpl,
+    });
+
+    let caught: unknown = null;
+    try {
+      await client.signRemote(
+        { content: "queued offline", tags: [] },
+        { cose_bytes: COSE_BYTES, signer_pubkey: SIGNER_PUBKEY },
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(TransientSyncError);
+    expect((caught as TransientSyncError).message).toMatch(/network error/);
+  });
+
+  it("maps a network rejection on /api/sign-callback to TransientSyncError too", async () => {
+    const fetchImpl = queuedFetch([
+      jsonResponse(200, {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { correlation_id: "c-1", expires_in: 300 },
+      }),
+      Object.assign(new Error("network down"), { name: "TypeError" }),
+    ]);
+    const client = new CloudClient({
+      jwt: JWT,
+      baseUrl: BASE,
+      fetch: fetchImpl,
+    });
+
+    await expect(
+      client.signRemote(
+        { content: "x", tags: [] },
+        { cose_bytes: COSE_BYTES, signer_pubkey: SIGNER_PUBKEY },
+      ),
+    ).rejects.toBeInstanceOf(TransientSyncError);
+  });
+});
+
+describe("CloudClient · typed errors", () => {
+  it("throws ReauthRequiredError on 401 from /mcp", async () => {
+    const fetchImpl = queuedFetch([
+      jsonResponse(401, { error: { code: 401, message: "expired" } }),
+    ]);
+    const client = new CloudClient({
+      jwt: JWT,
+      baseUrl: BASE,
+      fetch: fetchImpl,
+    });
+    await expect(
+      client.signRemote(
+        { content: "x", tags: [] },
+        { cose_bytes: COSE_BYTES, signer_pubkey: SIGNER_PUBKEY },
+      ),
+    ).rejects.toBeInstanceOf(ReauthRequiredError);
+  });
+
+  it("throws ReauthRequiredError on 401 from /api/sign-callback", async () => {
+    const fetchImpl = queuedFetch([
+      jsonResponse(200, {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { correlation_id: "c-1", expires_in: 300 },
+      }),
+      new Response("unauth", { status: 401 }),
+    ]);
+    const client = new CloudClient({
+      jwt: JWT,
+      baseUrl: BASE,
+      fetch: fetchImpl,
+    });
+    await expect(
+      client.signRemote(
+        { content: "x", tags: [] },
+        { cose_bytes: COSE_BYTES, signer_pubkey: SIGNER_PUBKEY },
+      ),
+    ).rejects.toBeInstanceOf(ReauthRequiredError);
+  });
+
+  it("throws PermanentSyncError on 400 from /mcp", async () => {
+    const fetchImpl = queuedFetch([
+      jsonResponse(400, { error: { code: 400, message: "malformed" } }),
+    ]);
+    const client = new CloudClient({
+      jwt: JWT,
+      baseUrl: BASE,
+      fetch: fetchImpl,
+    });
+    let caught: unknown = null;
+    try {
+      await client.signRemote(
+        { content: "x", tags: [] },
+        { cose_bytes: COSE_BYTES, signer_pubkey: SIGNER_PUBKEY },
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(PermanentSyncError);
+    expect((caught as PermanentSyncError).status).toBe(400);
+  });
+
+  it("throws PermanentSyncError on 410 (sign-callback expired) from /api/sign-callback", async () => {
+    const fetchImpl = queuedFetch([
+      jsonResponse(200, {
+        jsonrpc: "2.0",
+        id: 1,
+        result: { correlation_id: "c-1", expires_in: 300 },
+      }),
+      new Response("gone", { status: 410 }),
+    ]);
+    const client = new CloudClient({
+      jwt: JWT,
+      baseUrl: BASE,
+      fetch: fetchImpl,
+    });
+    let caught: unknown = null;
+    try {
+      await client.signRemote(
+        { content: "x", tags: [] },
+        { cose_bytes: COSE_BYTES, signer_pubkey: SIGNER_PUBKEY },
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(PermanentSyncError);
+    expect((caught as PermanentSyncError).status).toBe(410);
+  });
+
+  it("throws TransientSyncError on 503", async () => {
+    const fetchImpl = queuedFetch([
+      new Response("upstream down", { status: 503 }),
+    ]);
+    const client = new CloudClient({
+      jwt: JWT,
+      baseUrl: BASE,
+      fetch: fetchImpl,
+    });
+    let caught: unknown = null;
+    try {
+      await client.signRemote(
+        { content: "x", tags: [] },
+        { cose_bytes: COSE_BYTES, signer_pubkey: SIGNER_PUBKEY },
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(TransientSyncError);
+    expect((caught as TransientSyncError).status).toBe(503);
+  });
+});
+
+describe("CloudClient · recallRemote", () => {
+  it("returns parsed hits from mnemonic_recall", async () => {
+    const fetchImpl = queuedFetch([
+      jsonResponse(200, {
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          hits: [
+            {
+              attestation_id: "a1",
+              content: "first",
+              similarity: 0.91,
+              tags: ["t"],
+              signed_at: "2026-05-11T10:00:00Z",
+              solana_tx: "SoL1",
+              arweave_tx: "Ar1",
+            },
+            {
+              attestation_id: "a2",
+              content: "second",
+              similarity: 0.42,
+            },
+          ],
+        },
+      }),
+    ]);
+    const client = new CloudClient({
+      jwt: JWT,
+      baseUrl: BASE,
+      fetch: fetchImpl,
+    });
+    const hits = await client.recallRemote("test", 5);
+    expect(hits).toHaveLength(2);
+    expect(hits[0]).toMatchObject({
+      attestation_id: "a1",
+      similarity: 0.91,
+      solana_tx: "SoL1",
+      arweave_tx: "Ar1",
+    });
+    expect(hits[1]).toMatchObject({
+      attestation_id: "a2",
+      similarity: 0.42,
+    });
+  });
+
+  it("returns [] for empty query without hitting the network", async () => {
+    const fetchImpl = vi.fn();
+    const client = new CloudClient({
+      jwt: JWT,
+      baseUrl: BASE,
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+    expect(await client.recallRemote("", 5)).toEqual([]);
+    expect(await client.recallRemote("  ", 5)).toEqual([]);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});
+
+describe("CloudClient · verifyRemote", () => {
+  it("returns a verified-shape result", async () => {
+    const fetchImpl = queuedFetch([
+      jsonResponse(200, {
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          status: "verified",
+          signer: "Bsigner",
+          solana_tx: "SoL",
+          arweave_tx: "Ar",
+        },
+      }),
+    ]);
+    const client = new CloudClient({
+      jwt: JWT,
+      baseUrl: BASE,
+      fetch: fetchImpl,
+    });
+    const r = await client.verifyRemote("att-1");
+    expect(r).toEqual({
+      status: "verified",
+      signer: "Bsigner",
+      solana_tx: "SoL",
+      arweave_tx: "Ar",
+    });
+  });
+
+  it("returns tampered with reason", async () => {
+    const fetchImpl = queuedFetch([
+      jsonResponse(200, {
+        jsonrpc: "2.0",
+        id: 1,
+        result: {
+          status: "tampered",
+          signer: "Bsigner",
+          reason: "content_hash_mismatch",
+        },
+      }),
+    ]);
+    const client = new CloudClient({
+      jwt: JWT,
+      baseUrl: BASE,
+      fetch: fetchImpl,
+    });
+    const r = await client.verifyRemote("att-1");
+    expect(r).toEqual({
+      status: "tampered",
+      signer: "Bsigner",
+      reason: "content_hash_mismatch",
+    });
+  });
+
+  it("returns not_found for empty id without network", async () => {
+    const fetchImpl = vi.fn();
+    const client = new CloudClient({
+      jwt: JWT,
+      baseUrl: BASE,
+      fetch: fetchImpl as unknown as typeof fetch,
+    });
+    expect(await client.verifyRemote("")).toEqual({ status: "not_found" });
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

T18, the final implementation task of the chrome-extension feature. Implements cloud-tier sync per D2: Cloud = thin client to hosted-\`full\` MCP server; the user signs COSE locally, the server only verifies + anchors on Arweave / Solana.

- **\`runtime/sync/cloud-client.ts\`** — \`CloudClient\` with \`signRemote\` (deferred-signing: POST /mcp \`mnemonic_sign_memory\` → correlation_id → POST /api/sign-callback), \`recallRemote\`, \`verifyRemote\`. Typed errors (\`ReauthRequiredError\`, \`PermanentSyncError\`, \`TransientSyncError\`) so the drain branches on type rather than parsing strings.
- **\`background/cloud-sync.ts\`** — \`flushPending\` SW-facing entrypoint + \`drainPendingUploads\` pure test seam. On success: writes \`solana_tx\` / \`arweave_tx\` onto the local row, dequeues. On permanent 4xx: stamps \`sync_failed_permanent\` on the row + dequeues so the alarm-loop stops churning. On 401: halts the drain + dispatches \`mnemonik:re-auth-required\`. On 5xx / network: leaves the row queued for the next tick.
- **\`popup/tabs/Recall.tsx\`** — Cloud-tier merge: local + cloud recall results, dedupe by \`attestation_id\`, prefer the higher score, fold cloud-side tx ids over synthetic \`local:\` placeholders. Cloud failures never block local results (offline-first guarantee).
- **\`popup/runtime.ts\`** — adds \`cloudSync\` seam so popup tabs route through the runtime facade rather than importing the cloud client directly.
- **\`service-worker.ts\`** — alarm wires through new drain; \`cloudClientProvider\` + \`emitSyncEvent\` deps for the per-tick composition.

## TDD anchors (D13)

All three bound and green:

- \`deferred_signing_flow\` — \`tests/unit/runtime/sync/cloud-client.test.ts\` — mocks both \`/mcp\` and \`/api/sign-callback\`; asserts correlation_id roundtrip + final tx triple. Also pins: leg 2 carries NO Bearer JWT (capability auth per D2/D9).
- \`offline_enqueues_for_later\` — same file — \`fetch\` rejects → \`TransientSyncError\` so the SW drain leaves the row in \`pending_uploads\` for the next tick. The error type is \`!instanceof PermanentSyncError\` (would lose data) and \`!instanceof ReauthRequiredError\` (would spuriously stop the drain).
- \`alarm_drains_queue_on_reconnect\` — \`tests/unit/background/cloud-sync.test.ts\` — populates queue with 3 rows; fake \`CloudSignClient\` returns success for each; queue empty + every row updated.

Plus: 401 halts drain + emits event, permanent failure stamps row + dequeues, transient failure leaves queued, missing-row dequeues ghost entries, Cloud-tier offline-first preserves local results when cloud fails, Local-tier skips \`recallRemote\` entirely.

## Test plan

- [x] \`bun test tests/unit/runtime/sync tests/unit/background\` — 31/31 pass
- [x] \`npx vitest run tests/component/popup/Recall.test.tsx\` — 6/6 pass (3 new Cloud-tier tests)
- [x] \`npx vitest run tests/component\` — 45/45 pass (all popup + options surfaces)
- [x] \`bun test\` (full extension suite) — 217 pass, 1 pre-existing fail (\`tests/unit/sign/cose.test.ts\`, WASM artifact missing, documented in task constraints)
- [x] \`npx tsc -b --noEmit\` — clean (only pre-existing \`vitest.config.ts\` overload error from vite/vitest version skew, also documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)