### PR TITLE
test(extension): T22 — cloud-tier popup component tests

### DIFF
--- a/packages/extension/tests/component/popup/Capture.cloud.test.tsx
+++ b/packages/extension/tests/component/popup/Capture.cloud.test.tsx
@@ -6,12 +6,17 @@
 // onboarding).
 //
 // The runtime facade exposes two seams here: the high-level
-// `signRemote(args)` wrapper (which mirrors what `runtime.ts` does in
-// production — best-effort enqueue, attempt cloud push, branch on
-// error class) and the low-level `cloudSync.signRemote` (the actual
-// HTTP call). To preserve the contract that "popup invokes
-// cloudSync.signRemote with the right payload" we install a test
-// `signRemote` that mirrors production semantics and delegates to the
+// `signRemote(args)` wrapper (whose error-handling semantics mirror
+// what `runtime.ts` does in production — try cloud push, branch on
+// error class, dispatch the re-auth event, swallow Transient, re-throw
+// Permanent) and the low-level `cloudSync.signRemote` (the actual
+// HTTP call). The IDB enqueue/dequeue side-effects production performs
+// are deliberately NOT modelled — these tests assert the popup ↔
+// runtime contract, not the queue's persistence. The cloud-sync drain
+// (tests/unit/background/cloud-sync.test.ts) already covers that.
+//
+// To preserve the contract that "popup invokes cloudSync.signRemote
+// with the right payload" the test `signRemote` delegates to the
 // mocked `cloudSync.signRemote` — that way both seams are observable.
 
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
@@ -41,7 +46,9 @@ const chatgptAdapter: ChatAdapter = {
 
 const SIGN_RESULT: SignMemoryResult = {
   attestation_id: "att_cloudbeef",
-  content_hash: "cloudbeef".repeat(7) + "00000",
+  // 64 hex chars — matches the canonical blake3 hex length used
+  // everywhere else in the suite.
+  content_hash: "cb".repeat(32),
   signer_pubkey: "PubCloud",
   // The local-pipeline always writes synthetic `local:` ids first; the
   // cloud-side `signRemote` overwrites them with real tx ids.

--- a/packages/extension/tests/component/popup/Capture.cloud.test.tsx
+++ b/packages/extension/tests/component/popup/Capture.cloud.test.tsx
@@ -1,0 +1,305 @@
+// Capture-tab tests for Cloud-tier. Covers the deferred-signing happy
+// path (T18 spec D2) and the error taxonomy the runtime catches:
+// `TransientSyncError` (alarm-drain retries), `PermanentSyncError`
+// (row marked `sync_failed_permanent`), `ReauthRequiredError`
+// (`mnemonik:re-auth-required` dispatched, popup falls back to
+// onboarding).
+//
+// The runtime facade exposes two seams here: the high-level
+// `signRemote(args)` wrapper (which mirrors what `runtime.ts` does in
+// production — best-effort enqueue, attempt cloud push, branch on
+// error class) and the low-level `cloudSync.signRemote` (the actual
+// HTTP call). To preserve the contract that "popup invokes
+// cloudSync.signRemote with the right payload" we install a test
+// `signRemote` that mirrors production semantics and delegates to the
+// mocked `cloudSync.signRemote` — that way both seams are observable.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Capture } from "../../../src/popup/tabs/Capture.js";
+import {
+  setRuntime,
+  type PopupRuntime,
+  type SignMemoryArgs,
+  type SignMemoryResult,
+} from "../../../src/popup/runtime.js";
+import {
+  PermanentSyncError,
+  ReauthRequiredError,
+  TransientSyncError,
+} from "../../../src/runtime/sync/cloud-client.js";
+import type { ChatAdapter } from "../../../src/runtime/chat/types.js";
+
+const chatgptAdapter: ChatAdapter = {
+  hostPattern: /^chatgpt\.com\//,
+  platform: "chatgpt",
+  supportsInsert: true,
+  extractConversation: () => [],
+  findInputBox: () => null,
+  getChatId: () => null,
+};
+
+const SIGN_RESULT: SignMemoryResult = {
+  attestation_id: "att_cloudbeef",
+  content_hash: "cloudbeef".repeat(7) + "00000",
+  signer_pubkey: "PubCloud",
+  // The local-pipeline always writes synthetic `local:` ids first; the
+  // cloud-side `signRemote` overwrites them with real tx ids.
+  solana_tx: "local:cloudbeef",
+  arweave_tx: "local:cloudbeef",
+  created_at: "2026-05-11T12:00:00Z",
+};
+
+const CLOUD_TX = {
+  solana_tx: "SolRealTxAaa111",
+  arweave_tx: "ArRealTxBbb222",
+};
+
+interface CloudRuntimeOverrides {
+  signMemory?: PopupRuntime["signMemory"];
+  cloudSignRemote?: PopupRuntime["cloudSync"]["signRemote"];
+}
+
+/**
+ * Build a runtime stub whose top-level `signRemote` mirrors the
+ * production semantics in `runtime.ts`: try `cloudSync.signRemote`
+ * once, swallow `TransientSyncError` (alarm-drain retries),
+ * dispatch `mnemonik:re-auth-required` on `ReauthRequiredError`,
+ * re-throw `PermanentSyncError`. Tests can override the cloud seam
+ * via `cloudSignRemote` to drive each branch.
+ */
+function makeCloudRuntime(overrides: CloudRuntimeOverrides = {}): PopupRuntime {
+  const cloudSignRemote = overrides.cloudSignRemote ?? (async () => CLOUD_TX);
+  const signMemory =
+    overrides.signMemory ??
+    (async (_args: SignMemoryArgs): Promise<SignMemoryResult> => SIGN_RESULT);
+  return {
+    loadIdentity: async () => null,
+    loadStorageTier: async () => "cloud" as const,
+    getActiveTabAdapter: async () => null,
+    getActiveTabSelection: async () => "",
+    getActiveTabConversation: async () => null,
+    signMemory,
+    async signRemote(args): Promise<void> {
+      // Mirror runtime.ts behaviour so the popup observes the same
+      // contract the production code path provides.
+      try {
+        await this.cloudSync.signRemote(args);
+      } catch (err) {
+        if (err instanceof ReauthRequiredError) {
+          const g = globalThis as {
+            dispatchEvent?: (e: Event) => boolean;
+            CustomEvent?: typeof CustomEvent;
+          };
+          if (
+            typeof g.dispatchEvent === "function" &&
+            typeof g.CustomEvent === "function"
+          ) {
+            g.dispatchEvent(new g.CustomEvent("mnemonik:re-auth-required"));
+          }
+          return;
+        }
+        if (err instanceof PermanentSyncError) {
+          throw err;
+        }
+        // TransientSyncError or unknown — leave queued, swallow.
+      }
+    },
+    recall: async () => [],
+    verify: async () => ({ status: "not_found" }),
+    auth: {
+      signIn: async () => {
+        throw new Error("auth.signIn stub: not configured in test");
+      },
+      lookupExisting: async () => {
+        throw new Error("auth.lookupExisting stub: not configured in test");
+      },
+      ensureExtensionJwt: async () => {
+        throw new Error("auth.ensureExtensionJwt stub: not configured in test");
+      },
+      linkGoogle: async () => {
+        throw new Error("auth.linkGoogle stub: not configured in test");
+      },
+    },
+    session: {
+      get: async () => null,
+      set: async () => undefined,
+      clear: async () => undefined,
+      jwtExpiresAtMs: () => null,
+    },
+    cloudSync: {
+      signRemote: cloudSignRemote,
+      recallRemote: async () => null,
+      verifyRemote: async () => null,
+    },
+    keyEscrow: {
+      wrap: async () => {
+        throw new Error("keyEscrow.wrap stub: not configured in test");
+      },
+      unwrap: async () => {
+        throw new Error("keyEscrow.unwrap stub: not configured in test");
+      },
+      upload: async () => {
+        throw new Error("keyEscrow.upload stub: not configured in test");
+      },
+      fetch: async () => {
+        throw new Error("keyEscrow.fetch stub: not configured in test");
+      },
+      delete: async () => {
+        throw new Error("keyEscrow.delete stub: not configured in test");
+      },
+      rotate: async () => {
+        throw new Error("keyEscrow.rotate stub: not configured in test");
+      },
+      hasBlob: async () => false,
+    },
+  };
+}
+
+describe("Capture tab — Cloud tier", () => {
+  beforeEach(() => {
+    setRuntime(null);
+  });
+  afterEach(() => {
+    setRuntime(null);
+  });
+
+  it("cloud_push_succeeds — deferred-signing happy path drives signRemote with full payload", async () => {
+    // TDD anchor: cloud_push_succeeds. Sign with prefilled selection;
+    // assert the cloud-side signRemote was called exactly once with
+    // the canonical payload (content + tags + the SignMemoryResult
+    // fields the popup forwards). Success toast renders with the
+    // returned attestation_id.
+    const cloudSignRemote = vi
+      .fn<
+        [SignMemoryArgs & SignMemoryResult],
+        Promise<{ solana_tx: string; arweave_tx: string } | null>
+      >()
+      .mockResolvedValue(CLOUD_TX);
+    setRuntime(makeCloudRuntime({ cloudSignRemote }));
+
+    render(
+      <Capture
+        adapter={chatgptAdapter}
+        prefilledSelection="cloud-bound memory"
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText("Tags"), {
+      target: { value: "alpha" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /^sign$/i }));
+
+    await waitFor(() => expect(cloudSignRemote).toHaveBeenCalledTimes(1));
+    const payload = cloudSignRemote.mock.calls[0]?.[0];
+    expect(payload?.content).toBe("cloud-bound memory");
+    expect(payload?.tags).toContain("alpha");
+    expect(payload?.tags).toContain("source:chatgpt");
+    // The popup forwards every field the SignMemoryResult carries —
+    // the cloud-client needs `signer_pubkey` to attach to the
+    // sign-callback body, plus the attestation_id / content_hash so
+    // the server can match the pending bundle.
+    expect(payload?.attestation_id).toBe(SIGN_RESULT.attestation_id);
+    expect(payload?.content_hash).toBe(SIGN_RESULT.content_hash);
+    expect(payload?.signer_pubkey).toBe(SIGN_RESULT.signer_pubkey);
+
+    const toast = await screen.findByRole("status");
+    expect(toast.textContent ?? "").toMatch(/Signed/);
+    expect(toast.textContent ?? "").toMatch(/att_cloudbeef/);
+  });
+
+  it("TransientSyncError leaves the local sign succeeded — no hard error toast", async () => {
+    // The runtime swallows TransientSyncError so the alarm-drain can
+    // retry on the next tick. Local sign already succeeded (the
+    // signMemory call ran and persisted to IDB), so the popup must
+    // continue to render the success toast rather than a hard error
+    // that would scare the user off a recoverable upstream hiccup.
+    const cloudSignRemote = vi
+      .fn<
+        [SignMemoryArgs & SignMemoryResult],
+        Promise<{ solana_tx: string; arweave_tx: string } | null>
+      >()
+      .mockRejectedValue(new TransientSyncError("upstream 503", 503));
+    const signMemory = vi
+      .fn<[SignMemoryArgs], Promise<SignMemoryResult>>()
+      .mockResolvedValue(SIGN_RESULT);
+    setRuntime(makeCloudRuntime({ signMemory, cloudSignRemote }));
+
+    render(<Capture adapter={null} prefilledSelection="will retry later" />);
+    fireEvent.click(screen.getByRole("button", { name: /^sign$/i }));
+
+    // Local pipeline ran (row was created in IDB) and cloud push was
+    // attempted exactly once.
+    await waitFor(() => expect(signMemory).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(cloudSignRemote).toHaveBeenCalledTimes(1));
+
+    // Success toast renders — `signRemote` swallowed the transient
+    // error per the runtime contract.
+    const toast = await screen.findByRole("status");
+    expect(toast.textContent ?? "").toMatch(/Signed/);
+    expect(toast.textContent ?? "").toMatch(/att_cloudbeef/);
+    // No error-banner copy.
+    expect(screen.queryByText(/upstream 503/)).toBeNull();
+    expect(screen.queryByText(/error/i)).toBeNull();
+  });
+
+  it("PermanentSyncError surfaces a hard error toast (row marked sync_failed_permanent by runtime)", async () => {
+    // Mirror runtime.ts: PermanentSyncError is re-thrown. The popup
+    // catches it and shows a user-facing error toast.
+    const cloudSignRemote = vi
+      .fn<
+        [SignMemoryArgs & SignMemoryResult],
+        Promise<{ solana_tx: string; arweave_tx: string } | null>
+      >()
+      .mockRejectedValue(
+        new PermanentSyncError("sign-callback consumed/expired", 410),
+      );
+    setRuntime(makeCloudRuntime({ cloudSignRemote }));
+
+    render(<Capture adapter={null} prefilledSelection="bad payload" />);
+    fireEvent.click(screen.getByRole("button", { name: /^sign$/i }));
+
+    await waitFor(() => expect(cloudSignRemote).toHaveBeenCalledTimes(1));
+
+    const toast = await screen.findByRole("status");
+    expect(toast.textContent ?? "").toMatch(/consumed|expired|sign-callback/i);
+    // Success toast NOT rendered for a permanent failure — only the
+    // error one. Capture.tsx clears `result` on entry so this is the
+    // only role=status node.
+    expect(toast.textContent ?? "").not.toMatch(/Signed →/);
+  });
+
+  it("ReauthRequiredError dispatches `mnemonik:re-auth-required` and does not block the local sign", async () => {
+    // 401 from the cloud surface: the runtime swallows the error and
+    // emits a global event so App.tsx flips into onboarding. The
+    // local row stays queued for the next tick post re-auth.
+    const cloudSignRemote = vi
+      .fn<
+        [SignMemoryArgs & SignMemoryResult],
+        Promise<{ solana_tx: string; arweave_tx: string } | null>
+      >()
+      .mockRejectedValue(new ReauthRequiredError("sign-callback 401"));
+    setRuntime(makeCloudRuntime({ cloudSignRemote }));
+
+    const seen: string[] = [];
+    const listener = (e: Event): void => {
+      seen.push(e.type);
+    };
+    window.addEventListener("mnemonik:re-auth-required", listener);
+
+    try {
+      render(<Capture adapter={null} prefilledSelection="needs re-auth" />);
+      fireEvent.click(screen.getByRole("button", { name: /^sign$/i }));
+
+      await waitFor(() => expect(cloudSignRemote).toHaveBeenCalledTimes(1));
+      // Wait for the runtime's signRemote to settle — it's awaited
+      // by Capture, so by the time the toast renders the event has
+      // fired.
+      const toast = await screen.findByRole("status");
+      expect(toast.textContent ?? "").toMatch(/Signed/);
+      expect(seen).toContain("mnemonik:re-auth-required");
+    } finally {
+      window.removeEventListener("mnemonik:re-auth-required", listener);
+    }
+  });
+});

--- a/packages/extension/tests/component/popup/Recall.merge.test.tsx
+++ b/packages/extension/tests/component/popup/Recall.merge.test.tsx
@@ -77,9 +77,12 @@ function makeCloudMergeRuntime(opts: CloudMergeOverrides): PopupRuntime {
       }
       return opts.cloudResults;
     });
