### PR TITLE
test(extension): T24 — Options coverage gaps + property/fuzz tests

### DIFF
--- a/packages/extension/tests/component/options/About.test.tsx
+++ b/packages/extension/tests/component/options/About.test.tsx
@@ -1,0 +1,135 @@
+// About section — TA-MIN2 coverage. The component is a read-only
+// metadata panel that reads version/buildHash from the runtime facade
+// (which production wires to `chrome.runtime.getManifest`) and renders
+// the canonical out-bound links (privacy policy + source repo).
+//
+// Note on scope (T24 coverage-gap doc): the round-2 task brief sketched
+// a richer About panel (MCP endpoint, Discord, "Reset all data" button).
+// That UX has not landed — the current implementation is intentionally
+// minimal. These tests bind the *actual* surface; the richer surface is
+// tracked in `decisions.md` (T24 coverage gaps).
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { About } from "../../../src/options/sections/About.js";
+import {
+  setOptionsRuntime,
+  type OptionsRuntime,
+} from "../../../src/options/runtime.js";
+import { DEFAULT_SETTINGS_V1 } from "../../../src/settings.js";
+
+function makeRuntime(
+  about: OptionsRuntime["about"] = { version: "0.1.0" },
+): OptionsRuntime {
+  return {
+    settings: {
+      load: async () => DEFAULT_SETTINGS_V1,
+      update: async () => DEFAULT_SETTINGS_V1,
+    },
+    auth: {
+      signIn: async () => ({ googleSub: "g", email: "u", jwt: "j" }),
+      getSession: async () => null,
+      clearSession: async () => undefined,
+    },
+    identity: {
+      load: async () => null,
+      exportEncrypted: async () => new Uint8Array(),
+      importEncrypted: async () => ({ pubkey_base58: "x", did: "did:sol:x" }),
+    },
+    keyEscrow: {
+      rotate: async () => undefined,
+      delete: async () => undefined,
+      hasBlob: async () => false,
+    },
+    cloudSync: {
+      countLocalAttestations: async () => 0,
+      countCloudAttestations: async () => 0,
+      enqueueAll: async () => undefined,
+      subscribeProgress: () => () => undefined,
+      exportAll: async () => new Uint8Array(),
+    },
+    about,
+  };
+}
+
+describe("About section", () => {
+  beforeEach(() => setOptionsRuntime(null));
+  afterEach(() => setOptionsRuntime(null));
+
+  it("renders the section heading", async () => {
+    setOptionsRuntime(makeRuntime());
+    render(<About />);
+    expect(
+      screen.getByRole("heading", { name: /^about$/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the version from the runtime facade", async () => {
+    setOptionsRuntime(makeRuntime({ version: "1.2.3" }));
+    render(<About />);
+    // `useEffect` hydrates the value after first paint; `findByText`
+    // waits for it.
+    expect(await screen.findByText("1.2.3")).toBeInTheDocument();
+  });
+
+  it("renders the build hash row only when a hash is provided", async () => {
+    setOptionsRuntime(makeRuntime({ version: "1.2.3", buildHash: "abc1234" }));
+    render(<About />);
+    expect(await screen.findByText("abc1234")).toBeInTheDocument();
+    // Both Version and Build labels are present in the build-hash variant.
+    expect(screen.getByText(/^Version$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Build$/i)).toBeInTheDocument();
+  });
+
+  it("omits the build hash row when buildHash is undefined", async () => {
+    setOptionsRuntime(makeRuntime({ version: "0.1.0" }));
+    render(<About />);
+    // Wait for the version to land so the effect has run, then assert
+    // the Build label is NOT in the DOM.
+    await screen.findByText("0.1.0");
+    expect(screen.queryByText(/^Build$/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the privacy-policy link with safe rel attributes", async () => {
+    setOptionsRuntime(makeRuntime());
+    render(<About />);
+    const privacy = await screen.findByRole("link", {
+      name: /mnemonik\.xyz\/privacy/i,
+    });
+    expect(privacy).toHaveAttribute("href", "https://mnemonik.xyz/privacy");
+    expect(privacy).toHaveAttribute("target", "_blank");
+    // `noreferrer noopener` mitigates `window.opener` cross-origin
+    // leakage from third-party tabs spawned via this anchor.
+    const rel = privacy.getAttribute("rel") ?? "";
+    expect(rel).toContain("noreferrer");
+    expect(rel).toContain("noopener");
+  });
+
+  it("renders the source-repo link with safe rel attributes", async () => {
+    setOptionsRuntime(makeRuntime());
+    render(<About />);
+    const repo = await screen.findByRole("link", {
+      name: /github\.com\/mnemonik-xyz\/monorepo/i,
+    });
+    expect(repo).toHaveAttribute(
+      "href",
+      "https://github.com/mnemonik-xyz/monorepo",
+    );
+    expect(repo).toHaveAttribute("target", "_blank");
+    const rel = repo.getAttribute("rel") ?? "";
+    expect(rel).toContain("noreferrer");
+    expect(rel).toContain("noopener");
+  });
+
+  it("re-renders when the runtime is swapped between mounts", async () => {
+    setOptionsRuntime(makeRuntime({ version: "1.0.0" }));
+    const first = render(<About />);
+    await waitFor(() => expect(first.getByText("1.0.0")).toBeInTheDocument());
+    first.unmount();
+
+    setOptionsRuntime(makeRuntime({ version: "2.0.0", buildHash: "deadbeef" }));
+    render(<About />);
+    expect(await screen.findByText("2.0.0")).toBeInTheDocument();
+    expect(screen.getByText("deadbeef")).toBeInTheDocument();
+  });
+});

--- a/packages/extension/tests/component/options/Identity.import.test.tsx
+++ b/packages/extension/tests/component/options/Identity.import.test.tsx
@@ -1,0 +1,387 @@
+// Identity section — TA-MIN4 coverage. Exercises the encrypted-keypair
+// import flow: user types the passphrase, picks a file, the section
+// hands the bytes + passphrase to `identity.importEncrypted`.
+//
+// The flow is symmetric to the export pipeline (`Identity.test.tsx`
+// covers export). On success the displayed identity badge updates and
+// the passphrase input clears; on failure (wrong passphrase, malformed
+// blob) a toast surfaces the error message and the previously-loaded
+// identity stays put.
+//
+// We deliberately mock `getOptionsRuntime().identity.importEncrypted`
+// rather than the file-picker DOM API: the file picker is a native UI
+// surface, but the change event we dispatch carries the exact `File`
+// shape the production handler reads (`file.arrayBuffer()`).
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Identity } from "../../../src/options/sections/Identity.js";
+import {
+  setOptionsRuntime,
+  type OptionsRuntime,
+  type IdentitySnapshot,
+} from "../../../src/options/runtime.js";
+import { DEFAULT_SETTINGS_V1 } from "../../../src/settings.js";
+
+function makeRuntime(
+  overrides: {
+    pubkey?: string | null;
+    importEncrypted?: OptionsRuntime["identity"]["importEncrypted"];
+  } = {},
+): OptionsRuntime {
+  return {
+    settings: {
+      load: async () => DEFAULT_SETTINGS_V1,
+      update: async () => DEFAULT_SETTINGS_V1,
+    },
+    auth: {
+      signIn: async () => ({ googleSub: "g", email: "u", jwt: "j" }),
+      getSession: async () => null,
+      clearSession: async () => undefined,
+    },
+    identity: {
+      load: async () =>
+        overrides.pubkey
+          ? {
+              pubkey_base58: overrides.pubkey,
+              did: `did:sol:${overrides.pubkey}`,
+            }
+          : null,
+      exportEncrypted: async () => new Uint8Array([1, 2, 3, 4]),
+      importEncrypted:
+        overrides.importEncrypted ??
+        (async () => ({
+          pubkey_base58: "imported-default",
+          did: "did:sol:imported-default",
+        })),
+    },
+    keyEscrow: {
+      rotate: async () => undefined,
+      delete: async () => undefined,
+      hasBlob: async () => false,
+    },
+    cloudSync: {
+      countLocalAttestations: async () => 0,
+      countCloudAttestations: async () => 0,
+      enqueueAll: async () => undefined,
+      subscribeProgress: () => () => undefined,
+      exportAll: async () => new Uint8Array(),
+    },
+    about: { version: "0.1.0" },
+  };
+}
+
+/** Build a File the production handler can call `.arrayBuffer()` on.
+ *  We pass `Uint8Array` as the underlying chunk so the bytes round-trip
+ *  to the importer exactly.
+ *
+ *  jsdom's `File` polyfill (as of v24.x) does NOT implement
+ *  `arrayBuffer()` — we install a per-instance method that returns the
+ *  original bytes. This matches the browser contract well enough for
+ *  the handler under test. */
+function makeFile(bytes: Uint8Array, name = "keypair.enc.json"): File {
+  const file = new File([bytes], name, { type: "application/json" });
+  // Copy the bytes so a later in-place mutation in the test body
+  // doesn't poison the buffer the handler reads.
+  const copy = bytes.slice();
+  Object.defineProperty(file, "arrayBuffer", {
+    configurable: true,
+    value: async () =>
+      copy.buffer.slice(copy.byteOffset, copy.byteOffset + copy.byteLength),
+  });
+  return file;
+}
+
+/** Simulate the native file-picker: dispatch a change event whose
+ *  `target.files` carries our test File. React 19 + RTL's `fireEvent`
+ *  honours the `{target: {files: ...}}` override on `<input
+ *  type="file">`. */
+function pickFile(input: HTMLElement, file: File): void {
+  Object.defineProperty(input, "files", {
+    configurable: true,
+    value: [file],
+  });
+  fireEvent.change(input);
+}
+
+describe("Identity section — import flow (TA-MIN4)", () => {
+  beforeEach(() => setOptionsRuntime(null));
+  afterEach(() => setOptionsRuntime(null));
+
+  it("imports an encrypted blob and updates the displayed identity", async () => {
+    const restored: IdentitySnapshot = {
+      pubkey_base58: "NewPubKeyAfterImport",
+      did: "did:sol:NewPubKeyAfterImport",
+    };
+    const importEncrypted = vi
+      .fn<[Uint8Array, string], Promise<IdentitySnapshot>>()
+      .mockResolvedValue(restored);
+    setOptionsRuntime(
+      makeRuntime({
+        pubkey: "OldPubKeyOnDevice",
+        importEncrypted,
+      }),
+    );
+
+    render(<Identity />);
+    expect(
+      await screen.findByText("did:sol:OldPubKeyOnDevice"),
+    ).toBeInTheDocument();
+
+    const passInput = screen.getByLabelText(/Import passphrase/i);
+    fireEvent.change(passInput, { target: { value: "correct-passphrase-12" } });
+
+    const blobBytes = new Uint8Array([0xde, 0xad, 0xbe, 0xef]);
+    const fileInput = screen.getByLabelText(/Encrypted keypair file/i);
+    pickFile(fileInput, makeFile(blobBytes));
+
+    await waitFor(() => expect(importEncrypted).toHaveBeenCalledTimes(1));
+    const [gotBytes, gotPp] = importEncrypted.mock.calls[0]!;
+    expect(Array.from(gotBytes)).toEqual(Array.from(blobBytes));
+    expect(gotPp).toBe("correct-passphrase-12");
+
+    // Badge now shows the newly-imported identity (the success toast
+    // also surfaces, but the badge is the load-bearing UX signal).
+    expect(
+      await screen.findByText("did:sol:NewPubKeyAfterImport"),
+    ).toBeInTheDocument();
+    // Passphrase field clears on success so the next import attempt is
+    // a clean slate.
+    expect((passInput as HTMLInputElement).value).toBe("");
+  });
+
+  it("rejects an empty passphrase BEFORE calling the runtime", async () => {
+    const importEncrypted = vi
+      .fn<[Uint8Array, string], Promise<IdentitySnapshot>>()
+      .mockResolvedValue({
+        pubkey_base58: "WontBeReached",
+        did: "did:sol:WontBeReached",
+      });
+    setOptionsRuntime(
+      makeRuntime({
+        pubkey: "OriginalPub",
+        importEncrypted,
+      }),
+    );
+    render(<Identity />);
+    await screen.findByText("did:sol:OriginalPub");
+
+    // Skip the passphrase field, pick a file directly.
+    const fileInput = screen.getByLabelText(/Encrypted keypair file/i);
+    pickFile(fileInput, makeFile(new Uint8Array([1, 2, 3])));
+
+    // Toast surfaces the validation error; importEncrypted is NEVER
+    // invoked — this is the rate-limit-budget guard at the UI seam.
+    expect(
+      await screen.findByText(/Import passphrase is required\./i),
+    ).toBeInTheDocument();
+    expect(importEncrypted).not.toHaveBeenCalled();
+    // Identity badge unchanged.
+    expect(screen.getByText("did:sol:OriginalPub")).toBeInTheDocument();
+  });
+
+  it("surfaces a wrong-passphrase error from the runtime in a toast", async () => {
+    const importEncrypted = vi
+      .fn<[Uint8Array, string], Promise<IdentitySnapshot>>()
+      .mockRejectedValue(new Error("wrong passphrase or tampered ciphertext"));
+    setOptionsRuntime(
+      makeRuntime({
+        pubkey: "PrePub",
+        importEncrypted,
+      }),
+    );
+    render(<Identity />);
+    await screen.findByText("did:sol:PrePub");
+
+    fireEvent.change(screen.getByLabelText(/Import passphrase/i), {
+      target: { value: "wrong-pp" },
+    });
+    pickFile(
+      screen.getByLabelText(/Encrypted keypair file/i),
+      makeFile(new Uint8Array([9, 9, 9])),
+    );
+
+    expect(
+      await screen.findByText(
+        /Import failed:.*wrong passphrase or tampered ciphertext/i,
+      ),
+    ).toBeInTheDocument();
+    // Identity badge unchanged — the wrong-passphrase failure must NOT
+    // wipe the currently-loaded keypair.
+    expect(screen.getByText("did:sol:PrePub")).toBeInTheDocument();
+  });
+
+  it("surfaces a malformed-blob error from the runtime (bad JSON)", async () => {
+    // The production importer parses the JSON envelope before unwrap;
+    // a `SyntaxError`-shaped failure should appear in the toast as-is.
+    const importEncrypted = vi
+      .fn<[Uint8Array, string], Promise<IdentitySnapshot>>()
+      .mockRejectedValue(new SyntaxError("Unexpected token in JSON at pos 0"));
+    setOptionsRuntime(
+      makeRuntime({
+        pubkey: "PrePub",
+        importEncrypted,
+      }),
+    );
+    render(<Identity />);
+    await screen.findByText("did:sol:PrePub");
+
+    fireEvent.change(screen.getByLabelText(/Import passphrase/i), {
+      target: { value: "pp-12-chars-or-more" },
+    });
+    pickFile(
+      screen.getByLabelText(/Encrypted keypair file/i),
+      makeFile(new Uint8Array([0x7b, 0x62, 0x61, 0x64])), // "{bad"
+    );
+
+    expect(
+      await screen.findByText(/Import failed:.*Unexpected token/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText("did:sol:PrePub")).toBeInTheDocument();
+  });
+
+  it("surfaces a missing-field error from the runtime", async () => {
+    // The production importer rejects blobs that decrypt to a JSON
+    // payload missing required fields (e.g. no `secret_b64`). The error
+    // message is opaque to the UI; we only assert it surfaces verbatim.
+    const importEncrypted = vi
+      .fn<[Uint8Array, string], Promise<IdentitySnapshot>>()
+      .mockRejectedValue(new Error("keypair payload is missing 'secret_b64'"));
+    setOptionsRuntime(
+      makeRuntime({
+        pubkey: "PrePub",
+        importEncrypted,
+      }),
+    );
+    render(<Identity />);
+    await screen.findByText("did:sol:PrePub");
+
+    fireEvent.change(screen.getByLabelText(/Import passphrase/i), {
+      target: { value: "pp-12-chars-or-more" },
+    });
+    pickFile(
+      screen.getByLabelText(/Encrypted keypair file/i),
+      makeFile(new Uint8Array([1, 2, 3])),
+    );
+
+    expect(
+      await screen.findByText(/Import failed:.*missing 'secret_b64'/i),
+    ).toBeInTheDocument();
+  });
+
+  it("surfaces a wrong-byte-length error from the runtime", async () => {
+    // Ed25519 secrets must be 32 or 64 bytes. A 30-byte payload is
+    // accepted at the file boundary but rejected at the keypair-shape
+    // boundary — the runtime returns a typed error which we surface.
+    const importEncrypted = vi
+      .fn<[Uint8Array, string], Promise<IdentitySnapshot>>()
+      .mockRejectedValue(
+        new Error("invalid Ed25519 secret length: got 30, want 32 or 64"),
+      );
+    setOptionsRuntime(
+      makeRuntime({
+        pubkey: "PrePub",
+        importEncrypted,
+      }),
+    );
+    render(<Identity />);
+    await screen.findByText("did:sol:PrePub");
+
+    fireEvent.change(screen.getByLabelText(/Import passphrase/i), {
+      target: { value: "pp-12-chars-or-more" },
+    });
+    pickFile(
+      screen.getByLabelText(/Encrypted keypair file/i),
+      makeFile(new Uint8Array(30)),
+    );
+
+    expect(
+      await screen.findByText(
+        /Import failed:.*invalid Ed25519 secret length.*30.*32 or 64/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("export → triggers a download with the encrypted blob bytes", async () => {
+    // The export path is exercised in `Identity.test.tsx` at the
+    // runtime-call level (asserts `exportEncrypted(passphrase)`); here
+    // we close the loop by asserting the *download surface* — i.e. a
+    // Blob URL is created. Together they bind the canonical
+    // "Export → download" UX without overlapping coverage.
+    const encrypted = new Uint8Array([0x01, 0x02, 0x03, 0x04, 0x05]);
+    const runtime = makeRuntime({ pubkey: "ExportPub" });
+    runtime.identity.exportEncrypted = async () => encrypted;
+    setOptionsRuntime(runtime);
+
+    const createObjectURL = vi
+      .fn<[Blob], string>()
+      .mockReturnValue("blob:fake-url");
+    const revokeObjectURL = vi.fn<[string], void>();
+    const originalCreate = URL.createObjectURL;
+    const originalRevoke = URL.revokeObjectURL;
+    URL.createObjectURL =
+      createObjectURL as unknown as typeof URL.createObjectURL;
+    URL.revokeObjectURL =
+      revokeObjectURL as unknown as typeof URL.revokeObjectURL;
+    try {
+      render(<Identity />);
+      await screen.findByText("did:sol:ExportPub");
+
+      const passInput = await screen.findByLabelText(/Export passphrase/i);
+      // zxcvbn-friendly long string — see Identity.test.tsx for the
+      // same passphrase shape.
+      fireEvent.change(passInput, {
+        target: { value: "Tr0ub4dor&3-Mnemonik-lazy-bear" },
+      });
+      fireEvent.click(
+        screen.getByRole("button", { name: /^export keypair$/i }),
+      );
+
+      await waitFor(() => expect(createObjectURL).toHaveBeenCalledTimes(1));
+      const blobArg = createObjectURL.mock.calls[0]![0];
+      expect(blobArg).toBeInstanceOf(Blob);
+      expect(blobArg.type).toBe("application/json");
+      // The download helper revokes the URL after click — proves the
+      // bookkeeping path runs (rather than leaving a dangling Blob URL).
+      await waitFor(() =>
+        expect(revokeObjectURL).toHaveBeenCalledWith("blob:fake-url"),
+      );
+    } finally {
+      URL.createObjectURL = originalCreate;
+      URL.revokeObjectURL = originalRevoke;
+    }
+  });
+
+  it("does not crash when the file input fires a change with no file", async () => {
+    // Defensive: a user can clear a file picker via the OS dialog
+    // ("Cancel" on macOS); the event fires with an empty FileList. The
+    // section's onChange short-circuits when `e.target.files?.[0]` is
+    // undefined — no toast, no importer call.
+    const importEncrypted = vi
+      .fn<[Uint8Array, string], Promise<IdentitySnapshot>>()
+      .mockResolvedValue({
+        pubkey_base58: "WontHappen",
+        did: "did:sol:WontHappen",
+      });
+    setOptionsRuntime(
+      makeRuntime({
+        pubkey: "Stable",
+        importEncrypted,
+      }),
+    );
+    render(<Identity />);
+    await screen.findByText("did:sol:Stable");
+
+    const fileInput = screen.getByLabelText(/Encrypted keypair file/i);
+    Object.defineProperty(fileInput, "files", {
+      configurable: true,
+      value: [],
+    });
+    fireEvent.change(fileInput);
+
+    // Give the microtask queue a tick; the importer must remain idle.
+    await Promise.resolve();
+    expect(importEncrypted).not.toHaveBeenCalled();
+    expect(screen.getByText("did:sol:Stable")).toBeInTheDocument();
+  });
+});

--- a/packages/extension/tests/component/options/Identity.import.test.tsx
+++ b/packages/extension/tests/component/options/Identity.import.test.tsx
@@ -180,6 +180,14 @@ describe("Identity section — import flow (TA-MIN4)", () => {
     expect(screen.getByText("did:sol:OriginalPub")).toBeInTheDocument();
   });
 
+  // The four tests below are the regression-lock matrix for the
+  // documented failure classes the runtime can throw (wrong passphrase,
+  // malformed JSON, missing field, wrong byte length). They look
+  // similar because the component handles every rejection the same
+  // way — `Import failed: <err.message>` toast + badge unchanged — but
+  // we keep them as four distinct cases so a future change that
+  // accidentally swallows one class still surfaces here.
+  // (Round-1 review finding 1.)
   it("surfaces a wrong-passphrase error from the runtime in a toast", async () => {
     const importEncrypted = vi
       .fn<[Uint8Array, string], Promise<IdentitySnapshot>>()

--- a/packages/extension/tests/unit/auth/key-escrow.fuzz.test.ts
+++ b/packages/extension/tests/unit/auth/key-escrow.fuzz.test.ts
@@ -192,18 +192,19 @@ describe("key-escrow fuzz — nonce tampering fails closed", () => {
   }, /* timeout */ 60_000);
 });
 
-// ── Property 4: KDF determinism over fixed (passphrase, salt) ────────────
+// ── Property 4: round-trip identity over a fixed salt ──────────────────
 //
-// `deriveKey(passphrase, salt)` produces the same AES-GCM key for the
-// same inputs. We can't observe the raw key bytes (non-extractable
-// CryptoKey by design) so we verify determinism by wrapping under one
-// derived key and unwrapping under another — same plaintext recovered.
-// This binds the property that `kdf_params` carry stable values when
-// the salt is fixed, which the production schema relies on for the
-// "same passphrase + same blob" invariant after a rotate.
+// Round-1 review (test-reviewer-round1.json finding 3): the canonical
+// KDF-determinism unit test lives at `key-escrow.test.ts::deriveKey >
+// is deterministic for (passphrase, salt)`. THIS property's value is
+// the "rotate" invariant — when the same (passphrase, salt) is reused
+// across two wraps, both round-trip to the original secret. AES-GCM tag
+// verification implicitly proves the KDF returned the same key both
+// times; a non-deterministic KDF would surface here as a
+// `WrongPassphraseError` on the second unwrap.
 
-describe("key-escrow fuzz — KDF determinism (fixed salt)", () => {
-  it("10 random (secret, passphrase) pairs produce wrap-with-k1, unwrap-with-k2 success", async () => {
+describe("key-escrow fuzz — round-trip over fixed salt (rotate invariant)", () => {
+  it("10 random (secret, passphrase) pairs wrap twice under fixed salt → both unwrap byte-for-byte", async () => {
     const r = mulberry32(0xabad_d00d);
     for (let i = 0; i < 10; i++) {
       const secret = randomSecret(r);
@@ -214,18 +215,16 @@ describe("key-escrow fuzz — KDF determinism (fixed salt)", () => {
       const blobA = await fastWrap(secret, pp, "DetPub", fixedSalt);
       const blobB = await fastWrap(secret, pp, "DetPub", fixedSalt);
       // The kdf_params salt_b64 MUST match — fixed salt in, same out.
+      // This is the visible-on-the-wire half of the determinism story;
+      // the unwrap below is the cryptographic half.
       const sa = (JSON.parse(blobA.kdf_params) as { salt_b64: string })
         .salt_b64;
       const sb = (JSON.parse(blobB.kdf_params) as { salt_b64: string })
         .salt_b64;
       expect(sa).toBe(sb);
-      // The KDF is deterministic, so a key derived from
-      // (passphrase, fixedSalt) decrypts ciphertext produced by ANY
-      // wrap that used the same key — including blobA, even when we
-      // hand it the (fresh-nonce) ciphertext from blobB. We prove
-      // this by unwrapping blobA with the same passphrase: if the
-      // KDF were non-deterministic, the derived key would differ and
-      // AES-GCM tag verification would fail.
+      // Both blobs unwrap to the original secret. A non-deterministic
+      // KDF would derive a different key on the second wrap and the
+      // unwrap below would throw `WrongPassphraseError`.
       const outA = await unwrapSecret(blobA, pp);
       const outB = await unwrapSecret(blobB, pp);
       expect(Array.from(outA)).toEqual(Array.from(secret));

--- a/packages/extension/tests/unit/auth/key-escrow.fuzz.test.ts
+++ b/packages/extension/tests/unit/auth/key-escrow.fuzz.test.ts
@@ -1,0 +1,235 @@
+// Property-based fuzz tests for `wrapSecret` + `unwrapSecret`. The
+// canonical unit test at `tests/unit/auth/key-escrow.test.ts` covers
+// deterministic round-trips, error variants, and HTTP shape; this
+// file exercises the *round-trip identity* over random secret + random
+// passphrase inputs and proves the AES-GCM tag rejects single-byte
+// tampering on both the ciphertext and the nonce.
+//
+// Argon2id at production parameters costs ~100ms per derive. We MUST
+// cap the iteration budget so the suite stays under the CI runner's
+// soft 60s per-file threshold. With fast Argon2id parameters (m=8 KiB
+// / t=1 / p=1) each iteration runs ~10ms and 50 iterations land
+// comfortably under 1s on the GitHub Actions ubuntu-latest runner.
+//
+// We don't depend on `fast-check` — see `tests/unit/messages.fuzz.test.ts`
+// for the same rationale; the hand-rolled generator below is the
+// minimum surface that the property assertions actually need.
+
+import { describe, it, expect } from "vitest";
+import {
+  AES_GCM_NONCE_LENGTH,
+  ARGON2ID_SALT_LENGTH,
+  KDF_IDENTIFIER,
+  WrongPassphraseError,
+  deriveKey,
+  unwrapSecret,
+  type EscrowBlob,
+} from "../../../src/auth/key-escrow.js";
+
+// ── Iteration / timing budget ────────────────────────────────────────────
+//
+// 50 iterations of wrap+unwrap with FAST_PARAMS land at ~20ms each on a
+// 2024 laptop; we double the floor to 40ms per iteration to give CI
+// containers a margin. Total wall-clock budget: 50 * 40 = 2000ms.
+const FUZZ_ITERATIONS = 50;
+
+// Reduced Argon2id parameters — keep the fuzz tests fast enough for CI.
+// The constants test in `key-escrow.test.ts` binds the *production*
+// parameters; here we only need the wrap → unwrap identity to hold for
+// arbitrary (secret, passphrase) pairs.
+const FAST_PARAMS = { memoryCostKib: 8, timeCost: 1, parallelism: 1 };
+
+// ── Tiny PRNG (mulberry32) ───────────────────────────────────────────────
+// Same seedable PRNG as `messages.fuzz.test.ts`. Deterministic seeds let
+// a CI failure be reproduced locally with the same input sequence.
+
+function mulberry32(seed: number): () => number {
+  let s = seed >>> 0;
+  return (): number => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function b64(bytes: Uint8Array): string {
+  return globalThis.btoa(String.fromCharCode(...bytes));
+}
+
+function unb64(s: string): Uint8Array {
+  const bin = globalThis.atob(s);
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+/** Generate a random secret of length ∈ [1, 256]. */
+function randomSecret(r: () => number): Uint8Array {
+  const len = 1 + Math.floor(r() * 256);
+  const out = new Uint8Array(len);
+  for (let i = 0; i < len; i++) out[i] = Math.floor(r() * 256);
+  return out;
+}
+
+/** Generate a random passphrase of UTF-8 length ∈ [8, 200]. We sample
+ *  from a printable-ASCII window so the bytes round-trip through the
+ *  WebCrypto `TextEncoder` without surrogate-pair pitfalls. The
+ *  hash-wasm Argon2id accepts any UTF-8 string. */
+function randomPassphrase(r: () => number): string {
+  const len = 8 + Math.floor(r() * 193);
+  let s = "";
+  for (let i = 0; i < len; i++) {
+    s += String.fromCharCode(0x21 + Math.floor(r() * (0x7e - 0x21)));
+  }
+  return s;
+}
+
+/** Replicate `wrapSecret` with reduced Argon2id parameters so the fuzz
+ *  budget stays predictable. The wire-shape is identical so
+ *  `unwrapSecret` (which honours in-blob params) reads it transparently. */
+async function fastWrap(
+  secret: Uint8Array,
+  passphrase: string,
+  pubkey: string,
+  fixedSalt?: Uint8Array,
+): Promise<EscrowBlob> {
+  const salt =
+    fixedSalt ?? crypto.getRandomValues(new Uint8Array(ARGON2ID_SALT_LENGTH));
+  const nonce = crypto.getRandomValues(new Uint8Array(AES_GCM_NONCE_LENGTH));
+  const key = await deriveKey(passphrase, salt, FAST_PARAMS);
+  const ct = await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: nonce },
+    key,
+    secret,
+  );
+  return {
+    ciphertext_b64: b64(new Uint8Array(ct)),
+    nonce_b64: b64(nonce),
+    kdf: KDF_IDENTIFIER,
+    kdf_params: JSON.stringify({
+      salt_b64: b64(salt),
+      m: FAST_PARAMS.memoryCostKib,
+      t: FAST_PARAMS.timeCost,
+      p: FAST_PARAMS.parallelism,
+    }),
+    pubkey_base58: pubkey,
+  };
+}
+
+// ── Property 1: wrap → unwrap is identity ────────────────────────────────
+
+describe("key-escrow fuzz — wrap_unwrap_is_identity (TDD anchor)", () => {
+  it(`${String(FUZZ_ITERATIONS)} random (secret, passphrase) pairs round-trip byte-for-byte`, async () => {
+    const r = mulberry32(0xdeadbeef);
+    for (let i = 0; i < FUZZ_ITERATIONS; i++) {
+      const secret = randomSecret(r);
+      const passphrase = randomPassphrase(r);
+      const blob = await fastWrap(secret, passphrase, "FuzzPub");
+      const out = await unwrapSecret(blob, passphrase);
+      expect(out.length).toBe(secret.length);
+      // Use `Array.from` to compare structurally — `toEqual` on
+      // typed arrays is value-equal in vitest but `.from` gives a
+      // cleaner diff on the rare failure.
+      expect(Array.from(out)).toEqual(Array.from(secret));
+    }
+  }, /* timeout */ 60_000);
+});
+
+// ── Property 2: tampered ciphertext → WrongPassphraseError ───────────────
+
+describe("key-escrow fuzz — ciphertext tampering fails closed", () => {
+  it(`${String(FUZZ_ITERATIONS / 2)} random wraps survive a single-byte ciphertext flip`, async () => {
+    // Half the iteration budget — each test in this file pays an
+    // Argon2id derive, so we trade breadth across two tampering
+    // properties.
+    const r = mulberry32(0x1ce_b00b);
+    const N = Math.floor(FUZZ_ITERATIONS / 2);
+    for (let i = 0; i < N; i++) {
+      const secret = randomSecret(r);
+      const pp = randomPassphrase(r);
+      const blob = await fastWrap(secret, pp, "TamperPub");
+      const ct = unb64(blob.ciphertext_b64);
+      // Flip one bit at a random offset. Even a 1-bit perturbation
+      // MUST trip AES-GCM's authentication tag.
+      const idx = Math.floor(r() * ct.length);
+      ct[idx] = ct[idx]! ^ 0x01;
+      const tampered: EscrowBlob = { ...blob, ciphertext_b64: b64(ct) };
+      let caught: unknown = undefined;
+      try {
+        await unwrapSecret(tampered, pp);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(WrongPassphraseError);
+    }
+  }, /* timeout */ 60_000);
+});
+
+// ── Property 3: tampered nonce → WrongPassphraseError ────────────────────
+
+describe("key-escrow fuzz — nonce tampering fails closed", () => {
+  it(`${String(FUZZ_ITERATIONS / 2)} random wraps survive a single-byte nonce flip`, async () => {
+    const r = mulberry32(0x5e57_bee5);
+    const N = Math.floor(FUZZ_ITERATIONS / 2);
+    for (let i = 0; i < N; i++) {
+      const secret = randomSecret(r);
+      const pp = randomPassphrase(r);
+      const blob = await fastWrap(secret, pp, "NoncePub");
+      const nonce = unb64(blob.nonce_b64);
+      const idx = Math.floor(r() * nonce.length);
+      nonce[idx] = nonce[idx]! ^ 0xff;
+      const tampered: EscrowBlob = { ...blob, nonce_b64: b64(nonce) };
+      let caught: unknown = undefined;
+      try {
+        await unwrapSecret(tampered, pp);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(WrongPassphraseError);
+    }
+  }, /* timeout */ 60_000);
+});
+
+// ── Property 4: KDF determinism over fixed (passphrase, salt) ────────────
+//
+// `deriveKey(passphrase, salt)` produces the same AES-GCM key for the
+// same inputs. We can't observe the raw key bytes (non-extractable
+// CryptoKey by design) so we verify determinism by wrapping under one
+// derived key and unwrapping under another — same plaintext recovered.
+// This binds the property that `kdf_params` carry stable values when
+// the salt is fixed, which the production schema relies on for the
+// "same passphrase + same blob" invariant after a rotate.
+
+describe("key-escrow fuzz — KDF determinism (fixed salt)", () => {
+  it("10 random (secret, passphrase) pairs produce wrap-with-k1, unwrap-with-k2 success", async () => {
+    const r = mulberry32(0xabad_d00d);
+    for (let i = 0; i < 10; i++) {
+      const secret = randomSecret(r);
+      const pp = randomPassphrase(r);
+      const fixedSalt = crypto.getRandomValues(
+        new Uint8Array(ARGON2ID_SALT_LENGTH),
+      );
+      const blobA = await fastWrap(secret, pp, "DetPub", fixedSalt);
+      const blobB = await fastWrap(secret, pp, "DetPub", fixedSalt);
+      // The kdf_params salt_b64 MUST match — fixed salt in, same out.
+      const sa = (JSON.parse(blobA.kdf_params) as { salt_b64: string })
+        .salt_b64;
+      const sb = (JSON.parse(blobB.kdf_params) as { salt_b64: string })
+        .salt_b64;
+      expect(sa).toBe(sb);
+      // The KDF is deterministic, so a key derived from
+      // (passphrase, fixedSalt) decrypts ciphertext produced by ANY
+      // wrap that used the same key — including blobA, even when we
+      // hand it the (fresh-nonce) ciphertext from blobB. We prove
+      // this by unwrapping blobA with the same passphrase: if the
+      // KDF were non-deterministic, the derived key would differ and
+      // AES-GCM tag verification would fail.
+      const outA = await unwrapSecret(blobA, pp);
+      const outB = await unwrapSecret(blobB, pp);
+      expect(Array.from(outA)).toEqual(Array.from(secret));
+      expect(Array.from(outB)).toEqual(Array.from(secret));
+    }
+  }, /* timeout */ 60_000);
+});

--- a/packages/extension/tests/unit/messages.fuzz.test.ts
+++ b/packages/extension/tests/unit/messages.fuzz.test.ts
@@ -151,9 +151,9 @@ function assertResultShape(out: unknown): void {
 describe("parseMsg — fuzz / property tests", () => {
   it("parseMsg_never_throws — 1000 random inputs", () => {
     const r = mulberry32(0xc0ffee);
+    let acceptedCount = 0;
     for (let i = 0; i < 1000; i++) {
       const input = randomValue(r, 4);
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       let out: ReturnType<typeof parseMsg>;
       // The assertion under test: parseMsg must never throw on any
       // hostile shape. We wrap the call so a failure surfaces with the
@@ -170,8 +170,18 @@ describe("parseMsg — fuzz / property tests", () => {
       // Must be either null or a typed Msg — never undefined, never
       // partially-typed.
       expect(out === null || typeof out === "object").toBe(true);
-      if (out !== null) assertResultShape(out);
+      if (out !== null) {
+        assertResultShape(out);
+        acceptedCount++;
+      }
     }
+    // Round-1 review (test-reviewer-round1.json finding 2): a buggy
+    // refactor that early-returned null for every input would slip
+    // past the above per-iteration assertions silently. The generator
+    // is seeded so this lower bound is stable run-to-run; tightening
+    // the floor would invite flakes if the generator distribution
+    // shifts under a future tweak.
+    expect(acceptedCount).toBeGreaterThan(0);
   });
 
   it("never returns undefined — even for hostile primitives", () => {

--- a/packages/extension/tests/unit/messages.fuzz.test.ts
+++ b/packages/extension/tests/unit/messages.fuzz.test.ts
@@ -1,0 +1,280 @@
+// Property-based fuzz tests for `parseMsg`. The unit test suite at
+// `tests/unit/messages.test.ts` enumerates the documented variants;
+// this file binds the *invariant*: `parseMsg(x)` must NEVER throw and
+// must ALWAYS return either `null` or a fully-typed `Msg`.
+//
+// We don't depend on `fast-check` — it isn't in the extension's
+// devDependencies, and adding a new dep purely for property generation
+// is heavier than the ≤50-line hand-rolled generator below. See
+// `decisions.md` T24 coverage-gaps subsection for the trade-off note.
+//
+// Iteration count: 1000 random inputs. Each call is sub-millisecond
+// (pure object / array walking, no I/O, no crypto), so the full suite
+// lands in well under a second on a 2024-class laptop AND on the
+// GitHub Actions ubuntu-latest runner.
+
+import { describe, it, expect } from "vitest";
+import { parseMsg, type Msg } from "../../src/messages.js";
+
+// ── Tiny PRNG (mulberry32) ───────────────────────────────────────────────
+//
+// We need *deterministic* runs so a CI failure can be reproduced by
+// re-running with the same seed. `Math.random` has no observable seed
+// API; this 16-line PRNG covers the property-test use case (uniform-ish
+// 32-bit state, period ~2^32). Seeded with a constant so a bug surfaces
+// the same way locally and on CI.
+
+function mulberry32(seed: number): () => number {
+  let s = seed >>> 0;
+  return (): number => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+// ── Hand-rolled generator (≤50 lines as per T24 brief) ───────────────────
+
+const KNOWN_TYPES = [
+  "sw:open-recall-overlay",
+  "sw:save-selection",
+  "ui:sign-memory",
+  "ui:recall",
+  "ui:flush-pending",
+  "tab:capture-candidate",
+  "tab:fab-save-chat",
+  "tab:fab-save-selection",
+  "tab:fab-open-popup",
+  "unknown:bogus",
+  "ui:eval-rce", // attacker-supplied discriminant — must reject
+  "", // empty string discriminant
+];
+
+function randomScalar(r: () => number): unknown {
+  const pick = Math.floor(r() * 8);
+  if (pick === 0) return null;
+  if (pick === 1) return undefined;
+  if (pick === 2) return r() < 0.5;
+  if (pick === 3) return Math.floor((r() - 0.5) * 1e6);
+  if (pick === 4)
+    return Math.random() < 0.5 ? Number.NaN : Number.POSITIVE_INFINITY;
+  if (pick === 5)
+    return r()
+      .toString(36)
+      .slice(2, 2 + Math.floor(r() * 32));
+  if (pick === 6) return Symbol("sym").toString(); // pretend; symbol itself is rare
+  return [];
+}
+
+function randomValue(r: () => number, depth: number): unknown {
+  if (depth <= 0) return randomScalar(r);
+  const pick = Math.floor(r() * 6);
+  if (pick === 0) return randomScalar(r);
+  if (pick === 1) {
+    const len = Math.floor(r() * 4);
+    const arr: unknown[] = [];
+    for (let i = 0; i < len; i++) arr.push(randomValue(r, depth - 1));
+    return arr;
+  }
+  if (pick === 2) {
+    // Plain object with random keys.
+    const obj: Record<string, unknown> = {};
+    const len = Math.floor(r() * 4);
+    for (let i = 0; i < len; i++) {
+      obj[`k${String(i)}`] = randomValue(r, depth - 1);
+    }
+    return obj;
+  }
+  if (pick === 3) {
+    // Object with a known `type` discriminant but random payload.
+    const t = KNOWN_TYPES[Math.floor(r() * KNOWN_TYPES.length)]!;
+    return { type: t, payload: randomValue(r, depth - 1) };
+  }
+  if (pick === 4) {
+    // Object with a known type AND a plausibly-shaped payload + extra
+    // junk keys (the parser must accept this and ignore the extras).
+    const t = KNOWN_TYPES[Math.floor(r() * KNOWN_TYPES.length)]!;
+    return {
+      type: t,
+      payload: {
+        selectionText: "x",
+        pageUrl: "https://example.test/",
+        capturedAt: "2026-05-11T00:00:00Z",
+        content: "x",
+        tags: ["a"],
+        query: "q",
+        ownerPubkey: "P",
+        limit: 5,
+        trigger: "hotkey",
+        platform: "chatgpt",
+        url: "https://x",
+        __extra_junk: randomValue(r, depth - 1),
+      },
+      __extraTopLevel: r(),
+    };
+  }
+  return randomScalar(r);
+}
+
+// ── Invariant: never throws, always returns Msg | null ───────────────────
+
+function assertResultShape(out: unknown): void {
+  if (out === null) return;
+  // Result must be a plain object with a string `type` field that
+  // appears in the documented union. We don't pin payload shape here —
+  // the per-variant guards already do — but we DO require the
+  // top-level structure.
+  expect(out).not.toBeNull();
+  expect(typeof out).toBe("object");
+  expect(Array.isArray(out)).toBe(false);
+  const o = out as { type?: unknown };
+  expect(typeof o.type).toBe("string");
+  // Narrow against the discriminant set. `as Msg["type"]` so a future
+  // addition to the union surfaces here as a tsc error, not a runtime
+  // surprise.
+  const allowed: ReadonlySet<Msg["type"]> = new Set([
+    "sw:open-recall-overlay",
+    "sw:save-selection",
+    "ui:sign-memory",
+    "ui:recall",
+    "ui:flush-pending",
+    "tab:capture-candidate",
+    "tab:fab-save-chat",
+    "tab:fab-save-selection",
+    "tab:fab-open-popup",
+  ]);
+  expect(allowed.has(o.type as Msg["type"])).toBe(true);
+}
+
+describe("parseMsg — fuzz / property tests", () => {
+  it("parseMsg_never_throws — 1000 random inputs", () => {
+    const r = mulberry32(0xc0ffee);
+    for (let i = 0; i < 1000; i++) {
+      const input = randomValue(r, 4);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      let out: ReturnType<typeof parseMsg>;
+      // The assertion under test: parseMsg must never throw on any
+      // hostile shape. We wrap the call so a failure surfaces with the
+      // offending input attached.
+      try {
+        out = parseMsg(input);
+      } catch (err) {
+        throw new Error(
+          `parseMsg threw on input ${JSON.stringify(input)}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+      // Must be either null or a typed Msg — never undefined, never
+      // partially-typed.
+      expect(out === null || typeof out === "object").toBe(true);
+      if (out !== null) assertResultShape(out);
+    }
+  });
+
+  it("never returns undefined — even for hostile primitives", () => {
+    const candidates: unknown[] = [
+      undefined,
+      null,
+      0,
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      "",
+      "ui:sign-memory",
+      true,
+      false,
+      [],
+      [{ type: "ui:flush-pending" }],
+      new Date("2026-05-11"),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      function foo() {} as unknown,
+      Symbol("s"),
+    ];
+    for (const c of candidates) {
+      const out = parseMsg(c);
+      // Must NOT be `undefined` — the contract is `Msg | null`.
+      expect(out === undefined).toBe(false);
+      expect(out === null || typeof out === "object").toBe(true);
+    }
+  });
+
+  it("adversarial: valid type with completely wrong payload shape → null", () => {
+    expect(parseMsg({ type: "ui:sign-memory", payload: 42 })).toBeNull();
+    expect(parseMsg({ type: "ui:sign-memory", payload: null })).toBeNull();
+    expect(parseMsg({ type: "ui:sign-memory", payload: [1, 2, 3] })).toBeNull();
+    expect(
+      parseMsg({
+        type: "ui:recall",
+        payload: { query: 123, ownerPubkey: "p" },
+      }),
+    ).toBeNull();
+  });
+
+  it("adversarial: valid type + valid payload + extra fields → parses, extras ignored", () => {
+    const out = parseMsg({
+      type: "ui:sign-memory",
+      payload: {
+        content: "hello",
+        tags: ["a", "b"],
+        __extra: "ignored",
+        nestedJunk: { a: [1, 2, 3] },
+      },
+      __topLevelExtra: 9001,
+    });
+    expect(out).toMatchObject({
+      type: "ui:sign-memory",
+      payload: { content: "hello", tags: ["a", "b"] },
+    });
+  });
+
+  it("adversarial: deeply-nested junk in payload field → null", () => {
+    // `query` must be a string. A nested object that happens to type-
+    // check as `{ nested: {...} }` must still be rejected.
+    const out = parseMsg({
+      type: "ui:recall",
+      payload: {
+        query: { nested: { a: [1, "b"] } },
+        ownerPubkey: "P",
+        limit: 5,
+      },
+    });
+    expect(out).toBeNull();
+  });
+
+  it("adversarial: prototype-pollution-looking inputs are safe", () => {
+    // `__proto__`, `constructor`, `prototype` keys must NOT crash the
+    // parser. parseMsg uses bracket access (`input["type"]`) which DOES
+    // walk the prototype chain — that's expected JS object semantics
+    // and is benign here because the SW router only ever consumes the
+    // narrowed `Msg` shape; the parser does not deep-copy keys, so a
+    // prototype with extra junk fields never reaches a handler.
+    //
+    // The assertion here is the negative one: the function must not
+    // throw, and the result must still be either null or a valid Msg.
+    const a = parseMsg({ __proto__: { type: "ui:flush-pending" } });
+    expect(a === null || a?.type === "ui:flush-pending").toBe(true);
+    const b = parseMsg({ constructor: "ui:flush-pending" });
+    // `constructor` is a real own key here, not the discriminant — and
+    // the `type` key is absent, so the result must be null.
+    expect(b).toBeNull();
+    // Own `type` wins over inherited rogue keys.
+    expect(
+      parseMsg({ type: "ui:flush-pending", __proto__: { rogue: 1 } }),
+    ).toEqual({ type: "ui:flush-pending" });
+  });
+
+  it("adversarial: arrays at the top level always return null", () => {
+    expect(parseMsg([])).toBeNull();
+    expect(parseMsg([{ type: "ui:flush-pending" }])).toBeNull();
+    expect(parseMsg(["ui:flush-pending"])).toBeNull();
+  });
+
+  it("adversarial: numeric / boolean `type` discriminants → null", () => {
+    expect(parseMsg({ type: 1 })).toBeNull();
+    expect(parseMsg({ type: true })).toBeNull();
+    expect(parseMsg({ type: null })).toBeNull();
+    expect(parseMsg({ type: { nested: "ui:flush-pending" } })).toBeNull();
+  });
+});

--- a/work/chrome-extension/decisions.md
+++ b/work/chrome-extension/decisions.md
@@ -1232,3 +1232,37 @@ Three round-1 reviewers (code-reviewer, security-auditor, test-reviewer) returne
 - `vitest run tests/unit/auth/key-escrow.test.ts` → 50 pass (was 33 before round-1; +17 from this fix wave).
 - `bun test` (full extension) → 196 pass / 1 pre-existing `cose.test.ts` WASM failure (unchanged from the pre-fix baseline).
 
+
+---
+
+## 2026-05-11 · T24 — Options edges + fuzz tests
+
+Round-2 test audit flagged TA-MIN2 (no `About` section test) and TA-MIN4 (no Identity-import test). Plus the user requested maximum coverage on the parser/crypto seams — both are stable contracts that benefit from property-based fuzzing more than they benefit from another deterministic unit. T24 closes all three gaps in tests-only changes.
+
+**Files added (tests-only — no production code touched):**
+
+- `packages/extension/tests/component/options/About.test.tsx` — 7 tests. Renders the section heading, asserts the version row reads from `getOptionsRuntime().about`, asserts the optional build-hash row appears iff `buildHash` is set, asserts the privacy and source-repo links have `target="_blank"` + `rel="noreferrer noopener"`, and that swapping the runtime between mounts re-hydrates the row values.
+- `packages/extension/tests/component/options/Identity.import.test.tsx` — 8 tests. Mocks `identity.importEncrypted` directly (the file-picker is jsdom-stubbed). Covers happy path (file bytes + passphrase reach the runtime; badge updates; passphrase clears), empty-passphrase short-circuit before any runtime call (preserves rate-limit budget at the UI seam), three malformed-blob error variants (wrong passphrase, bad-JSON `SyntaxError`, missing-field `Error`, wrong-byte-length `Error`), the export-blob download path (asserts `URL.createObjectURL` is called with a JSON Blob and `URL.revokeObjectURL` is called after), and a defensive no-file-selected event (`a.click()` cancel on macOS) that must not crash.
+- `packages/extension/tests/unit/messages.fuzz.test.ts` — 8 tests, 1000 random inputs in the headline property. Hand-rolled mulberry32 PRNG + 50-line generator (no `fast-check` dep added; see "coverage gaps" below). Asserts `parseMsg` never throws, never returns `undefined`, and always returns either `null` or a typed `Msg` whose `type` is in the documented discriminant set. Adversarial samples: valid type + wrong payload shape → null, valid type + valid payload + extra fields → parsed (extras ignored), deeply-nested junk → null, prototype-pollution-looking inputs → safe, array-at-top → null, numeric/boolean discriminants → null.
+- `packages/extension/tests/unit/auth/key-escrow.fuzz.test.ts` — 4 properties × budgeted iteration counts (50 for the headline round-trip, 25 each for ciphertext + nonce tampering, 10 for KDF determinism). Uses the established `fastWrap` pattern (`memoryCostKib=8, timeCost=1, parallelism=1`) so the full suite lands in ~100ms; the production-parameter coverage is owned by `tests/unit/auth/key-escrow.test.ts`'s `wrapSecret — production parameters` test, not duplicated here.
+
+**Coverage gaps closed:**
+
+- TA-MIN2: About section. **Closed** — 7 tests bind the actual surface (version + build-hash + Privacy/Source links). The task brief mentioned MCP-endpoint + Discord links + "Reset all data" button — that UX has not landed in `About.tsx`; binding to the *current* component is the right call rather than testing a future surface that doesn't exist yet. The richer surface remains tracked as a forward-looking item but does not block T24.
+- TA-MIN4: Identity-import. **Closed** — 8 tests bind import (happy + 4 error variants + defensive no-file + empty-passphrase short-circuit) and export download surface.
+- TDD anchor `parseMsg_never_throws`. **Closed** — 1000 random inputs, all return null or typed Msg, never throw, never return undefined. Locks the type-narrowing invariant against future refactors.
+- TDD anchor `wrap_unwrap_is_identity`. **Closed** — 50 random (secret length ∈ [1, 256], passphrase length ∈ [8, 200]) pairs round-trip byte-for-byte. Tampering properties (ciphertext + nonce, 25 each) prove AES-GCM fails closed on single-byte perturbations.
+
+**Decision: hand-rolled property generator rather than `fast-check`.** `fast-check` is not in the extension's devDependencies and would be the first new dep added in this wave. The hand-rolled generator at the top of each fuzz file is ≤ 50 lines (mulberry32 + a recursive `randomValue` walker) and gives us deterministic seeds for CI-reproducible failures — `fast-check`'s `seed` knob is the only feature we'd actually use. Trade-off: we don't get its shrinking minimiser; if the property tests start failing flakily on hostile inputs, swap in `fast-check` then.
+
+**Decision: budgeted iteration counts for Argon2id fuzz.** Each Argon2id derive costs ~10ms even at `memoryCostKib=8, timeCost=1, parallelism=1`. The total wall-clock budget at 50 iterations + 25 + 25 + 10 lands at ~1.1s on a 2024-class laptop; the file timeout is set to 60s per `it()` block as a paranoid ceiling. The PRODUCTION-parameter round-trip is covered exactly once, in `tests/unit/auth/key-escrow.test.ts::wrapSecret — production parameters` — fuzzing with `m=64MiB` would burn ~5s per iteration and crater the CI budget.
+
+**Test results (worktree, run via `npx vitest run`):**
+
+- `tests/component/options/About.test.tsx` — 7 / 7 pass, 62ms.
+- `tests/component/options/Identity.import.test.tsx` — 8 / 8 pass, 232ms.
+- `tests/unit/messages.fuzz.test.ts` — 8 / 8 pass, 9ms (1000 iterations on the headline property).
+- `tests/unit/auth/key-escrow.fuzz.test.ts` — 4 / 4 pass, 104ms (50 + 25 + 25 + 10 = 110 Argon2id derives total).
+- Combined: 27 / 27 pass in 963ms.
+- Full extension `npx vitest run` (no test-name filter): 337 pass, 7 unchanged pre-existing failures (`cose.test.ts` missing WASM build; `cloud-sync.test.ts` re-auth event listener — both predate this PR; confirmed via `git stash` baseline diff).
+- `bun test tests/unit/messages.fuzz.test.ts tests/unit/auth/key-escrow.fuzz.test.ts` — 12 / 12 pass, 367ms (1929 `expect()` calls — bun discovers each PRNG iteration as a separate assertion).

--- a/work/chrome-extension/decisions.md
+++ b/work/chrome-extension/decisions.md
@@ -1266,3 +1266,15 @@ Round-2 test audit flagged TA-MIN2 (no `About` section test) and TA-MIN4 (no Ide
 - Combined: 27 / 27 pass in 963ms.
 - Full extension `npx vitest run` (no test-name filter): 337 pass, 7 unchanged pre-existing failures (`cose.test.ts` missing WASM build; `cloud-sync.test.ts` re-auth event listener — both predate this PR; confirmed via `git stash` baseline diff).
 - `bun test tests/unit/messages.fuzz.test.ts tests/unit/auth/key-escrow.fuzz.test.ts` — 12 / 12 pass, 367ms (1929 `expect()` calls — bun discovers each PRNG iteration as a separate assertion).
+
+## 2026-05-11 · T24 — Round-1 review fixes
+
+`test-reviewer-round1.json` returned `needs_improvement` with three minor findings; all addressed. Reviewer reports at `work/chrome-extension/logs/working/task-24/test-reviewer-{round1,round2}.json`.
+
+| Finding | Severity | File | Resolution |
+| --- | --- | --- | --- |
+| T24-T-01 | minor | `tests/component/options/Identity.import.test.tsx` | **fixed** — leading comment block before the four error-variant tests calls them out as the regression-lock matrix for the documented failure classes (wrong passphrase, malformed JSON, missing field, wrong byte length). Tests kept as four distinct cases. |
+| T24-T-02 | minor | `tests/unit/messages.fuzz.test.ts` | **fixed** — `acceptedCount` counter inside the 1000-iteration loop + `expect(acceptedCount).toBeGreaterThan(0)` after. Catches a regression that early-returns null for every input. |
+| T24-T-03 | minor | `tests/unit/auth/key-escrow.fuzz.test.ts` | **fixed** — property reframed from "KDF determinism (which lives in the canonical `key-escrow.test.ts`)" to "round-trip identity over a fixed salt — the rotate invariant"; comments updated to describe what is actually verified. Determinism is implicit in the unwrap-succeeds assertion; the canonical determinism test is in `key-escrow.test.ts::deriveKey > is deterministic for (passphrase, salt)`. |
+
+Round-2 review: `status: passed`, 0 findings, 27/27 tests pass in 1.03s.


### PR DESCRIPTION
## Summary

Closes round-2 test-audit gaps **TA-MIN2** (no About section test) and **TA-MIN4** (no Identity-import test), plus adds two property-based fuzz suites for the highest-leverage parser/crypto seams.

- **Options coverage:** `About.test.tsx` (7 tests — version row, optional build-hash row, Privacy/Source links with safe `rel`, runtime-swap re-hydration) + `Identity.import.test.tsx` (8 tests — encrypted-blob import happy path, empty-passphrase short-circuit, four malformed-blob error variants, export-blob download surface, defensive no-file-selected).
- **Fuzz / property tests:** `messages.fuzz.test.ts` (1000 random inputs — parseMsg never throws, always returns `Msg | null`; adversarial samples for wrong shape, extras-ignored, deep junk, prototype-pollution, arrays, non-string discriminants) + `auth/key-escrow.fuzz.test.ts` (50-iter wrap/unwrap identity; 25-iter ciphertext + nonce tampering → `WrongPassphraseError`; 10-iter KDF determinism).
- **No production code touched.** Tests-only; no new dependencies (hand-rolled mulberry32 PRNG + ≤50-line generator rather than adding `fast-check` — trade-off documented in `decisions.md`).

## Test plan

- [x] `npx vitest run tests/component/options/About.test.tsx` — 7/7 pass, 62ms
- [x] `npx vitest run tests/component/options/Identity.import.test.tsx` — 8/8 pass, 232ms
- [x] `npx vitest run tests/unit/messages.fuzz.test.ts` — 8/8 pass, 9ms (1000 iterations on the headline property)
- [x] `npx vitest run tests/unit/auth/key-escrow.fuzz.test.ts` — 4/4 pass, 104ms (110 Argon2id derives total — well under the 60s CI ceiling per `it()` block)
- [x] `bun test tests/unit/messages.fuzz.test.ts tests/unit/auth/key-escrow.fuzz.test.ts` — 12/12 pass, 1929 `expect()` calls, 367ms
- [x] Full `npx vitest run` — 337 pass; 7 pre-existing failures (`cose.test.ts` missing WASM build; `cloud-sync.test.ts` re-auth event listener) confirmed via baseline `git stash` diff to be untouched by this PR.
- [ ] CI green on `node-test.yml` (Node 20 + Bun matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)