### PR TITLE
chore(extension): document Chrome extension OAuth config (T16 sign-in)

### DIFF
--- a/.claude/skills/project-knowledge/references/deployment.md
+++ b/.claude/skills/project-knowledge/references/deployment.md
@@ -279,6 +279,29 @@ longer required for the OAuth flow** — signing happens client-side in the
 webapp's WASM identity. The keypair is still required for legacy `full`
 storage mode (Arweave + Solana writes) but irrelevant to OAuth bootstrap.
 
+#### Chrome extension OAuth — Google sign-in (T14 + T16, 2026-05-11)
+
+The Chrome extension uses `chrome.identity.launchWebAuthFlow` (RFC 7636
+PKCE S256) against the server's `/oauth/google/start` + `/oauth/token`
+endpoints. Server-side Google config in `/home/claude/mcp.env`:
+
+```bash
+GOOGLE_OAUTH_CLIENT_ID=468578209539-nenf5avaagdv8b66rf4djojud4ighe03.apps.googleusercontent.com
+GOOGLE_OAUTH_CLIENT_SECRET=<held server-side; from Google Cloud Console>
+GOOGLE_OAUTH_REDIRECT_URI=https://iegoicpcogbnnnajgfdbljfickgfnfoj.chromiumapp.org/google
+```
+
+- Google Cloud project: `mnemonik-xyz`.
+- OAuth client type: **Web application** (the "Chrome extension" type
+  requires a Web Store Item ID at creation and produces a client
+  incompatible with `launchWebAuthFlow`).
+- Authorized redirect URI in Google Cloud Console must match
+  `GOOGLE_OAUTH_REDIRECT_URI` byte for byte.
+- Chrome Web Store Item ID: `iegoicpcogbnnnajgfdbljfickgfnfoj`.
+  Documented in `packages/extension/EXTENSION_ID.md`.
+- Server env var `GOOGLE_OAUTH_CLIENT_ID=""` (empty) disables the
+  Google OAuth router branch entirely (`mcp/src/oauth/google.rs::new`).
+
 ### Key Paths
 
 | Path | Purpose |

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,25 @@ TURBO_BITS=4
 ARWEAVE_URL=https://uploader.irys.xyz
 SOLANA_RPC_URL=https://api.mainnet-beta.solana.com
 
+# ── Google OAuth (hosted MCP + Chrome extension sign-in, T14/T16) ────────────
+# Empty client_id disables the Google OAuth handlers (router skips installation).
+# Get these from Google Cloud Console → APIs & Services → Credentials.
+# Use type "Web application" — Chrome extension OAuth type requires a Web Store
+# Item ID; "Web application" works with chrome.identity.launchWebAuthFlow +
+# PKCE via the extension's chromiumapp.org redirect URI.
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+# Must match exactly what's whitelisted under "Authorized redirect URIs" in
+# the Google Cloud OAuth client. For the production Chrome extension build
+# (Web Store ID iegoicpcogbnnnajgfdbljfickgfnfoj):
+#   https://iegoicpcogbnnnajgfdbljfickgfnfoj.chromiumapp.org/google
+GOOGLE_OAUTH_REDIRECT_URI=
+# Server's public origin (used in OAuth metadata + callback redirects).
+# MCP_PUBLIC_BASE_URL=https://mcp.mnemonik.xyz
+# HS256 secret for OAuth Bearer JWTs. Required in hosted mode. ≥32 random
+# bytes: `openssl rand -base64 32`.
+# MCP_JWT_SECRET=
+
 # ── MCP transport ─────────────────────────────────────────────────────────────
 # stdio — for Cursor/Claude Desktop local integration.
 # http  — for remote HTTP JSON-RPC.