+  const loadStorageTier = vi
+    .fn<[], Promise<"local" | "cloud">>()
+    .mockResolvedValue("cloud" as const);
   const runtime: PopupRuntime = {
     loadIdentity: async () => null,
-    loadStorageTier: async () => "cloud" as const,
+    loadStorageTier,
     getActiveTabAdapter: async () => null,
     getActiveTabSelection: async () => "",
     getActiveTabConversation: async () => null,
@@ -146,11 +149,16 @@ function makeCloudMergeRuntime(opts: CloudMergeOverrides): PopupRuntime {
   // callers — only tests pull off these handles.
   (
     runtime as unknown as {
-      __spies: { recall: typeof recall; recallRemote: typeof recallRemote };
+      __spies: {
+        recall: typeof recall;
+        recallRemote: typeof recallRemote;
+        loadStorageTier: typeof loadStorageTier;
+      };
     }
   ).__spies = {
     recall,
     recallRemote,
+    loadStorageTier,
   };
   return runtime;
 }
@@ -158,12 +166,14 @@ function makeCloudMergeRuntime(opts: CloudMergeOverrides): PopupRuntime {
 function spies(runtime: PopupRuntime): {
   recall: ReturnType<typeof vi.fn>;
   recallRemote: ReturnType<typeof vi.fn>;
+  loadStorageTier: ReturnType<typeof vi.fn>;
 } {
   return (
     runtime as unknown as {
       __spies: {
         recall: ReturnType<typeof vi.fn>;
         recallRemote: ReturnType<typeof vi.fn>;
+        loadStorageTier: ReturnType<typeof vi.fn>;
       };
     }
   ).__spies;
@@ -229,18 +239,17 @@ describe("Recall tab — Cloud-tier merge contract", () => {
 
     render(<Recall adapter={chatgptAdapter} />);
     // Wait for `loadStorageTier` to settle so the click runs in cloud
-    // mode rather than the default local fallback.
-    await waitFor(() => {
-      expect(runtime.loadStorageTier).toBeDefined();
-    });
+    // mode rather than the default local fallback. The Recall tab
+    // reads the tier exactly once on mount; we await that call AND
+    // a microtask so the React state commit propagates.
+    const { recall, recallRemote, loadStorageTier } = spies(runtime);
+    await waitFor(() => expect(loadStorageTier).toHaveBeenCalled());
     await new Promise((r) => setTimeout(r, 0));
 
     fireEvent.change(screen.getByLabelText("Recall query"), {
       target: { value: "test query" },
     });
     fireEvent.click(screen.getByRole("button", { name: /find/i }));
-
-    const { recall, recallRemote } = spies(runtime);
     await waitFor(() => expect(recall).toHaveBeenCalledTimes(1));
     await waitFor(() =>
       expect(recallRemote).toHaveBeenCalledWith("test query", 5),
@@ -300,14 +309,15 @@ describe("Recall tab — Cloud-tier merge contract", () => {
         arweave_tx: "ArRealCloudOnly",
       }),
     ];
-    setRuntime(
-      makeCloudMergeRuntime({
-        localResults,
-        cloudResults,
-      }),
-    );
+    const runtime = makeCloudMergeRuntime({
+      localResults,
+      cloudResults,
+    });
+    setRuntime(runtime);
 
     render(<Recall adapter={chatgptAdapter} />);
+    const { loadStorageTier } = spies(runtime);
+    await waitFor(() => expect(loadStorageTier).toHaveBeenCalled());
     await new Promise((r) => setTimeout(r, 0));
     fireEvent.change(screen.getByLabelText("Recall query"), {
       target: { value: "q" },
@@ -362,6 +372,8 @@ describe("Recall tab — Cloud-tier merge contract", () => {
       setRuntime(runtime);
 
       render(<Recall adapter={chatgptAdapter} />);
+      const { loadStorageTier } = spies(runtime);
+      await waitFor(() => expect(loadStorageTier).toHaveBeenCalled());
       await new Promise((r) => setTimeout(r, 0));
       fireEvent.change(screen.getByLabelText("Recall query"), {
         target: { value: "anything" },

--- a/packages/extension/tests/component/popup/Recall.merge.test.tsx
+++ b/packages/extension/tests/component/popup/Recall.merge.test.tsx
@@ -1,0 +1,398 @@
+// Recall-tab tests for the T18 Cloud-tier merge contract. The merge
+// rule lives in `mergeRecallHits` (pure helper, already unit-tested in
+// `Recall.test.tsx`); these component tests drive the full popup path:
+//
+//   - Local search (`runtime.recall`) and cloud search
+//     (`cloudSync.recallRemote`) both fire in parallel.
+//   - Results dedupe by `attestation_id`; the higher of the two scores
+//     wins on conflict.
+//   - Cloud-only entries carry non-`local:` tx ids (they were anchored
+//     server-side); local-only entries keep their `local:` placeholders.
+//   - Final list is sorted by score descending, truncated to limit.
+//
+// The TDD anchor `merge_dedupes_and_resorts` drives the canonical
+// scenario: three local + three cloud rows with one overlap, asserting
+// exact dedupe + score-winner + descending order.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Recall } from "../../../src/popup/tabs/Recall.js";
+import {
+  setRuntime,
+  type CloudRecallHit,
+  type PopupRuntime,
+} from "../../../src/popup/runtime.js";
+import type { ChatAdapter } from "../../../src/runtime/chat/types.js";
+import type { SearchResult } from "../../../src/runtime/store/types.js";
+
+const chatgptAdapter: ChatAdapter = {
+  hostPattern: /^chatgpt\.com\//,
+  platform: "chatgpt",
+  supportsInsert: true,
+  extractConversation: () => [],
+  findInputBox: () => null,
+  getChatId: () => null,
+};
+
+function localHit(over: Partial<SearchResult>): SearchResult {
+  return {
+    attestation_id: over.attestation_id ?? "att",
+    content: over.content ?? "local content",
+    content_hash: over.content_hash ?? "0".repeat(64),
+    tags: over.tags ?? [],
+    solana_tx: over.solana_tx ?? `local:${over.attestation_id ?? "x"}`,
+    arweave_tx: over.arweave_tx ?? `local:${over.attestation_id ?? "x"}`,
+    created_at: over.created_at ?? "2026-05-10T00:00:00Z",
+    relevance_score: over.relevance_score ?? 0.5,
+  };
+}
+
+function cloudHit(over: Partial<CloudRecallHit>): CloudRecallHit {
+  return {
+    attestation_id: over.attestation_id ?? "att",
+    content: over.content ?? "cloud content",
+    similarity: over.similarity ?? 0.5,
+    ...(over.tags !== undefined ? { tags: over.tags } : {}),
+    ...(over.signed_at !== undefined ? { signed_at: over.signed_at } : {}),
+    ...(over.solana_tx !== undefined ? { solana_tx: over.solana_tx } : {}),
+    ...(over.arweave_tx !== undefined ? { arweave_tx: over.arweave_tx } : {}),
+  };
+}
+
+interface CloudMergeOverrides {
+  localResults: SearchResult[];
+  cloudResults: CloudRecallHit[] | null;
+  cloudThrows?: unknown;
+}
+
+function makeCloudMergeRuntime(opts: CloudMergeOverrides): PopupRuntime {
+  const recall = vi
+    .fn<[string, number], Promise<SearchResult[]>>()
+    .mockResolvedValue(opts.localResults);
+  const recallRemote = vi
+    .fn<[string, number], Promise<CloudRecallHit[] | null>>()
+    .mockImplementation(async () => {
+      if (opts.cloudThrows !== undefined) {
+        throw opts.cloudThrows;
+      }
+      return opts.cloudResults;
+    });
+  const runtime: PopupRuntime = {
+    loadIdentity: async () => null,
+    loadStorageTier: async () => "cloud" as const,
+    getActiveTabAdapter: async () => null,
+    getActiveTabSelection: async () => "",
+    getActiveTabConversation: async () => null,
+    signMemory: async () => ({
+      attestation_id: "att_x",
+      content_hash: "x".repeat(64),
+      signer_pubkey: "Pub",
+      solana_tx: "local:x",
+      arweave_tx: "local:x",
+      created_at: "2026-05-11T00:00:00Z",
+    }),
+    signRemote: async () => undefined,
+    recall,
+    verify: async () => ({ status: "not_found" }),
+    auth: {
+      signIn: async () => {
+        throw new Error("auth.signIn stub: not configured in test");
+      },
+      lookupExisting: async () => {
+        throw new Error("auth.lookupExisting stub: not configured in test");
+      },
+      ensureExtensionJwt: async () => {
+        throw new Error("auth.ensureExtensionJwt stub: not configured in test");
+      },
+      linkGoogle: async () => {
+        throw new Error("auth.linkGoogle stub: not configured in test");
+      },
+    },
+    session: {
+      get: async () => null,
+      set: async () => undefined,
+      clear: async () => undefined,
+      jwtExpiresAtMs: () => null,
+    },
+    cloudSync: {
+      signRemote: async () => null,
+      recallRemote,
+      verifyRemote: async () => null,
+    },
+    keyEscrow: {
+      wrap: async () => {
+        throw new Error("keyEscrow.wrap stub: not configured in test");
+      },
+      unwrap: async () => {
+        throw new Error("keyEscrow.unwrap stub: not configured in test");
+      },
+      upload: async () => {
+        throw new Error("keyEscrow.upload stub: not configured in test");
+      },
+      fetch: async () => {
+        throw new Error("keyEscrow.fetch stub: not configured in test");
+      },
+      delete: async () => {
+        throw new Error("keyEscrow.delete stub: not configured in test");
+      },
+      rotate: async () => {
+        throw new Error("keyEscrow.rotate stub: not configured in test");
+      },
+      hasBlob: async () => false,
+    },
+  };
+  // Stash the spies on the runtime for asserting calls outside the
+  // closure. The cast keeps the runtime type clean for production
+  // callers — only tests pull off these handles.
+  (
+    runtime as unknown as {
+      __spies: { recall: typeof recall; recallRemote: typeof recallRemote };
+    }
+  ).__spies = {
+    recall,
+    recallRemote,
+  };
+  return runtime;
+}
+
+function spies(runtime: PopupRuntime): {
+  recall: ReturnType<typeof vi.fn>;
+  recallRemote: ReturnType<typeof vi.fn>;
+} {
+  return (
+    runtime as unknown as {
+      __spies: {
+        recall: ReturnType<typeof vi.fn>;
+        recallRemote: ReturnType<typeof vi.fn>;
+      };
+    }
+  ).__spies;
+}
+
+describe("Recall tab — Cloud-tier merge contract", () => {
+  beforeEach(() => {
+    setRuntime(null);
+  });
+  afterEach(() => {
+    setRuntime(null);
+  });
+
+  it("merge_dedupes_and_resorts — overlap deduped by id, best score wins, sorted desc", async () => {
+    // TDD anchor: three local + three cloud, one id overlaps. The
+    // duplicate row keeps the higher of the two scores; the final
+    // rendered list contains exactly five distinct ids in score
+    // descending order.
+    const localResults: SearchResult[] = [
+      localHit({
+        attestation_id: "att_dup",
+        relevance_score: 0.6,
+        content: "shared local-copy",
+      }),
+      localHit({
+        attestation_id: "att_local_only_hi",
+        relevance_score: 0.85,
+        content: "local-only top",
+      }),
+      localHit({
+        attestation_id: "att_local_only_mid",
+        relevance_score: 0.4,
+        content: "local-only mid",
+      }),
+    ];
+    const cloudResults: CloudRecallHit[] = [
+      // Same id as the local duplicate, but with a higher cloud-side
+      // similarity score — the merge keeps the cloud score.
+      cloudHit({
+        attestation_id: "att_dup",
+        similarity: 0.92,
+        content: "shared cloud-copy",
+        solana_tx: "SolReal_dup",
+        arweave_tx: "ArReal_dup",
+      }),
+      cloudHit({
+        attestation_id: "att_cloud_only_hi",
+        similarity: 0.78,
+        content: "cloud-only top",
+        solana_tx: "SolReal_co1",
+        arweave_tx: "ArReal_co1",
+      }),
+      cloudHit({
+        attestation_id: "att_cloud_only_lo",
+        similarity: 0.2,
+        content: "cloud-only bottom",
+        solana_tx: "SolReal_co2",
+        arweave_tx: "ArReal_co2",
+      }),
+    ];
+    const runtime = makeCloudMergeRuntime({ localResults, cloudResults });
+    setRuntime(runtime);
+
+    render(<Recall adapter={chatgptAdapter} />);
+    // Wait for `loadStorageTier` to settle so the click runs in cloud
+    // mode rather than the default local fallback.
+    await waitFor(() => {
+      expect(runtime.loadStorageTier).toBeDefined();
+    });
+    await new Promise((r) => setTimeout(r, 0));
+
+    fireEvent.change(screen.getByLabelText("Recall query"), {
+      target: { value: "test query" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /find/i }));
+
+    const { recall, recallRemote } = spies(runtime);
+    await waitFor(() => expect(recall).toHaveBeenCalledTimes(1));
+    await waitFor(() =>
+      expect(recallRemote).toHaveBeenCalledWith("test query", 5),
+    );
+
+    // The merged list — five distinct ids, sorted desc.
+    const list = await screen.findByLabelText("Recall results");
+    await waitFor(() => {
+      expect(list.querySelectorAll("li").length).toBe(5);
+    });
+    const items = Array.from(list.querySelectorAll("li"));
+
+    // Score-descending order check by parsing the first cell of each
+    // <li> (the score badge formatted as `.toFixed(3)`).
+    const scores = items.map((li) => {
+      const badge = li.querySelector("span");
+      return Number(badge?.textContent ?? "0");
+    });
+    const sorted = [...scores].sort((a, b) => b - a);
+    expect(scores).toEqual(sorted);
+
+    // The merged duplicate carries the higher cloud-side score (0.92,
+    // not 0.6). Find via the formatted score text.
+    expect(list.textContent ?? "").toMatch(/0\.920/);
+    // The lower local-side score for the duplicate must NOT appear —
+    // dedupe removed it.
+    expect(list.textContent ?? "").not.toMatch(/0\.600/);
+    // Each of the four non-duplicate scores renders.
+    expect(list.textContent ?? "").toMatch(/0\.850/);
+    expect(list.textContent ?? "").toMatch(/0\.780/);
+    expect(list.textContent ?? "").toMatch(/0\.400/);
+    expect(list.textContent ?? "").toMatch(/0\.200/);
+  });
+
+  it("cloud-only entries carry non-`local:` tx ids; local-only keep `local:` placeholders", async () => {
+    // The merge surfaces tx-id provenance on each row: cloud-only
+    // rows reach the renderer with real Solana / Arweave ids the
+    // server returned, while local-only rows still carry the synthetic
+    // `local:` prefix until the alarm-drain anchors them. We can't
+    // read tx ids straight off the DOM (the popup renders only the
+    // truncated `attestation_id`), so we re-run the same merge through
+    // a fresh `mergeRecallHits` import to assert the projected shape.
+    const localResults: SearchResult[] = [
+      localHit({
+        attestation_id: "att_local_only",
+        relevance_score: 0.8,
+        solana_tx: "local:LocalOnly",
+        arweave_tx: "local:LocalOnly",
+      }),
+    ];
+    const cloudResults: CloudRecallHit[] = [
+      cloudHit({
+        attestation_id: "att_cloud_only",
+        similarity: 0.7,
+        content: "cloud-only payload",
+        solana_tx: "SolRealCloudOnly",
+        arweave_tx: "ArRealCloudOnly",
+      }),
+    ];
+    setRuntime(
+      makeCloudMergeRuntime({
+        localResults,
+        cloudResults,
+      }),
+    );
+
+    render(<Recall adapter={chatgptAdapter} />);
+    await new Promise((r) => setTimeout(r, 0));
+    fireEvent.change(screen.getByLabelText("Recall query"), {
+      target: { value: "q" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /find/i }));
+
+    const list = await screen.findByLabelText("Recall results");
+    await waitFor(() => {
+      expect(list.querySelectorAll("li").length).toBe(2);
+    });
+
+    // The cloud-only content rendered.
+    expect(list.textContent ?? "").toMatch(/cloud-only payload/);
+    // The local-only row rendered with its synthetic `local:`
+    // provenance kept (re-derive via the pure helper to assert tx
+    // shape, since the renderer doesn't expose tx ids inline).
+    const { mergeRecallHits } =
+      await import("../../../src/popup/tabs/Recall.js");
+    const merged = mergeRecallHits(localResults, cloudResults, 5);
+    const localOnly = merged.find((r) => r.attestation_id === "att_local_only");
+    const cloudOnly = merged.find((r) => r.attestation_id === "att_cloud_only");
+    expect(localOnly?.solana_tx).toBe("local:LocalOnly");
+    expect(localOnly?.arweave_tx).toBe("local:LocalOnly");
+    expect(cloudOnly?.solana_tx).toBe("SolRealCloudOnly");
+    expect(cloudOnly?.arweave_tx).toBe("ArRealCloudOnly");
+  });
+
+  it("cloud failure is non-blocking — local results still render, no hard error banner", async () => {
+    // Offline-first guarantee: a `recallRemote` rejection must NOT
+    // block the local-results path. The popup swallows the error
+    // (Recall.tsx logs to `console.warn`) and the rendered list
+    // matches what local-only would render.
+    const localResults: SearchResult[] = [
+      localHit({
+        attestation_id: "att_l1",
+        relevance_score: 0.9,
+        content: "local A",
+      }),
+      localHit({
+        attestation_id: "att_l2",
+        relevance_score: 0.55,
+        content: "local B",
+      }),
+    ];
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const runtime = makeCloudMergeRuntime({
+        localResults,
+        cloudResults: null,
+        cloudThrows: new Error("503 upstream"),
+      });
+      setRuntime(runtime);
+
+      render(<Recall adapter={chatgptAdapter} />);
+      await new Promise((r) => setTimeout(r, 0));
+      fireEvent.change(screen.getByLabelText("Recall query"), {
+        target: { value: "anything" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /find/i }));
+
+      // Local results render unaffected.
+      const list = await screen.findByLabelText("Recall results");
+      await waitFor(() => {
+        expect(list.querySelectorAll("li").length).toBe(2);
+      });
+      expect(list.textContent ?? "").toMatch(/local A/);
+      expect(list.textContent ?? "").toMatch(/local B/);
+
+      // No hard error banner in the popup body (the inline error
+      // <div> would render the string verbatim if it had bubbled up).
+      expect(screen.queryByText(/503 upstream/)).toBeNull();
+
+      // The non-blocking warning surfaces via console.warn — the
+      // popup deliberately stays quiet in the UI (offline-first) but
+      // logs so developers can correlate with the SW drain.
+      const warned = warnSpy.mock.calls.some((args) =>
+        args.some(
+          (a) =>
+            typeof a === "string" &&
+            (a.includes("cloud recall failed") || a.includes("503 upstream")),
+        ),
+      );
+      expect(warned).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/packages/extension/tests/component/popup/Verify.cloud.test.tsx
+++ b/packages/extension/tests/component/popup/Verify.cloud.test.tsx
@@ -1,0 +1,239 @@
+// Verify-tab tests for Cloud-tier. The Verify tab calls
+// `runtime.verify(args)`; in Cloud-mode the runtime's `verify` impl
+// will route through `cloudSync.verifyRemote` (T18 D2 — cloud =
+// thin-client to the hosted `full` MCP). These tests install a
+// runtime stub whose `verify` mirrors that delegation, then assert
+// (a) `cloudSync.verifyRemote` was called with the attestation id and
+// (b) each of the three terminal outcomes from the cloud client
+// (`verified` / `tampered` / `not_found`) renders the correct popup
+// panel.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Verify } from "../../../src/popup/tabs/Verify.js";
+import {
+  setRuntime,
+  type CloudVerifyOutcome,
+  type PopupRuntime,
+  type VerifyArgs,
+  type VerifyOutcome,
+} from "../../../src/popup/runtime.js";
+
+/**
+ * Cloud-tier runtime stub. The `verify` seam delegates to
+ * `cloudSync.verifyRemote`, projecting the cloud-shaped result
+ * (signer / arweave_tx / solana_tx with `not_found` carrying no id)
+ * into the popup's `VerifyOutcome` discriminated union. This mirrors
+ * how the production `runtime.ts` will route Verify in Cloud mode
+ * once the seam is wired (see decisions.md T18 Cloud-tier contract).
+ *
+ * Tests inject the `verifyRemote` mock to drive each outcome.
+ */
+function makeCloudRuntime(
+  verifyRemote: PopupRuntime["cloudSync"]["verifyRemote"],
+): PopupRuntime {
+  return {
+    loadIdentity: async () => null,
+    loadStorageTier: async () => "cloud" as const,
+    getActiveTabAdapter: async () => null,
+    getActiveTabSelection: async () => "",
+    getActiveTabConversation: async () => null,
+    signMemory: async () => ({
+      attestation_id: "att_x",
+      content_hash: "x".repeat(64),
+      signer_pubkey: "Pub",
+      solana_tx: "local:x",
+      arweave_tx: "local:x",
+      created_at: "2026-05-11T00:00:00Z",
+    }),
+    signRemote: async () => undefined,
+    recall: async () => [],
+    async verify(args: VerifyArgs): Promise<VerifyOutcome> {
+      // Cloud-mode delegation: fall straight through to the cloud
+      // client. The popup never passes `fileBytes` in this path —
+      // file-drop verify is a documented backlog item — so we keep
+      // the test stub focused on the id path.
+      const id = args.attestationId?.trim();
+      if (!id) return { status: "not_found" };
+      const cloud = await this.cloudSync.verifyRemote(id);
+      if (cloud === null) {
+        // No JWT-bearing session — the popup renders "not found"
+        // rather than crashing. (Production runtime should surface a
+        // distinct sign-in prompt; tests here use the cloud mock to
+        // assert delegation, so the null branch is unreachable in
+        // these tests.)
+        return { status: "not_found", attestation_id: id };
+      }
+      return projectCloudVerifyOutcome(cloud, id);
+    },
+    auth: {
+      signIn: async () => {
+        throw new Error("auth.signIn stub: not configured in test");
+      },
+      lookupExisting: async () => {
+        throw new Error("auth.lookupExisting stub: not configured in test");
+      },
+      ensureExtensionJwt: async () => {
+        throw new Error("auth.ensureExtensionJwt stub: not configured in test");
+      },
+      linkGoogle: async () => {
+        throw new Error("auth.linkGoogle stub: not configured in test");
+      },
+    },
+    session: {
+      get: async () => null,
+      set: async () => undefined,
+      clear: async () => undefined,
+      jwtExpiresAtMs: () => null,
+    },
+    cloudSync: {
+      signRemote: async () => null,
+      recallRemote: async () => null,
+      verifyRemote,
+    },
+    keyEscrow: {
+      wrap: async () => {
+        throw new Error("keyEscrow.wrap stub: not configured in test");
+      },
+      unwrap: async () => {
+        throw new Error("keyEscrow.unwrap stub: not configured in test");
+      },
+      upload: async () => {
+        throw new Error("keyEscrow.upload stub: not configured in test");
+      },
+      fetch: async () => {
+        throw new Error("keyEscrow.fetch stub: not configured in test");
+      },
+      delete: async () => {
+        throw new Error("keyEscrow.delete stub: not configured in test");
+      },
+      rotate: async () => {
+        throw new Error("keyEscrow.rotate stub: not configured in test");
+      },
+      hasBlob: async () => false,
+    },
+  };
+}
+
+/** Project the `CloudVerifyOutcome` (server wire shape) onto the
+ *  popup's `VerifyOutcome`. Pure helper kept local to this test file
+ *  so we don't need to add a production export for a not-yet-wired
+ *  seam. */
+function projectCloudVerifyOutcome(
+  cloud: CloudVerifyOutcome,
+  id: string,
+): VerifyOutcome {
+  if (cloud.status === "verified") {
+    const out: VerifyOutcome = {
+      status: "verified",
+      signer_pubkey: cloud.signer,
+      // The cloud surface doesn't return `created_at` or
+      // `content_hash` on the verify path — the popup renderer
+      // tolerates empty strings (it just truncates).
+      created_at: "",
+      content_hash: "",
+    };
+    if (cloud.solana_tx) out.solana_tx = cloud.solana_tx;
+    if (cloud.arweave_tx) out.arweave_tx = cloud.arweave_tx;
+    return out;
+  }
+  if (cloud.status === "tampered") {
+    return { status: "tampered", reason: cloud.reason };
+  }
+  return { status: "not_found", attestation_id: id };
+}
+
+describe("Verify tab — Cloud tier", () => {
+  beforeEach(() => setRuntime(null));
+  afterEach(() => setRuntime(null));
+
+  it("paste-id flow calls cloudSync.verifyRemote with the attestation id", async () => {
+    const verifyRemote = vi
+      .fn<[string], Promise<CloudVerifyOutcome | null>>()
+      .mockResolvedValue({
+        status: "verified",
+        signer: "PubCloudSignerXyz",
+        solana_tx: "SolRealTxAaa",
+        arweave_tx: "ArRealTxBbb",
+      });
+    setRuntime(makeCloudRuntime(verifyRemote));
+
+    render(<Verify />);
+    fireEvent.change(screen.getByLabelText("Attestation id"), {
+      target: { value: "att_cloud_one" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /verify/i }));
+
+    await waitFor(() => expect(verifyRemote).toHaveBeenCalledTimes(1));
+    expect(verifyRemote).toHaveBeenCalledWith("att_cloud_one");
+  });
+
+  it("verified path renders the verified panel with cloud signer + tx ids", async () => {
+    const verifyRemote = vi
+      .fn<[string], Promise<CloudVerifyOutcome | null>>()
+      .mockResolvedValue({
+        status: "verified",
+        signer: "PubCloudSignerXyz",
+        solana_tx: "SolRealTxAaa",
+        arweave_tx: "ArRealTxBbb",
+      });
+    setRuntime(makeCloudRuntime(verifyRemote));
+
+    render(<Verify />);
+    fireEvent.change(screen.getByLabelText("Attestation id"), {
+      target: { value: "att_cloud_one" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /verify/i }));
+
+    const status = await screen.findByRole("status");
+    expect(status.textContent ?? "").toMatch(/verified/i);
+    // Cloud-side signer (not the `local:` placeholder).
+    expect(status.textContent ?? "").toMatch(/PubClo/);
+    // Cloud anchors render their truncated form.
+    expect(status.textContent ?? "").toMatch(/SolRea/);
+    expect(status.textContent ?? "").toMatch(/ArReal/);
+  });
+
+  it("tampered path renders the tampered panel with the cloud-side reason", async () => {
+    const verifyRemote = vi
+      .fn<[string], Promise<CloudVerifyOutcome | null>>()
+      .mockResolvedValue({
+        status: "tampered",
+        signer: "PubCloudSignerXyz",
+        reason: "blake3 hash mismatch",
+      });
+    setRuntime(makeCloudRuntime(verifyRemote));
+
+    render(<Verify />);
+    fireEvent.change(screen.getByLabelText("Attestation id"), {
+      target: { value: "att_tamper" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /verify/i }));
+
+    await waitFor(() => expect(verifyRemote).toHaveBeenCalledTimes(1));
+    const status = await screen.findByRole("status");
+    expect(status.textContent ?? "").toMatch(/tampered/i);
+    expect(status.textContent ?? "").toMatch(/blake3 hash mismatch/);
+  });
+
+  it("not_found path renders the not-found panel", async () => {
+    const verifyRemote = vi
+      .fn<[string], Promise<CloudVerifyOutcome | null>>()
+      .mockResolvedValue({ status: "not_found" });
+    setRuntime(makeCloudRuntime(verifyRemote));
+
+    render(<Verify />);
+    fireEvent.change(screen.getByLabelText("Attestation id"), {
+      target: { value: "att_unknown" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /verify/i }));
+
+    await waitFor(() => expect(verifyRemote).toHaveBeenCalledTimes(1));
+    const status = await screen.findByRole("status");
+    expect(status.textContent ?? "").toMatch(/not found/i);
+    // Verify.tsx renders the requested id under the not-found banner.
+    expect(status.textContent ?? "").toMatch(/att_unknown/);
+    // Not the file-drop placeholder.
+    expect(status.textContent ?? "").not.toMatch(/file verification/i);
+  });
+});


### PR DESCRIPTION
## Summary

Round-2 test audit (TA-MIN3) flagged the Cloud-tier code paths in `Capture.tsx`, `Verify.tsx`, and the Cloud-mode `Recall.tsx` merge as untested at the component layer. The cloud-client unit tests already cover the wire surface in isolation, but the popup's interaction with the `runtime.cloudSync.*` facade was unverified.

This PR adds three new component-test files that mount each popup tab in Cloud-tier mode with an injected runtime whose `cloudSync` facade is mocked, then asserts the T18 deferred-signing contract end-to-end through the React tree.

- `Capture.cloud.test.tsx` — drives the deferred-signing happy path plus the three error branches the popup runtime catches.
- `Verify.cloud.test.tsx` — drives `cloudSync.verifyRemote` for each terminal state.
- `Recall.merge.test.tsx` — drives the merge contract (dedupe / score-winner / sort / tx-id provenance / offline-first failure).

No production code changes. Tests reuse the existing `setRuntime` seam and the `chrome.*` stubs from sibling component tests.

## TDD anchors

- `Capture.cloud.test.tsx::cloud_push_succeeds` — asserts `signRemote` called once with the canonical payload, success toast carries the returned `attestation_id`.
- `Recall.merge.test.tsx::merge_dedupes_and_resorts` — three local + three cloud rows with one overlap, asserting exact dedupe + score-winner + descending order.

## Test plan

- [x] `vitest run tests/component/popup/Capture.cloud.test.tsx tests/component/popup/Verify.cloud.test.tsx tests/component/popup/Recall.merge.test.tsx` — 11/11 new tests pass.
- [x] Full popup-tab sweep `vitest run tests/component/popup/` — 51/51 pass (no regressions).
- [x] `tsc -b --noEmit` — no new type errors introduced by the three new files (pre-existing errors in sibling tests / Vite plugin types are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)