--- a/packages/extension/EXTENSION_ID.md
+++ b/packages/extension/EXTENSION_ID.md
@@ -1,0 +1,68 @@
+# Mnemonik — Chrome extension ID
+
+**Stable extension ID:** `iegoicpcogbnnnajgfdbljfickgfnfoj`
+
+This is the Chrome Web Store Item ID assigned to the Mnemonik
+extension. It is the identifier Google's OAuth flow binds the
+sign-in redirect to, and the identifier the server's
+`GOOGLE_OAUTH_REDIRECT_URI` must match.
+
+## Why it matters
+
+`chrome.identity.launchWebAuthFlow` uses a redirect URI of the form
+
+```
+https://<extension-id>.chromiumapp.org/<path>
+```
+
+T16 passes `path = "google"` (see
+`packages/extension/src/auth/google-oauth.ts::REDIRECT_PATH`), so the
+full redirect URI is:
+
+```
+https://iegoicpcogbnnnajgfdbljfickgfnfoj.chromiumapp.org/google
+```
+
+This exact URI must be whitelisted under "Authorized redirect URIs"
+in the Google Cloud OAuth client (project `mnemonik-xyz`, OAuth
+client type "Web application"). The MCP server's
+`GOOGLE_OAUTH_REDIRECT_URI` env var must match the same string —
+Google's `oauth2.googleapis.com/token` endpoint compares the value
+on the token-exchange leg.
+
+## Stable ID — two installation modes
+
+1. **Web Store install (production / user-facing).** Google assigns
+   and enforces the ID once the extension is published. End-users
+   install via `https://chrome.google.com/webstore/detail/<id>` and
+   the ID is automatically `iegoicpcogbnnnajgfdbljfickgfnfoj`.
+2. **Unpacked dev load.** Chrome derives the ID from the SHA-256 of
+   the manifest's `key` field. To get the same ID under
+   `chrome://extensions → Load unpacked`, the developer must add a
+   `key` field to `manifest.json` whose public-key bytes hash to the
+   same ID. The `key` value is intentionally NOT checked into this
+   repo — see `RELEASE.md` for how it is stored.
+
+## Google Cloud OAuth client
+
+- Project: `mnemonik-xyz`
+- OAuth client type: **Web application** (not Chrome extension —
+  the latter requires a Web Store Item ID for creation, but the
+  resulting client is incompatible with `launchWebAuthFlow`).
+- Authorized redirect URI: the URL above.
+- Client ID is the public token sent on `/oauth/google/start`. The
+  client secret is held server-side only and never reaches the
+  extension (Decision 5 in `work/chrome-extension/decisions.md`).
+
+## Server env vars
+
+See `.env.example`:
+
+- `GOOGLE_OAUTH_CLIENT_ID` — public; the same string the OAuth
+  consent screen surfaces to end users.
+- `GOOGLE_OAUTH_CLIENT_SECRET` — held only on the MCP server. Used
+  in the `oauth2.googleapis.com/token` exchange (PKCE flow; secret
+  is optional in pure RFC 7636 but Google's web-application client
+  type still requires it).
+- `GOOGLE_OAUTH_REDIRECT_URI` — must equal the URI above byte for
+  byte.


### PR DESCRIPTION
## Summary

Pure documentation / config — no code or test changes.

- \`.env.example\`: new \`GOOGLE_OAUTH_{CLIENT_ID,CLIENT_SECRET,REDIRECT_URI}\` block with reasoning for OAuth client type "Web application" vs "Chrome extension".
- \`packages/extension/EXTENSION_ID.md\`: canonical doc for Chrome Web Store Item ID \`iegoicpcogbnnnajgfdbljfickgfnfoj\` + the exact redirect URI Google's Cloud Console must whitelist + how unpacked-vs-Web-Store installs both produce the same ID.
- \`.claude/skills/project-knowledge/references/deployment.md\`: new subsection under hosted MCP block listing the env vars the VPS needs.

## Why "Web application" instead of "Chrome extension" OAuth type

Google Cloud Console's "Chrome extension" OAuth client type requires a Web Store Item ID at creation AND produces a client that's incompatible with \`chrome.identity.launchWebAuthFlow\`. T16 uses \`launchWebAuthFlow\` + PKCE → "Web application" type works perfectly with a manually-whitelisted redirect URI.

## Configured OAuth client

- Client ID: \`468578209539-nenf5avaagdv8b66rf4djojud4ighe03.apps.googleusercontent.com\`
- Authorized redirect URI: \`https://iegoicpcogbnnnajgfdbljfickgfnfoj.chromiumapp.org/google\`
- Client secret: held by the user / set on the VPS only

## Out of scope

The manifest \`key\` field for unpacked dev loads is intentionally NOT committed (the matching private key never leaves the developer's machine). End-users installing from Web Store get the matching ID injected by Google automatically.

## Test plan
- [x] No code changes — docs + env example only.
- [x] Mention of Web-Store ID is exact: \`iegoicpcogbnnnajgfdbljfickgfnfoj\`.
- [x] CI green (docs-only PR).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>