### PR TITLE
fix(extension): T25 round-2 review fixes (1 BLOCK + 2 majors + 6 minors)

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,65 +1,174 @@
-# Mnemonic Protocol — Quickstart
+# Quickstart — 60 seconds to your first signed memory
 
-Five steps to go from zero to "my AI agent on Device A remembers something my AI agent on Device B asks for."
+> Three commands. No build. The hosted MCP server at `mcp.mnemonik.xyz` is free for the public beta.
 
-## Links
+## TL;DR
 
-- Install: <https://mnemonik.xyz/install>
-- Webapp: <https://mnemonik.xyz>
-- MCP endpoint: <https://mcp.mnemonik.xyz/mcp>
-- Discord: <https://discord.gg/ws6wruJj>
-- Source: <https://github.com/mnemonik-xyz/monorepo>
+```bash
+# 1. Open https://mnemonik.xyz/install in your browser
+# 2. Click "Send to CLI" → copy the ticket UUID
+# 3. Run:
+npx @mnemonik-xyz/cli init --ticket <uuid>
+npx @mnemonik-xyz/cli login
+npx @mnemonik-xyz/cli sign "first memory"
+```
 
-## 1. Open the install page
+(If you prefer a standalone CLI-only keypair without webapp pairing, replace step 3's first command with `npx @mnemonik-xyz/cli init --standalone`.)
 
-Go to <https://mnemonik.xyz/install> in your everyday browser. This page is the single entry point — it creates your identity, hands it to your IDE, and finishes the OAuth handshake in one flow.
-
-## 2. Create your identity
-
-The page generates an Ed25519 keypair locally in your browser. The private key never leaves the device — it stays in browser storage. Your public key is your identity from now on, across every IDE, every device, every model.
-
-Write down (or save to a password manager) the recovery hint the page shows you. That is how you re-import this identity onto another device later.
-
-## 3. Install Mnemonic into the IDE of your choice
-
-Still on the install page, pick your IDE — Cursor, Claude Desktop, Windsurf, or any other Model Context Protocol client. Click the install button for that IDE.
-
-The page registers the Mnemonic MCP server with the IDE and runs the OAuth handshake using the keypair you just created. When you reopen the IDE, the Mnemonic tools appear in its tool list automatically.
-
-That is it for setup.
-
-## 4. Ask your AI agent to store something
-
-In your IDE's chat, just talk to it. Tell it what you want remembered.
-
-Examples that work:
-
-> "Remember that we decided to ship version 0.2 next Tuesday, with Alex as the release owner."
-
-> "Save this code review summary as a memory tagged 'reviews' and 'v0.2'."
-
-> "Store our current architecture decision: we are choosing Postgres over MongoDB because of the reporting requirements."
-
-The agent calls `mnemonic_sign_memory` for you. Behind the scenes, the text is embedded, signed with your Ed25519 key, anchored on Solana, and copied to permanent decentralized storage. You will see a confirmation with an attestation identifier and links to the on-chain record.
-
-## 5. Recall it from anywhere — different IDE, different device
-
-This is the part that is genuinely new.
-
-Open a different IDE on a different device. Repeat steps 1 to 3 — the install page will let you re-import the same identity using the recovery hint from step 2. Once that identity is loaded, the new IDE is connected to your same memory store.
-
-Ask the agent in plain language:
-
-> "What did we decide about the version 0.2 release?"
-
-> "Remind me of our database choice and why."
-
-> "Pull up the code review notes I tagged 'v0.2'."
-
-The agent calls `mnemonic_recall`. It searches by meaning, not keyword. It returns the memories you signed earlier, signed by you, verifiable by anyone, available wherever you bring your identity.
-
-That is the whole loop: portable, attestable memory for AI agents, across any tool, any device.
+That's it. You now have a verifiable, persistent memory anchored against the production Mnemonic server.
 
 ---
 
-Help and questions: <https://discord.gg/ws6wruJj>
+## Step-by-step
+
+### 1. Set up your identity (10 seconds)
+
+Two paths — pick one:
+
+**Recommended — pair with the webapp** (keeps CLI + browser keypairs in sync, so signs from Cursor / Claude.ai / VS Code Just Work):
+
+1. Open `https://mnemonik.xyz/install` in your browser.
+2. Click **"Send to CLI"** → copy the ticket UUID it shows.
+3. Run:
+
+   ```bash
+   npx @mnemonik-xyz/cli init --ticket <uuid>
+   ```
+
+   This imports the webapp's localStorage Ed25519 keypair into `~/.mnemonic/identity.json` (mode 0600). Same keypair on both sides → no `pending bundle owner mismatch` later.
+
+**Standalone** — CLI-only, no webapp pairing (advanced; use only if you do not plan to use the webapp / IDE integrations):
+
+```bash
+npx @mnemonik-xyz/cli init --standalone
+```
+
+Generates a fresh Ed25519 keypair, also at `~/.mnemonic/identity.json` mode 0600. The key never leaves the host.
+
+If `~/.mnemonic/identity.json` already exists, both modes refuse to overwrite. Pass `--force` to replace it (only if you have a backup — losing the key means losing access to memories signed under it).
+
+### 2. Authenticate against the hosted server (10 seconds)
+
+```bash
+npx @mnemonik-xyz/cli login
+```
+
+Opens your default browser to the OAuth 2.1 + PKCE authorization page at `mcp.mnemonik.xyz`. Approve in the browser, return to the terminal — the CLI captures the JWT and persists it at `~/.mnemonic/token.json` (also mode 0600).
+
+The browser-side step is required because the OAuth challenge is signed with the same Ed25519 keypair you just created — that's how the server knows the JWT belongs to you.
+
+### 3. Sign your first memory (3 seconds)
+
+```bash
+npx @mnemonik-xyz/cli sign "first memory"
+```
+
+Output:
+
+```
+attestation_id: Qm9...
+signed_at:      2026-05-02T10:00:00Z
+status:         signed
+content_hash:   <blake3 of your content>
+solana_tx:      <real Solana SPL Memo tx>      ← anchor on mainnet
+arweave_tx:     <real Arweave tx>              ← bytes preserved
+```
+
+You now have a memory that:
+
+- Anyone can semantically search.
+- Anyone with the `solana_tx` can independently verify (no Mnemonic-server dependency).
+- Will outlive the laptop you signed it on.
+
+### 4. Recall semantically (1 second)
+
+```bash
+npx @mnemonik-xyz/cli recall "memory"
+```
+
+Returns the top-k most similar attestations by cosine similarity — *not* keyword match.
+
+### 5. Verify (independently)
+
+```bash
+npx @mnemonik-xyz/cli verify <attestation_id>
+```
+
+Or, fully outside the Mnemonic ecosystem, anyone can verify your memory using only public infrastructure:
+
+```bash
+# Fetch raw COSE bytes from Arweave (any gateway)
+curl -sS "https://arweave.net/<arweave_tx>" -o memory.cose
+
+# Recompute the hash + verify the COSE signature
+# (sample verifier code in packages/sdk/src/verify.ts)
+
+# Confirm Solana SPL Memo tx contains the same hash
+solana confirm <solana_tx> --url https://api.mainnet-beta.solana.com
+```
+
+The point of the protocol is that your claim ("I signed this memory at this time") is third-party-verifiable — no central authority required.
+
+---
+
+## From an MCP-aware AI client (one click)
+
+Mnemonic is exposed over the Model Context Protocol, which means Claude, Cursor, VS Code, and Windsurf can use it directly as a memory backend with no glue code.
+
+Install via the one-click connector:
+
+- **mnemonik.xyz/install** — picks the right deeplink for your client.
+
+After install, the client will run the same OAuth handshake on first call, and from there every chat turn can call `mnemonic_sign_memory`, `mnemonic_recall`, and the rest as normal MCP tools.
+
+---
+
+## From an SDK (TypeScript / Node / Bun / Deno / browsers)
+
+```ts
+import { MnemonicClient, LocalSigner, Keypair } from "@mnemonik-xyz/sdk";
+
+const keypair = Keypair.generate();                      // or load from disk
+const signer = new LocalSigner(keypair);
+const client = new MnemonicClient({ baseUrl: "https://mcp.mnemonik.xyz", signer });
+
+// (Run OAuth flow elsewhere, persist the JWT, then:)
+client.setJwt(jwtFromOauth);
+client.setKeypair(keypair);
+
+const result = await client.signMemory("first memory", { tags: ["demo"] });
+console.log(result.attestationId, result.solanaTx, result.arweaveTx);
+
+const hits = await client.recall("first");
+console.log(hits);
+```
+
+The SDK runs unmodified in Node 20+, Bun, Deno, and modern browsers.
+
+---
+
+## Self-host (later, optional)
+
+The hosted server is free. If you'd rather run it yourself:
+
+```bash
+git clone https://github.com/mnemonik-xyz/monorepo.git
+cd monorepo
+cargo build --release -p mnemonic-mcp --features local-embed
+
+STORAGE_MODE=local PAYMENT_MODE=none \
+  ./target/release/mnemonic-mcp --transport http --port 3000
+```
+
+`STORAGE_MODE=local` keeps everything on disk (no chain, no payment). Flip to `STORAGE_MODE=full` once you have a funded keypair to anchor on Solana mainnet.
+
+Full self-host docs: `.claude/skills/project-knowledge/references/deployment.md`.
+
+---
+
+## Help
+
+- **Discord:** [discord.gg/ws6wruJj](https://discord.gg/ws6wruJj)
+- **Issues:** [github.com/mnemonik-xyz/monorepo/issues](https://github.com/mnemonik-xyz/monorepo/issues)
+- **Whitepaper:** [docs/WHITEPAPER.md](./WHITEPAPER.md)
+- **How it works:** [docs/how-it-works.md](./how-it-works.md)

--- a/packages/extension/src/auth/storage-keys.ts
+++ b/packages/extension/src/auth/storage-keys.ts
@@ -1,0 +1,31 @@
+// Single source of truth for chrome.storage.local identity keys.
+//
+// Pre-T25-round-2 these literals were duplicated across three sites:
+//   - `options/runtime-impl.ts` exported `IDENTITY_KEY` / `IDENTITY_SECRET_KEY`.
+//   - `popup/onboarding/Restore.tsx` exported `IDENTITY_STORAGE_KEY` /
+//     `IDENTITY_SECRET_STORAGE_KEY`.
+//   - `popup/Onboarding.tsx::mintAndPersistKeypair` used bare string
+//     literals `"identity"` / `"identity_secret"`.
+//
+// All three sites happened to agree on the literal value `"identity"` /
+// `"identity_secret"`, but a future rename would only touch one site
+// and silently break recovery (the popup writes one key, the options
+// reader looks at another). Code-review finding PR136-C-01 + audit
+// finding SA-T25-003.
+//
+// This module lives under `src/auth/` because both the options realm
+// and the popup realm already depend on `src/auth/`, so importing from
+// here introduces no new cross-realm coupling. The constants are
+// re-exported from their previous homes for callers that still rely on
+// the old names — those re-exports are mechanical and can be removed
+// once every import site is migrated.
+
+/** chrome.storage.local key for the public identity metadata
+ *  (`{pubkey_base58, created_at?}`). Read by both the popup runtime
+ *  and the options identity facade. */
+export const IDENTITY_KEY = "identity";
+
+/** chrome.storage.local key for the 64-byte Solana keypair secret
+ *  (seed||pubkey) stored as a structured-clone-safe `number[]`.
+ *  Never logged. */
+export const IDENTITY_SECRET_KEY = "identity_secret";

--- a/packages/extension/src/content/recall-overlay.ts
+++ b/packages/extension/src/content/recall-overlay.ts
@@ -19,6 +19,7 @@
 import { parseMsg } from "../messages.js";
 import { selectAdapter } from "../runtime/chat/registry.js";
 import type { SearchResult } from "../runtime/store/types.js";
+import { IDENTITY_KEY } from "../auth/storage-keys.js";
 import { SHADOW_STYLES } from "./shadow-styles.js";
 
 const HOST_TAG = "mnemonik-overlay-host";
@@ -224,11 +225,11 @@ async function runSearch(state: OverlayState, raw: string): Promise<void> {
     // identity row so the SW recall scopes correctly.
     let ownerPubkey: string | undefined;
     try {
-      const stored = (await chrome.storage.local.get("identity")) as Record<
+      const stored = (await chrome.storage.local.get(IDENTITY_KEY)) as Record<
         string,
         unknown
       >;
-      const id = stored.identity as { pubkey_base58?: string } | undefined;
+      const id = stored[IDENTITY_KEY] as { pubkey_base58?: string } | undefined;
       if (id?.pubkey_base58) ownerPubkey = id.pubkey_base58;
     } catch {
       // chrome.storage might be unavailable in some test harnesses;

--- a/packages/extension/src/options/runtime-impl.ts
+++ b/packages/extension/src/options/runtime-impl.ts
@@ -82,6 +82,12 @@ export { IDENTITY_KEY, IDENTITY_SECRET_KEY } from "../auth/storage-keys.js";
 const BASE58_ALPHABET =
   "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
+/** Pre-computed Set for O(1) character membership lookups (PR136-C-06).
+ *  Pulled out of `isLikelyBase58` so the 58-entry Set is constructed
+ *  once at module-load instead of `String.indexOf`-scanning the
+ *  alphabet on every character. */
+const BASE58_SET: Set<string> = new Set(BASE58_ALPHABET);
+
 function isLikelyBase58(s: string): boolean {
   if (typeof s !== "string" || s.length === 0) return false;
   // Solana Ed25519 pubkeys are 32 bytes → ~43-44 base58 chars. We use a
@@ -89,7 +95,7 @@ function isLikelyBase58(s: string): boolean {
   // reach the WASM validator for the authoritative check.
   if (s.length < 32 || s.length > 64) return false;
   for (let i = 0; i < s.length; i++) {
-    if (BASE58_ALPHABET.indexOf(s[i]!) < 0) return false;
+    if (!BASE58_SET.has(s[i]!)) return false;
   }
   return true;
 }
@@ -347,20 +353,46 @@ function createIdentityFacade(): IdentityFacade {
         );
       }
       // Byte-range validation — keeps a hand-edited JSON with > 255
-      // entries from poisoning chrome.storage.
+      // entries from poisoning chrome.storage. PR136-C-04: the message
+      // says "byte value" (the actual failure mode), not "secret length"
+      // — by this point the 64-element length is already confirmed.
       const normalised: number[] = [];
-      for (const n of secret) {
+      for (let i = 0; i < secret.length; i++) {
+        const n = secret[i];
         const num = typeof n === "number" ? n : Number(n);
         if (!Number.isInteger(num) || num < 0 || num > 255) {
-          throw new Error("Wrong secret length: contains non-byte value");
+          throw new Error(
+            `Invalid secret byte at index ${i}: expected an integer in [0, 255]`,
+          );
         }
         normalised.push(num);
       }
-      // Persist atomically. Carry `created_at` forward when the import
-      // envelope has an `exported_at`; we treat the export timestamp as
-      // a lower-bound on the identity's age, which keeps the Options
-      // "Created …" row useful after a round-trip.
-      const created_at = Date.now();
+      // PR136-C-02: forward `exported_at` from the import envelope as
+      // `created_at` when it parses to a sensible wall-clock time, so a
+      // round-trip (export → import) preserves the original age. The
+      // exporter writes ISO-8601 strings; we accept either ISO strings
+      // or epoch-ms numbers for backward compatibility. Guard against:
+      //   - missing / wrong-type values (fall back to Date.now()),
+      //   - unparseable strings (NaN getTime()),
+      //   - non-positive timestamps,
+      //   - absurdly-future timestamps (clock skew tolerance: 24h).
+      const now = Date.now();
+      const FUTURE_TOLERANCE_MS = 24 * 60 * 60 * 1000;
+      let created_at = now;
+      const exportedAt = obj.exported_at;
+      if (typeof exportedAt === "string" || typeof exportedAt === "number") {
+        const parsed =
+          typeof exportedAt === "number"
+            ? exportedAt
+            : new Date(exportedAt).getTime();
+        if (
+          Number.isFinite(parsed) &&
+          parsed > 0 &&
+          parsed <= now + FUTURE_TOLERANCE_MS
+        ) {
+          created_at = parsed;
+        }
+      }
       await chrome.storage.local.set({
         [IDENTITY_KEY]: { pubkey_base58: pub, created_at },
         [IDENTITY_SECRET_KEY]: normalised,

--- a/packages/extension/src/options/runtime-impl.ts
+++ b/packages/extension/src/options/runtime-impl.ts
@@ -161,6 +161,16 @@ function createAuthFacade(): AuthFacade {
   };
 }
 
+/** SA-T25-002 TOCTOU serialiser. `generate()` runs
+ *  read → check → WASM → write across multiple awaits; two concurrent
+ *  invocations (e.g. a double-clicked button or two open Options tabs)
+ *  could both pass the existence check before either completes the
+ *  write. We funnel every call through this module-level lock so the
+ *  second caller awaits the first and then re-reads storage — its
+ *  existence check will trip and throw, surfacing the duplicate-click
+ *  as a typed error in the UI rather than a silently overwritten key. */
+let generateInFlight: Promise<IdentitySnapshot> | null = null;
+
 function createIdentityFacade(): IdentityFacade {
   return {
     async load(): Promise<IdentitySnapshot | null> {
@@ -188,37 +198,71 @@ function createIdentityFacade(): IdentityFacade {
       }
     },
     async generate(): Promise<IdentitySnapshot> {
-      // Refuse to clobber an existing identity. The UI confirms the
-      // destructive regenerate path via a dialog and calls `clear()`
-      // FIRST — by the time we land here the storage should be empty.
-      const existing = (await chrome.storage.local.get([
-        IDENTITY_KEY,
-        IDENTITY_SECRET_KEY,
-      ])) as Record<string, unknown>;
-      if (
-        existing[IDENTITY_KEY] !== undefined ||
-        existing[IDENTITY_SECRET_KEY] !== undefined
-      ) {
-        throw new Error(
-          "Refusing to overwrite existing identity — clear it first",
-        );
+      // SA-T25-002: serialise concurrent generate() calls so the
+      // read → check → write sequence is observed atomically. A second
+      // caller awaits the first; after the first resolves, the second
+      // re-runs the existence check and throws because the now-stored
+      // keypair trips the clobber-guard. The lock is released in a
+      // finally{} so a thrown WASM init failure does not wedge future
+      // calls.
+      if (generateInFlight) {
+        await generateInFlight.catch(() => undefined);
       }
-      // WASM `generate_keypair` uses `getrandom`'s `js` feature →
-      // `crypto.getRandomValues`. CSPRNG-quality entropy. The base58
-      // pubkey is encoded inside the WASM boundary so we don't have to
-      // roll one here.
-      const { generateKeypair } = await import("../runtime/sign/cose.js");
-      const kp = await generateKeypair();
-      const created_at = Date.now();
-      await chrome.storage.local.set({
-        [IDENTITY_KEY]: { pubkey_base58: kp.pubkey_base58, created_at },
-        [IDENTITY_SECRET_KEY]: kp.secret,
-      });
-      return {
-        pubkey_base58: kp.pubkey_base58,
-        did: `did:sol:${kp.pubkey_base58}`,
-        created_at,
+      const run = async (): Promise<IdentitySnapshot> => {
+        // Refuse to clobber an existing identity. The UI confirms the
+        // destructive regenerate path via a dialog and calls `clear()`
+        // FIRST — by the time we land here the storage should be empty.
+        const existing = (await chrome.storage.local.get([
+          IDENTITY_KEY,
+          IDENTITY_SECRET_KEY,
+        ])) as Record<string, unknown>;
+        if (
+          existing[IDENTITY_KEY] !== undefined ||
+          existing[IDENTITY_SECRET_KEY] !== undefined
+        ) {
+          throw new Error(
+            "Refusing to overwrite existing identity — clear it first",
+          );
+        }
+        // WASM `generate_keypair` uses `getrandom`'s `js` feature →
+        // `crypto.getRandomValues`. CSPRNG-quality entropy. The base58
+        // pubkey is encoded inside the WASM boundary so we don't have to
+        // roll one here.
+        const { generateKeypair } = await import("../runtime/sign/cose.js");
+        const kp = await generateKeypair();
+        // SA-T25-004: mirror the byte-range normalisation that
+        // importPlain / exportPlain perform so all three storage-write
+        // paths share the same invariant. `generateKeypair` already
+        // validates internally — this is defence-in-depth against a
+        // future binding swap that bypasses the cose.ts normalisation.
+        if (!Array.isArray(kp.secret) || kp.secret.length !== 64) {
+          throw new Error("generate: WASM returned a malformed secret");
+        }
+        const normalisedSecret: number[] = [];
+        for (const n of kp.secret) {
+          const num = typeof n === "number" ? n : Number(n);
+          if (!Number.isInteger(num) || num < 0 || num > 255) {
+            throw new Error("generate: WASM returned a non-byte value");
+          }
+          normalisedSecret.push(num);
+        }
+        const created_at = Date.now();
+        await chrome.storage.local.set({
+          [IDENTITY_KEY]: { pubkey_base58: kp.pubkey_base58, created_at },
+          [IDENTITY_SECRET_KEY]: normalisedSecret,
+        });
+        return {
+          pubkey_base58: kp.pubkey_base58,
+          did: `did:sol:${kp.pubkey_base58}`,
+          created_at,
+        };
       };
+      generateInFlight = run();
+      try {
+        return await generateInFlight;
+      } finally {
+        generateInFlight = null;
+      }
     },
     async clear(): Promise<void> {
       // Best-effort: chrome.storage.local.remove is idempotent for

--- a/packages/extension/src/options/runtime-impl.ts
+++ b/packages/extension/src/options/runtime-impl.ts
@@ -43,6 +43,7 @@ import {
   jwtExpiresAtMs,
 } from "../auth/session.js";
 import { ensureExtensionJwt } from "../auth/extension-bootstrap.js";
+import { IDENTITY_KEY, IDENTITY_SECRET_KEY } from "../auth/storage-keys.js";
 import type { Session } from "../auth/types.js";
 import type {
   AuthFacade,
@@ -65,13 +66,12 @@ import type {
 export const PLAIN_EXPORT_WARNING =
   "Never share this file — anyone with it controls your identity. Store it in a password manager.";
 
-/** chrome.storage.local key the popup + options runtimes share for the
- *  `{pubkey_base58, created_at?}` blob. Mirrors `runtime-impl.ts`'s
- *  `loadIdentity` reader in the popup realm (T25 single source of
- *  truth). Re-exported via the IdentityFacade — components do NOT
- *  reach into chrome.storage directly. */
-export const IDENTITY_KEY = "identity";
-export const IDENTITY_SECRET_KEY = "identity_secret";
+/** chrome.storage.local keys the popup + options runtimes share for
+ *  the `{pubkey_base58, created_at?}` + 64-byte secret pair. The
+ *  canonical definitions now live in `src/auth/storage-keys.ts` —
+ *  re-export here for callers that still depend on the old import
+ *  path (PR136-C-01 / SA-T25-003). */
+export { IDENTITY_KEY, IDENTITY_SECRET_KEY } from "../auth/storage-keys.js";
 
 /** Lightweight base58 (Bitcoin alphabet) validator. The full base58
  *  decode is not needed here — we just sanity-check that every
@@ -397,11 +397,10 @@ function createCloudSyncFacade(): CloudSyncFacade {
       // bundle stays small — only the Storage section migration flow
       // pays the cost.
       try {
-        const stored = (await chrome.storage.local.get(["identity"])) as Record<
-          string,
-          unknown
-        >;
-        const identity = stored.identity as
+        const stored = (await chrome.storage.local.get([
+          IDENTITY_KEY,
+        ])) as Record<string, unknown>;
+        const identity = stored[IDENTITY_KEY] as
           | { pubkey_base58?: string }
           | undefined;
         if (!identity?.pubkey_base58) return 0;
@@ -426,11 +425,10 @@ function createCloudSyncFacade(): CloudSyncFacade {
       // the SW alarm-driven `drainPendingUploads` (`background/
       // cloud-sync.ts`) flushes them on the next tick.
       try {
-        const stored = (await chrome.storage.local.get(["identity"])) as Record<
-          string,
-          unknown
-        >;
-        const identity = stored.identity as
+        const stored = (await chrome.storage.local.get([
+          IDENTITY_KEY,
+        ])) as Record<string, unknown>;
+        const identity = stored[IDENTITY_KEY] as
           | { pubkey_base58?: string }
           | undefined;
         if (!identity?.pubkey_base58) return;
@@ -503,11 +501,11 @@ function createCloudSyncFacade(): CloudSyncFacade {
       // Cloud → Local archive: bundle every local row as JSON. The COSE
       // bytes are emitted as base64 so the archive is JSON-clean. The
       // Storage section triggers a download of the returned bytes.
-      const stored = (await chrome.storage.local.get(["identity"])) as Record<
+      const stored = (await chrome.storage.local.get([IDENTITY_KEY])) as Record<
         string,
         unknown
       >;
-      const identity = stored.identity as
+      const identity = stored[IDENTITY_KEY] as
         | { pubkey_base58?: string }
         | undefined;
       if (!identity?.pubkey_base58) {

--- a/packages/extension/src/options/sections/Identity.tsx
+++ b/packages/extension/src/options/sections/Identity.tsx
@@ -124,6 +124,13 @@ export function Identity(props: IdentityProps = {}): JSX.Element {
       showToast("No identity to export.", "error");
       return;
     }
+    // SA-T25-001: gate the unencrypted-private-key download behind the
+    // same ConfirmFn seam regenerate + import-overwrite use, so an
+    // accidental click does not write the cleartext keypair to disk.
+    const ok = confirm(
+      "Download unencrypted private key file? Anyone with this file controls your identity. Keep it in your password manager.",
+    );
+    if (!ok) return;
     try {
       const payload = await getOptionsRuntime().identity.exportPlain();
       const json = JSON.stringify(payload, null, 2);
@@ -140,7 +147,7 @@ export function Identity(props: IdentityProps = {}): JSX.Element {
         "error",
       );
     }
-  }, [identity, showToast]);
+  }, [identity, confirm, showToast]);
 
   // ── T25: Plain import ─────────────────────────────────────────────────
   const onImportPlainFile = useCallback(

--- a/packages/extension/src/popup/Onboarding.tsx
+++ b/packages/extension/src/popup/Onboarding.tsx
@@ -25,6 +25,7 @@ import type {
   LookupResult,
   Session,
 } from "../auth/types.js";
+import { IDENTITY_KEY, IDENTITY_SECRET_KEY } from "../auth/storage-keys.js";
 import { Restore } from "./onboarding/Restore.js";
 import { SetPassphrase } from "./onboarding/SetPassphrase.js";
 
@@ -351,20 +352,21 @@ async function loadLocalKeypair(): Promise<{
   pubkey_base58: string;
   secret: Uint8Array;
 } | null> {
-  let stored: {
-    identity?: { pubkey_base58?: string } | null;
-    identity_secret?: number[] | null;
-  } = {};
+  let stored: Record<string, unknown> = {};
   try {
     stored = (await chrome.storage.local.get([
-      "identity",
-      "identity_secret",
-    ])) as typeof stored;
+      IDENTITY_KEY,
+      IDENTITY_SECRET_KEY,
+    ])) as Record<string, unknown>;
   } catch {
     return null;
   }
-  const pub = stored.identity?.pubkey_base58;
-  const sec = stored.identity_secret;
+  const identity = stored[IDENTITY_KEY] as
+    | { pubkey_base58?: string }
+    | null
+    | undefined;
+  const pub = identity?.pubkey_base58;
+  const sec = stored[IDENTITY_SECRET_KEY] as number[] | null | undefined;
   if (!pub || !Array.isArray(sec) || sec.length === 0) return null;
   return { pubkey_base58: pub, secret: Uint8Array.from(sec) };
 }
@@ -396,8 +398,8 @@ async function mintAndPersistKeypair(): Promise<{
   // by re-opening the popup — the new keypair is on disk and the
   // welcome-back branch will pick it up.
   await chrome.storage.local.set({
-    identity: { pubkey_base58: kp.pubkey_base58, created_at },
-    identity_secret: kp.secret,
+    [IDENTITY_KEY]: { pubkey_base58: kp.pubkey_base58, created_at },
+    [IDENTITY_SECRET_KEY]: kp.secret,
   });
   return {
     pubkey_base58: kp.pubkey_base58,

--- a/packages/extension/src/popup/Onboarding.tsx
+++ b/packages/extension/src/popup/Onboarding.tsx
@@ -371,6 +371,24 @@ async function loadLocalKeypair(): Promise<{
   return { pubkey_base58: pub, secret: Uint8Array.from(sec) };
 }
 
+/** PR136-C-07: typed error raised by `mintAndPersistKeypair` when
+ *  chrome.storage.local is in a partial-identity state (one of
+ *  `identity` / `identity_secret` present, the other missing).
+ *  `loadLocalKeypair` returns null in that case, which would normally
+ *  drive the fresh-user mint branch — but minting would silently
+ *  overwrite the existing public-half row and invalidate any
+ *  attestations the user already signed under that pubkey. We surface
+ *  this as a typed error so the orchestrator routes to the error step
+ *  and the user can recover the missing half (e.g. via Restore on a
+ *  paired device, or by clearing the partial state on the Options
+ *  page). */
+export class PartialIdentityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "PartialIdentityError";
+  }
+}
+
 /** T25 — mint a fresh Ed25519 keypair via the WASM `generate_keypair`
  *  export and persist it to `chrome.storage.local` under the canonical
  *  `identity` / `identity_secret` keys. Mirrors
@@ -384,11 +402,32 @@ async function loadLocalKeypair(): Promise<{
  *
  *  The returned `secret` is a `Uint8Array` (matching `loadLocalKeypair`'s
  *  contract) so the caller can keep the wipe-on-unmount discipline
- *  Onboarding already enforces for the `set_passphrase` step. */
+ *  Onboarding already enforces for the `set_passphrase` step.
+ *
+ *  PR136-C-07 (round-2): mirrors the partial-state guard in
+ *  `options/runtime-impl.ts::generate`. Refuses to write when either
+ *  key is already present in chrome.storage.local so the autogen path
+ *  can never silently clobber a half-populated identity row. */
 async function mintAndPersistKeypair(): Promise<{
   pubkey_base58: string;
   secret: Uint8Array;
 }> {
+  // Read both canonical keys first. We refuse the write if EITHER is
+  // present so a future code path that ends up here with a populated
+  // (but unreadable) public-half row cannot overwrite the linked
+  // pubkey. The caller surfaces the typed error in the error step.
+  const existing = (await chrome.storage.local.get([
+    IDENTITY_KEY,
+    IDENTITY_SECRET_KEY,
+  ])) as Record<string, unknown>;
+  if (
+    existing[IDENTITY_KEY] !== undefined ||
+    existing[IDENTITY_SECRET_KEY] !== undefined
+  ) {
+    throw new PartialIdentityError(
+      "Refusing to autogen a keypair — chrome.storage.local already has a partial identity row. Clear it via Options → Identity before re-signing in.",
+    );
+  }
   const { generateKeypair } = await import("../runtime/sign/cose.js");
   const kp = await generateKeypair();
   const created_at = Date.now();

--- a/packages/extension/src/popup/onboarding/Restore.tsx
+++ b/packages/extension/src/popup/onboarding/Restore.tsx
@@ -51,6 +51,7 @@ import {
   WrongPassphraseError,
   type EscrowBlob,
 } from "../../auth/key-escrow.js";
+import { IDENTITY_KEY, IDENTITY_SECRET_KEY } from "../../auth/storage-keys.js";
 import { getRuntime } from "../runtime.js";
 
 /** Persistent block budget (T17 task spec § Restore UX). After 5 wrong
@@ -67,14 +68,12 @@ export const RESTORE_BLOCKED_KEY = "restore_blocked_until";
  *  successful restore. */
 export const RESTORE_ATTEMPT_KEY = "restore_attempt_count";
 
-/** chrome.storage.local keys for the persisted keypair after restore.
- *  Mirror the layout `popup/runtime-impl.ts::loadIdentity` reads —
- *  `identity = {pubkey_base58}` (public metadata) and `identity_secret`
- *  (64-byte Solana keypair as a number[]; structured-clone-safe). Using
- *  a separate key for the secret matches the rest of the popup runtime
- *  and avoids breaking `signMemory`. */
-export const IDENTITY_STORAGE_KEY = "identity";
-export const IDENTITY_SECRET_STORAGE_KEY = "identity_secret";
+// chrome.storage.local keys for the persisted keypair after restore.
+// Mirror the layout `popup/runtime-impl.ts::loadIdentity` reads:
+//   `identity = {pubkey_base58}` (public metadata) and `identity_secret`
+//   (64-byte Solana keypair as a number[]; structured-clone-safe).
+// The canonical definitions live in `src/auth/storage-keys.ts` (PR136-C-01
+// / SA-T25-003) — Restore consumes them directly from there.
 
 /** Truncate a base58 pubkey for the welcome-back headline ("H8x...c4v"). */
 export function truncatePubkey(pub: string, head = 6, tail = 4): string {
@@ -447,8 +446,8 @@ export function Restore(props: RestoreProps): JSX.Element {
         // unavoidable; see the THREAT MODEL block in `key-escrow.ts`.
         const secretArray = Array.from(secret);
         await storage.set({
-          [IDENTITY_STORAGE_KEY]: { pubkey_base58: existingPubkey },
-          [IDENTITY_SECRET_STORAGE_KEY]: secretArray,
+          [IDENTITY_KEY]: { pubkey_base58: existingPubkey },
+          [IDENTITY_SECRET_KEY]: secretArray,
         });
         // Best-effort wipe of the recovered bytes. JS gives no
         // guarantee — see the THREAT MODEL note in `key-escrow.ts`.

--- a/packages/extension/src/popup/runtime-impl.ts
+++ b/packages/extension/src/popup/runtime-impl.ts
@@ -4,6 +4,7 @@
 // for the action it triggers (sign / recall / verify) and nothing more.
 
 import { IndexedDbStore } from "../runtime/store/indexeddb.js";
+import { IDENTITY_KEY, IDENTITY_SECRET_KEY } from "../auth/storage-keys.js";
 import type { AttestationRow, SearchResult } from "../runtime/store/types.js";
 import type {
   SignMemoryArgs,
@@ -198,20 +199,21 @@ async function loadIdentity(): Promise<FullIdentity | null> {
   // against a truncated `identity_secret` write — Solana keypairs are
   // 64 bytes (32-byte seed || 32-byte pubkey); anything else is bogus
   // and would produce malformed signatures if we let it through.
-  let stored: {
-    identity?: { pubkey_base58?: string } | null;
-    identity_secret?: number[] | null;
-  } = {};
+  let stored: Record<string, unknown> = {};
   try {
     stored = (await chrome.storage.local.get([
-      "identity",
-      "identity_secret",
-    ])) as typeof stored;
+      IDENTITY_KEY,
+      IDENTITY_SECRET_KEY,
+    ])) as Record<string, unknown>;
   } catch {
     return null;
   }
-  const pub = stored.identity?.pubkey_base58;
-  const sec = stored.identity_secret;
+  const identity = stored[IDENTITY_KEY] as
+    | { pubkey_base58?: string }
+    | null
+    | undefined;
+  const pub = identity?.pubkey_base58;
+  const sec = stored[IDENTITY_SECRET_KEY] as number[] | null | undefined;
   if (!pub || !Array.isArray(sec) || sec.length !== 64) return null;
   return { pubkey_base58: pub, secret: sec };
 }

--- a/packages/extension/src/popup/runtime.ts
+++ b/packages/extension/src/popup/runtime.ts
@@ -24,6 +24,7 @@ import type {
 // Sync JWT-parsing helper — exposed on the runtime facade so popup
 // components don't import `auth/session.ts` directly (M3 / AUD-C-08).
 import { jwtExpiresAtMs as syncJwtExpiresAtMs } from "../auth/session.js";
+import { IDENTITY_KEY } from "../auth/storage-keys.js";
 
 /** Re-export of `RecallRemoteHit` so popup callers depend on the
  *  facade rather than reaching into `runtime/sync/cloud-client.ts`. */
@@ -274,10 +275,11 @@ export function getRuntime(): PopupRuntime {
 export function createDefaultRuntime(): PopupRuntime {
   return {
     async loadIdentity() {
-      const stored = await readChromeStorage<{
-        identity?: PopupIdentity | null;
-      }>("local", ["identity"]);
-      return stored.identity ?? null;
+      const stored = await readChromeStorage<Record<string, unknown>>("local", [
+        IDENTITY_KEY,
+      ]);
+      const identity = stored[IDENTITY_KEY] as PopupIdentity | null | undefined;
+      return identity ?? null;
     },
     async loadStorageTier() {
       const stored = await readChromeStorage<{

--- a/packages/extension/tests/component/options/Identity.export.test.tsx
+++ b/packages/extension/tests/component/options/Identity.export.test.tsx
@@ -114,7 +114,11 @@ describe("Identity section — T25 plain export", () => {
       // 12-char base58 pubkey so the truncation rule fires (head=6,
       // tail=4 → "PubKey…0xAB").
       setOptionsRuntime(makeRuntime({ pubkey: "PubKeyAA0xAB" }));
-      render(<Identity />);
+      // SA-T25-001: Export now goes through the confirm seam. Accept
+      // the dialog so the download path runs; the separate cancel test
+      // below locks the false-return path.
+      const confirm = vi.fn<[string], boolean>().mockReturnValue(true);
+      render(<Identity confirm={confirm} />);
       await screen.findByText("did:sol:PubKeyAA0xAB");
 
       fireEvent.click(screen.getByRole("button", { name: /^Export$/ }));
@@ -146,6 +150,53 @@ describe("Identity section — T25 plain export", () => {
       expect(
         await screen.findByText(/Keypair downloaded\./i),
       ).toBeInTheDocument();
+    } finally {
+      triggerSpy.mockRestore();
+    }
+  });
+
+  it("export_confirm_dialog_fires_before_download_and_cancel_keeps_keypair_on_disk", async () => {
+    // SA-T25-001: an accidental click on Export must NOT silently write
+    // the cleartext keypair to disk. The component gates the download
+    // behind the same ConfirmFn seam regenerate + import-overwrite use.
+    const triggerSpy = vi
+      .spyOn(downloadModule, "triggerDownload")
+      .mockImplementation(() => undefined);
+    try {
+      setOptionsRuntime(makeRuntime({ pubkey: "PubKeyAA0xAB" }));
+      const confirm = vi.fn<[string], boolean>().mockReturnValue(false);
+      render(<Identity confirm={confirm} />);
+      await screen.findByText("did:sol:PubKeyAA0xAB");
+
+      fireEvent.click(screen.getByRole("button", { name: /^Export$/ }));
+
+      // Drain microtasks so any pending onClick fully resolves.
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(confirm).toHaveBeenCalledTimes(1);
+      // The confirm copy explicitly names "unencrypted private key" so
+      // a future copy-edit that softens the language trips the test.
+      expect(confirm.mock.calls[0]![0]).toMatch(/unencrypted private key/i);
+      expect(triggerSpy).not.toHaveBeenCalled();
+    } finally {
+      triggerSpy.mockRestore();
+    }
+  });
+
+  it("export_confirm_dialog_accept_proceeds_to_download", async () => {
+    const triggerSpy = vi
+      .spyOn(downloadModule, "triggerDownload")
+      .mockImplementation(() => undefined);
+    try {
+      setOptionsRuntime(makeRuntime({ pubkey: "PubKeyAA0xAB" }));
+      const confirm = vi.fn<[string], boolean>().mockReturnValue(true);
+      render(<Identity confirm={confirm} />);
+      await screen.findByText("did:sol:PubKeyAA0xAB");
+
+      fireEvent.click(screen.getByRole("button", { name: /^Export$/ }));
+
+      await waitFor(() => expect(triggerSpy).toHaveBeenCalledTimes(1));
+      expect(confirm).toHaveBeenCalledTimes(1);
     } finally {
       triggerSpy.mockRestore();
     }

--- a/packages/extension/tests/component/popup/Onboarding.autogenIdentity.test.tsx
+++ b/packages/extension/tests/component/popup/Onboarding.autogenIdentity.test.tsx
@@ -28,9 +28,9 @@ import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import { Onboarding } from "../../../src/popup/Onboarding.js";
 import { setRuntime, type PopupRuntime } from "../../../src/popup/runtime.js";
 import {
-  IDENTITY_STORAGE_KEY,
-  IDENTITY_SECRET_STORAGE_KEY,
-} from "../../../src/popup/onboarding/Restore.js";
+  IDENTITY_KEY,
+  IDENTITY_SECRET_KEY,
+} from "../../../src/auth/storage-keys.js";
 import { __setWasmForTesting } from "../../../src/runtime/sign/cose.js";
 import type {
   GoogleSignInResult,
@@ -176,8 +176,8 @@ describe("Onboarding — T25 auto-generate identity on fresh sign-in", () => {
     installWasmStubWithGenerate(FRESH_PUBKEY);
 
     // Sanity: storage starts empty.
-    expect(store.has(IDENTITY_STORAGE_KEY)).toBe(false);
-    expect(store.has(IDENTITY_SECRET_STORAGE_KEY)).toBe(false);
+    expect(store.has(IDENTITY_KEY)).toBe(false);
+    expect(store.has(IDENTITY_SECRET_KEY)).toBe(false);
 
     const signIn = vi
       .fn<[], Promise<GoogleSignInResult>>()
@@ -210,12 +210,12 @@ describe("Onboarding — T25 auto-generate identity on fresh sign-in", () => {
     );
 
     // chrome.storage.local now holds the canonical identity layout.
-    const identity = store.get(IDENTITY_STORAGE_KEY) as
+    const identity = store.get(IDENTITY_KEY) as
       | { pubkey_base58?: string; created_at?: number }
       | undefined;
     expect(identity?.pubkey_base58).toBe(FRESH_PUBKEY);
     expect(typeof identity?.created_at).toBe("number");
-    const secret = store.get(IDENTITY_SECRET_STORAGE_KEY);
+    const secret = store.get(IDENTITY_SECRET_KEY);
     expect(Array.isArray(secret)).toBe(true);
     expect((secret as number[]).length).toBe(64);
     // Sanity check on the byte range — keep a structured-clone bug

--- a/packages/extension/tests/component/popup/Onboarding.autogenIdentity.test.tsx
+++ b/packages/extension/tests/component/popup/Onboarding.autogenIdentity.test.tsx
@@ -311,6 +311,70 @@ describe("Onboarding — T25 auto-generate identity on fresh sign-in", () => {
     expect(store.get(IDENTITY_SECRET_KEY)).toEqual(preSeededSecret);
   });
 
+  // PR136-C-07: partial-state guard. `loadLocalKeypair` returns null
+  // when either canonical key is missing (the other may be present
+  // from a previous half-completed flow). The pre-T25-round-2
+  // mintAndPersistKeypair would silently overwrite the surviving
+  // public-half row, invalidating any attestations signed under it.
+  // The guard now throws a PartialIdentityError; the orchestrator
+  // surfaces it as a typed error step.
+  it("refuses to autogen when only the public-half row is present in storage", async () => {
+    const { store } = installChromeStub();
+    // Pre-seed ONLY the public-half row. The secret is missing, so
+    // loadLocalKeypair returns null and the fresh-user mint branch
+    // runs — but the guard MUST trip before the WASM call.
+    store.set(IDENTITY_KEY, {
+      pubkey_base58: "OrphanedPubkey0xDEAD",
+      created_at: 1700000000000,
+    });
+
+    const generateKeypairSpy = vi.fn(() => ({
+      pubkey_base58: "SHOULD_NOT_BE_USED",
+      secret: Array.from({ length: 64 }, () => 0),
+    }));
+    __setWasmForTesting({
+      default: () => Promise.resolve(undefined),
+      generate_keypair: generateKeypairSpy,
+      sign_challenge: () => new Uint8Array(64),
+      sign_cose_payload: () => new Uint8Array([0x84]),
+      import_keypair_json: () => ({}),
+      export_keypair_json: () => "{}",
+      compress_embedding: () => new Uint8Array(0),
+      decompress_embedding: () => new Float32Array(0),
+      to_canonical_cbor_bytes: () => new Uint8Array(0),
+      blake3_hash: () => new Uint8Array(32),
+      blake3_hash_hex: () => "00".repeat(32),
+    } as unknown as Parameters<typeof __setWasmForTesting>[0]);
+
+    const signIn = vi
+      .fn<[], Promise<GoogleSignInResult>>()
+      .mockResolvedValue(makeSignInResult());
+    const lookupExisting = vi
+      .fn<[string], Promise<LookupResult>>()
+      .mockResolvedValue({
+        existingPubkey: null,
+        escrowPresent: false,
+        linkChallenge: btoa("link-challenge-XYZ"),
+      });
+    setRuntime(makeRuntime({ signIn, lookupExisting }));
+
+    render(<Onboarding onComplete={() => undefined} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Sign in with Google/i }),
+    );
+
+    expect(
+      await screen.findByText(/keypair generation failed:.*partial identity/i),
+    ).toBeInTheDocument();
+    // WASM was never asked to mint.
+    expect(generateKeypairSpy).not.toHaveBeenCalled();
+    // The orphaned public-half row is untouched.
+    expect(
+      (store.get(IDENTITY_KEY) as { pubkey_base58: string }).pubkey_base58,
+    ).toBe("OrphanedPubkey0xDEAD");
+    expect(store.has(IDENTITY_SECRET_KEY)).toBe(false);
+  });
+
   it("surfaces a typed error when generate_keypair throws", async () => {
     installChromeStub();
     // Wasm stub whose generate_keypair throws synchronously — the

--- a/packages/extension/tests/component/popup/Onboarding.autogenIdentity.test.tsx
+++ b/packages/extension/tests/component/popup/Onboarding.autogenIdentity.test.tsx
@@ -227,6 +227,90 @@ describe("Onboarding — T25 auto-generate identity on fresh sign-in", () => {
     }
   });
 
+  // PR136-C-03: regression-lock the "do NOT autogen when a keypair
+  // already exists" half of the contract. The pre-T25 deadlock was on
+  // fresh-user storage; if a future commit inverts the conditional
+  // (e.g. `if (keypair)` instead of `if (!keypair)`), it would silently
+  // overwrite the existing keypair on every sign-in. This test fails
+  // loudly in that case.
+  it("does NOT regenerate the keypair when one already exists in storage", async () => {
+    const { store } = installChromeStub();
+    // Pre-seed canonical identity layout: a 64-byte secret + the
+    // public-half row. The auto-gen path must NOT touch either.
+    const PRE_SEEDED_PUBKEY = "PreSeededPubKey0xCAFE";
+    const preSeededSecret: number[] = [];
+    for (let i = 0; i < 64; i++) preSeededSecret.push((i * 7 + 3) & 0xff);
+    store.set(IDENTITY_KEY, {
+      pubkey_base58: PRE_SEEDED_PUBKEY,
+      created_at: 1700000000000,
+    });
+    store.set(IDENTITY_SECRET_KEY, preSeededSecret);
+
+    // Install a WASM stub that would surface a different pubkey if the
+    // autogen path fires by mistake — the assertion compares the
+    // stored pubkey against PRE_SEEDED_PUBKEY, so this drift is what
+    // makes the test definitive.
+    const generateKeypairSpy = vi.fn(() => ({
+      pubkey_base58: "SHOULD_NOT_BE_USED",
+      secret: Array.from({ length: 64 }, () => 0),
+    }));
+    __setWasmForTesting({
+      default: () => Promise.resolve(undefined),
+      generate_keypair: generateKeypairSpy,
+      sign_challenge: () => new Uint8Array(64),
+      sign_cose_payload: () => new Uint8Array([0x84]),
+      import_keypair_json: () => ({}),
+      export_keypair_json: () => "{}",
+      compress_embedding: () => new Uint8Array(0),
+      decompress_embedding: () => new Float32Array(0),
+      to_canonical_cbor_bytes: () => new Uint8Array(0),
+      blake3_hash: () => new Uint8Array(32),
+      blake3_hash_hex: () => "00".repeat(32),
+    } as unknown as Parameters<typeof __setWasmForTesting>[0]);
+
+    const signIn = vi
+      .fn<[], Promise<GoogleSignInResult>>()
+      .mockResolvedValue(makeSignInResult());
+    // Fresh-user branch (existingPubkey === null) — exactly the branch
+    // that triggers mintAndPersistKeypair in the pre-T25 contract. The
+    // guard prevents autogen ONLY when storage already has a keypair.
+    const lookupExisting = vi
+      .fn<[string], Promise<LookupResult>>()
+      .mockResolvedValue({
+        existingPubkey: null,
+        escrowPresent: false,
+        linkChallenge: btoa("link-challenge-XYZ"),
+      });
+    setRuntime(makeRuntime({ signIn, lookupExisting }));
+
+    render(<Onboarding onComplete={() => undefined} />);
+    fireEvent.click(
+      screen.getByRole("button", { name: /Sign in with Google/i }),
+    );
+
+    // Wait until the flow reaches SetPassphrase so we know the
+    // orchestrator has finished its sign-in branch.
+    await waitFor(
+      () => {
+        expect(
+          screen.queryByText(/Set recovery passphrase/i),
+        ).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
+
+    // The stored values are byte-identical to the pre-seeded ones —
+    // mintAndPersistKeypair did NOT fire.
+    expect(generateKeypairSpy).not.toHaveBeenCalled();
+    const identity = store.get(IDENTITY_KEY) as {
+      pubkey_base58?: string;
+      created_at?: number;
+    };
+    expect(identity.pubkey_base58).toBe(PRE_SEEDED_PUBKEY);
+    expect(identity.created_at).toBe(1700000000000);
+    expect(store.get(IDENTITY_SECRET_KEY)).toEqual(preSeededSecret);
+  });
+
   it("surfaces a typed error when generate_keypair throws", async () => {
     installChromeStub();
     // Wasm stub whose generate_keypair throws synchronously — the

--- a/packages/extension/tests/component/popup/Onboarding.test.tsx
+++ b/packages/extension/tests/component/popup/Onboarding.test.tsx
@@ -34,9 +34,9 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { Onboarding } from "../../../src/popup/Onboarding.js";
 import { setRuntime, type PopupRuntime } from "../../../src/popup/runtime.js";
 import {
-  IDENTITY_STORAGE_KEY,
-  IDENTITY_SECRET_STORAGE_KEY,
-} from "../../../src/popup/onboarding/Restore.js";
+  IDENTITY_KEY,
+  IDENTITY_SECRET_KEY,
+} from "../../../src/auth/storage-keys.js";
 import { __setWasmForTesting } from "../../../src/runtime/sign/cose.js";
 import type {
   GoogleSignInResult,
@@ -231,8 +231,8 @@ describe("Onboarding — fresh user (no existingPubkey)", () => {
     // requires a local keypair before mounting <SetPassphrase>.
     const secretBytes = makeSecret();
     installChromeStub({
-      [IDENTITY_STORAGE_KEY]: { pubkey_base58: PRESEEDED_PUBKEY },
-      [IDENTITY_SECRET_STORAGE_KEY]: Array.from(secretBytes),
+      [IDENTITY_KEY]: { pubkey_base58: PRESEEDED_PUBKEY },
+      [IDENTITY_SECRET_KEY]: Array.from(secretBytes),
     });
 
     const signIn = vi
@@ -370,8 +370,8 @@ describe("Onboarding — fresh user (no existingPubkey)", () => {
 
   it("surfaces a typed error and stays signed-out when no linkChallenge is issued", async () => {
     installChromeStub({
-      [IDENTITY_STORAGE_KEY]: { pubkey_base58: PRESEEDED_PUBKEY },
-      [IDENTITY_SECRET_STORAGE_KEY]: Array.from(makeSecret()),
+      [IDENTITY_KEY]: { pubkey_base58: PRESEEDED_PUBKEY },
+      [IDENTITY_SECRET_KEY]: Array.from(makeSecret()),
     });
     setRuntime(
       makeRuntime({
@@ -475,10 +475,10 @@ describe("Onboarding — welcome back (existingPubkey + escrowPresent)", () => {
     // chrome.storage.local.set received both the `identity` metadata
     // and the `identity_secret` array (mirrors the layout
     // `runtime-impl.ts::loadIdentity` reads).
-    const persistedIdentity = store.get(IDENTITY_STORAGE_KEY) as
+    const persistedIdentity = store.get(IDENTITY_KEY) as
       | { pubkey_base58: string }
       | undefined;
-    const persistedSecret = store.get(IDENTITY_SECRET_STORAGE_KEY) as
+    const persistedSecret = store.get(IDENTITY_SECRET_KEY) as
       | number[]
       | undefined;
     expect(persistedIdentity).toBeDefined();

--- a/packages/extension/tests/component/popup/Restore.test.tsx
+++ b/packages/extension/tests/component/popup/Restore.test.tsx
@@ -18,11 +18,13 @@ import {
   BLOCK_WINDOW_MS,
   RESTORE_BLOCKED_KEY,
   RESTORE_ATTEMPT_KEY,
-  IDENTITY_STORAGE_KEY,
-  IDENTITY_SECRET_STORAGE_KEY,
   formatCountdown,
   truncatePubkey,
 } from "../../../src/popup/onboarding/Restore.js";
+import {
+  IDENTITY_KEY,
+  IDENTITY_SECRET_KEY,
+} from "../../../src/auth/storage-keys.js";
 import {
   ARGON2ID_SALT_LENGTH,
   AES_GCM_NONCE_LENGTH,
@@ -268,12 +270,10 @@ describe("Restore — happy path", () => {
     await waitFor(() => {
       expect(completed).toBe(true);
     });
-    const identity = store.get(IDENTITY_STORAGE_KEY) as
+    const identity = store.get(IDENTITY_KEY) as
       | { pubkey_base58: string }
       | undefined;
-    const secretArr = store.get(IDENTITY_SECRET_STORAGE_KEY) as
-      | number[]
-      | undefined;
+    const secretArr = store.get(IDENTITY_SECRET_KEY) as number[] | undefined;
     expect(identity).toBeDefined();
     expect(identity?.pubkey_base58).toBe("PubHappy");
     expect(secretArr).toBeDefined();
@@ -330,8 +330,8 @@ describe("Restore — pubkey mismatch (audit S2 / FW-S-02)", () => {
     // onComplete fired.
     expect(unwrapSpy).not.toHaveBeenCalled();
     expect(completed).toBe(false);
-    expect(store.get(IDENTITY_STORAGE_KEY)).toBeUndefined();
-    expect(store.get(IDENTITY_SECRET_STORAGE_KEY)).toBeUndefined();
+    expect(store.get(IDENTITY_KEY)).toBeUndefined();
+    expect(store.get(IDENTITY_SECRET_KEY)).toBeUndefined();
   });
 });
 

--- a/packages/extension/tests/unit/options/runtime-impl.identity.test.ts
+++ b/packages/extension/tests/unit/options/runtime-impl.identity.test.ts
@@ -1,0 +1,268 @@
+// T25 round-2 — direct unit tests for the IdentityFacade write paths.
+//
+// The component tests mock the entire runtime so they cannot lock the
+// production validator semantics. This file talks to
+// `createDefaultOptionsRuntime().identity` with a chrome.storage stub
+// so each validation branch in `importPlain` / `exportPlain` /
+// `generate` is regression-locked at the producer side:
+//
+//   - PR136-C-05: byte-range validation rejects a secret with a
+//     non-number element AND a number > 255 at a specific index.
+//   - PR136-C-04: the byte-range error message identifies the failure
+//     by index + range, not by misleading "secret length" prefix.
+//   - PR136-C-02: `importPlain` carries `exported_at` forward as
+//     `created_at` when it parses to a sensible past timestamp; falls
+//     back to Date.now() when missing / unparseable / absurdly future.
+//   - SA-T25-004: `generate` rejects a malformed WASM-returned secret
+//     before it reaches chrome.storage.
+//
+// The chrome.storage stub is a thin in-memory map so the assertions
+// can read back what the facade wrote.
+
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { createDefaultOptionsRuntime } from "../../../src/options/runtime-impl.js";
+import {
+  IDENTITY_KEY,
+  IDENTITY_SECRET_KEY,
+} from "../../../src/auth/storage-keys.js";
+import { __setWasmForTesting } from "../../../src/runtime/sign/cose.js";
+
+const VALID_BASE58_PUBKEY = "5MhYbm6Q1vN9zJZ7QcLwY4uG2Yk3rrgu1qB7L8Tk2pYn";
+
+function makeSecret(): number[] {
+  const out: number[] = [];
+  for (let i = 0; i < 64; i++) out.push((i * 13 + 7) & 0xff);
+  return out;
+}
+
+function installChromeStub(): {
+  store: Map<string, unknown>;
+  setSpy: ReturnType<typeof vi.fn>;
+} {
+  const store = new Map<string, unknown>();
+  const setSpy = vi.fn(async (items: Record<string, unknown>) => {
+    for (const [k, v] of Object.entries(items)) store.set(k, v);
+  });
+  (globalThis as { chrome?: unknown }).chrome = {
+    storage: {
+      local: {
+        get: async (keys: string | string[]) => {
+          const list = typeof keys === "string" ? [keys] : keys;
+          const out: Record<string, unknown> = {};
+          for (const k of list) {
+            if (store.has(k)) out[k] = store.get(k);
+          }
+          return out;
+        },
+        set: setSpy,
+        remove: async (keys: string | string[]) => {
+          const list = typeof keys === "string" ? [keys] : keys;
+          for (const k of list) store.delete(k);
+        },
+      },
+    },
+    runtime: { getManifest: () => ({ version: "0.0.0" }) },
+  };
+  return { store, setSpy };
+}
+
+describe("OptionsRuntime.identity.importPlain — validation matrix", () => {
+  let store: Map<string, unknown>;
+
+  beforeEach(() => {
+    ({ store } = installChromeStub());
+  });
+
+  // PR136-C-05: a hand-edited JSON with a non-number element in the
+  // secret array must be rejected BEFORE any chrome.storage.set call.
+  it("rejects a secret containing a non-number element with an index-locked error", async () => {
+    const runtime = createDefaultOptionsRuntime();
+    const badSecret = makeSecret();
+    // Replace index 5 with a non-numeric value the byte-range validator
+    // must detect. `Number("not-a-number")` yields NaN — fails the
+    // `Number.isInteger` guard — so the error message points at the
+    // exact offending index, not a generic length complaint.
+    (badSecret as unknown[])[5] = "not-a-number";
+    await expect(
+      runtime.identity.importPlain({
+        version: 1,
+        pubkey_base58: VALID_BASE58_PUBKEY,
+        secret: badSecret,
+        exported_at: "2026-05-11T00:00:00.000Z",
+        warning: "any",
+      }),
+    ).rejects.toThrow(/Invalid secret byte at index 5/);
+    expect(store.has(IDENTITY_KEY)).toBe(false);
+    expect(store.has(IDENTITY_SECRET_KEY)).toBe(false);
+  });
+
+  it("rejects a secret containing an object element with an index-locked error", async () => {
+    // Different non-number flavour: a plain object. Confirms the
+    // validator does not silently coerce structured values either.
+    const runtime = createDefaultOptionsRuntime();
+    const badSecret = makeSecret();
+    (badSecret as unknown[])[7] = { not: "a number" };
+    await expect(
+      runtime.identity.importPlain({
+        version: 1,
+        pubkey_base58: VALID_BASE58_PUBKEY,
+        secret: badSecret,
+      }),
+    ).rejects.toThrow(/Invalid secret byte at index 7/);
+  });
+
+  it("rejects a secret containing a value > 255 with the new byte-range message (PR136-C-04)", async () => {
+    const runtime = createDefaultOptionsRuntime();
+    const badSecret = makeSecret();
+    badSecret[12] = 256;
+    await expect(
+      runtime.identity.importPlain({
+        version: 1,
+        pubkey_base58: VALID_BASE58_PUBKEY,
+        secret: badSecret,
+      }),
+    ).rejects.toThrow(/Invalid secret byte at index 12/);
+    // The misleading "Wrong secret length:" prefix must NOT appear —
+    // the length check already passed by the time we reach byte-range.
+    await expect(
+      runtime.identity.importPlain({
+        version: 1,
+        pubkey_base58: VALID_BASE58_PUBKEY,
+        secret: badSecret,
+      }),
+    ).rejects.not.toThrow(/Wrong secret length: contains non-byte value/);
+    expect(store.has(IDENTITY_KEY)).toBe(false);
+  });
+
+  // PR136-C-02: exported_at must round-trip as created_at when valid.
+  it("forwards a valid ISO exported_at as created_at", async () => {
+    const runtime = createDefaultOptionsRuntime();
+    const exportedAt = "2025-01-15T12:00:00.000Z";
+    const expectedMs = new Date(exportedAt).getTime();
+    const snap = await runtime.identity.importPlain({
+      version: 1,
+      pubkey_base58: VALID_BASE58_PUBKEY,
+      secret: makeSecret(),
+      exported_at: exportedAt,
+      warning: "any",
+    });
+    expect(snap.created_at).toBe(expectedMs);
+    const stored = store.get(IDENTITY_KEY) as { created_at: number };
+    expect(stored.created_at).toBe(expectedMs);
+  });
+
+  it("falls back to Date.now() when exported_at is missing", async () => {
+    const runtime = createDefaultOptionsRuntime();
+    const before = Date.now();
+    const snap = await runtime.identity.importPlain({
+      version: 1,
+      pubkey_base58: VALID_BASE58_PUBKEY,
+      secret: makeSecret(),
+    });
+    const after = Date.now();
+    expect(snap.created_at).toBeGreaterThanOrEqual(before);
+    expect(snap.created_at).toBeLessThanOrEqual(after);
+  });
+
+  it("falls back to Date.now() when exported_at is an unparseable string", async () => {
+    const runtime = createDefaultOptionsRuntime();
+    const before = Date.now();
+    const snap = await runtime.identity.importPlain({
+      version: 1,
+      pubkey_base58: VALID_BASE58_PUBKEY,
+      secret: makeSecret(),
+      exported_at: "not-a-date",
+    });
+    expect(snap.created_at).toBeGreaterThanOrEqual(before);
+    expect(snap.created_at).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("falls back to Date.now() when exported_at is absurdly in the future", async () => {
+    const runtime = createDefaultOptionsRuntime();
+    // 10 days in the future — well past the 24h tolerance window.
+    const future = new Date(
+      Date.now() + 10 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    const before = Date.now();
+    const snap = await runtime.identity.importPlain({
+      version: 1,
+      pubkey_base58: VALID_BASE58_PUBKEY,
+      secret: makeSecret(),
+      exported_at: future,
+    });
+    expect(snap.created_at).toBeGreaterThanOrEqual(before);
+    expect(snap.created_at).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("accepts an epoch-ms number for exported_at", async () => {
+    const runtime = createDefaultOptionsRuntime();
+    const exportedMs = 1700000000000; // 2023-11-14
+    const snap = await runtime.identity.importPlain({
+      version: 1,
+      pubkey_base58: VALID_BASE58_PUBKEY,
+      secret: makeSecret(),
+      exported_at: exportedMs,
+    });
+    expect(snap.created_at).toBe(exportedMs);
+  });
+});
+
+describe("OptionsRuntime.identity.generate — SA-T25-004 storage invariants", () => {
+  beforeEach(() => {
+    installChromeStub();
+  });
+
+  // The cose.ts `generateKeypair` wrapper already validates the secret
+  // before returning, so a misbehaving WASM stub trips ITS guard
+  // first — the runtime-impl byte-range check is defence-in-depth
+  // against a future binding swap that bypasses cose.ts. These tests
+  // pin that the generate() facade rejects bad bytes EITHER way, so
+  // chrome.storage is never written with a malformed secret.
+  it("rejects a WASM-returned secret with a non-byte value", async () => {
+    __setWasmForTesting({
+      default: () => Promise.resolve(undefined),
+      generate_keypair: () => {
+        const bad = makeSecret();
+        (bad as unknown[])[3] = "x";
+        return { pubkey_base58: VALID_BASE58_PUBKEY, secret: bad };
+      },
+      sign_challenge: () => new Uint8Array(64),
+      sign_cose_payload: () => new Uint8Array([0x84]),
+      import_keypair_json: () => ({}),
+      export_keypair_json: () => "{}",
+      compress_embedding: () => new Uint8Array(0),
+      decompress_embedding: () => new Float32Array(0),
+      to_canonical_cbor_bytes: () => new Uint8Array(0),
+      blake3_hash: () => new Uint8Array(32),
+      blake3_hash_hex: () => "00".repeat(32),
+    } as unknown as Parameters<typeof __setWasmForTesting>[0]);
+    const runtime = createDefaultOptionsRuntime();
+    // Either guard (cose.ts upstream or runtime-impl defence) rejects.
+    await expect(runtime.identity.generate()).rejects.toThrow(/non-byte value/);
+    __setWasmForTesting(null);
+  });
+
+  it("rejects a WASM-returned secret with the wrong length", async () => {
+    __setWasmForTesting({
+      default: () => Promise.resolve(undefined),
+      generate_keypair: () => ({
+        pubkey_base58: VALID_BASE58_PUBKEY,
+        secret: [1, 2, 3], // way too short
+      }),
+      sign_challenge: () => new Uint8Array(64),
+      sign_cose_payload: () => new Uint8Array([0x84]),
+      import_keypair_json: () => ({}),
+      export_keypair_json: () => "{}",
+      compress_embedding: () => new Uint8Array(0),
+      decompress_embedding: () => new Float32Array(0),
+      to_canonical_cbor_bytes: () => new Uint8Array(0),
+      blake3_hash: () => new Uint8Array(32),
+      blake3_hash_hex: () => "00".repeat(32),
+    } as unknown as Parameters<typeof __setWasmForTesting>[0]);
+    const runtime = createDefaultOptionsRuntime();
+    await expect(runtime.identity.generate()).rejects.toThrow(
+      /secret of length 3, expected 64|malformed secret/,
+    );
+    __setWasmForTesting(null);
+  });
+});

--- a/work/chrome-extension/decisions.md
+++ b/work/chrome-extension/decisions.md
@@ -1931,3 +1931,34 @@ Round-2 test audit flagged TA-MIN2 (no `About` section test) and TA-MIN4 (no Ide
 | T24-T-03 | minor | `tests/unit/auth/key-escrow.fuzz.test.ts` | **fixed** — property reframed from "KDF determinism (which lives in the canonical `key-escrow.test.ts`)" to "round-trip identity over a fixed salt — the rotate invariant"; comments updated to describe what is actually verified. Determinism is implicit in the unwrap-succeeds assertion; the canonical determinism test is in `key-escrow.test.ts::deriveKey > is deterministic for (passphrase, salt)`. |
 
 Round-2 review: `status: passed`, 0 findings, 27/27 tests pass in 1.03s.
+
+## 2026-05-11 · T25 — Round-2 review fixes
+
+`code-reviewer-round1.json` (2 major + 6 minor) and `security-auditor-round1.json` (1 medium BLOCK + 3 low) returned `request-changes` / `BLOCK`. Reviewer reports at `work/chrome-extension/logs/working/pr-136/{code-reviewer,security-auditor}-round1.json`.
+
+| Finding | Severity | File | Resolution |
+| --- | --- | --- | --- |
+| SA-T25-001 | medium (BLOCK) | `src/options/sections/Identity.tsx` | **fixed** — `onExportPlain()` now calls `confirm("Download unencrypted private key file? …")` via the same ConfirmFn seam regenerate + import-overwrite use, before `triggerDownload`. Two new tests in `Identity.export.test.tsx` lock both branches (accept proceeds, cancel keeps the file off disk). |
+| PR136-C-01 / SA-T25-003 | major / low | three sites (popup, options, Restore) | **fixed** — created `src/auth/storage-keys.ts` exporting `IDENTITY_KEY = "identity"` + `IDENTITY_SECRET_KEY = "identity_secret"`. Every read/write site (popup/options runtime, content recall-overlay, Onboarding orchestrator, Restore, plus three test files) now imports from there. Removed the duplicate definitions and the legacy `IDENTITY_STORAGE_KEY` / `IDENTITY_SECRET_STORAGE_KEY` aliases. |
+| PR136-C-02 | major | `src/options/runtime-impl.ts::importPlain` | **fixed** — comment promised `exported_at` forwarding but code hardcoded `Date.now()`. Now parses `exported_at` (ISO string OR epoch-ms number), validates `Number.isFinite && > 0 && <= now + 24h tolerance`, and uses it as `created_at`. Falls back to `Date.now()` on any guard-trip. Six new unit tests cover the matrix (valid ISO, missing, unparseable, far-future, epoch-ms number, round-trip preserved). |
+| PR136-C-03 | major | `tests/component/popup/Onboarding.autogenIdentity.test.tsx` | **fixed** — added a new test that pre-seeds canonical `identity` + `identity_secret`, drives the fresh-user lookup branch, and asserts (a) `generate_keypair` mock NEVER called, (b) stored values byte-identical to pre-seed. Inverts cleanly to catch a future `if (keypair)` regression. |
+| PR136-C-04 | minor | `src/options/runtime-impl.ts::importPlain` | **fixed** — byte-range error message was "Wrong secret length: contains non-byte value" — but length is already confirmed 64 by that branch. Now reads "Invalid secret byte at index N: expected an integer in [0, 255]", identifying both failure mode AND offending index. |
+| PR136-C-05 | minor | `tests/unit/options/runtime-impl.identity.test.ts` (new) | **fixed** — added direct unit tests for the validator: non-number string at index 5, non-number object at index 7, value > 255 at index 12, each asserting the index-locked error AND that chrome.storage is never written. |
+| PR136-C-06 | minor | `src/options/runtime-impl.ts::isLikelyBase58` | **fixed** — replaced `BASE58_ALPHABET.indexOf(c) < 0` with `BASE58_SET.has(c)` on a module-scope `Set<string>`. O(1) per character vs prior O(58). |
+| PR136-C-07 | minor | `src/popup/Onboarding.tsx::mintAndPersistKeypair` | **fixed** — mirrored the partial-state guard from `IdentityFacade.generate`. Reads both canonical keys; throws `PartialIdentityError` if either is present rather than silently overwriting the orphaned half. New test in `Onboarding.autogenIdentity.test.tsx` pre-seeds only the public-half row and asserts WASM never fires + error step surfaces + stored values untouched. |
+| SA-T25-002 | low | `src/options/runtime-impl.ts::generate` | **fixed** — added module-level `generateInFlight: Promise<IdentitySnapshot> \| null` lock. A second concurrent call awaits the first; after release it re-runs the existence check and trips the clobber guard. Lock released in `finally{}` so a WASM init failure does not wedge future calls. |
+| SA-T25-004 | low | `src/options/runtime-impl.ts::generate` | **fixed** — mirrored the byte-range normalisation loop (`Number.isInteger && [0, 255]`) from `importPlain` / `exportPlain` so all three storage-write paths share the same invariant. Two new unit tests pin the defence-in-depth behaviour via stubbed WASM. |
+
+**Test results (worktree):**
+
+- `tests/component/options tests/component/popup tests/unit/options` — **124 / 124 pass** in 2.52s.
+- `tests/unit/options/runtime-impl.identity.test.ts` (new) — 10 / 10 pass in 4ms.
+- `tests/component/popup/Onboarding.autogenIdentity.test.tsx` — 4 / 4 pass (1 pre-existing happy + 1 pre-existing WASM-error + 1 new no-overwrite + 1 new partial-state guard).
+- `tests/component/options/Identity.export.test.tsx` — 5 / 5 pass (3 pre-existing + 2 new confirm-dialog branches).
+- `bun x vite build` — successful (`✓ built in 1.73s`).
+
+**Decision: drop the `IDENTITY_STORAGE_KEY` re-exports rather than keep them as backward-compat aliases.** The duplicate names were not imported by anything but the (now-migrated) tests, so carrying them forward would only invite a future drift. Any new consumer imports `IDENTITY_KEY` / `IDENTITY_SECRET_KEY` from `src/auth/storage-keys.ts` directly.
+
+**Decision: 24-hour clock-skew tolerance for `exported_at` forward.** A user who exports on a system with a slow clock could legitimately end up with an `exported_at` slightly in the future relative to the import-time clock. 24h is generous enough to cover NTP-stragglers without admitting a hand-edited "imported from the year 3000" envelope as the canonical `created_at`.
+
+**Decision: defence-in-depth on `generate` write-path even though `cose.ts::generateKeypair` already validates.** SA-T25-004 explicitly called out the inconsistency between `generate` and `importPlain` / `exportPlain`. The audit asks for the storage-layer invariant to be enforced regardless of upstream behaviour so a future binding swap that drops the cose.ts guard does not silently propagate bad bytes into chrome.storage. The two unit tests in `runtime-impl.identity.test.ts::generate` regex-match either error string (cose.ts upstream OR runtime-impl downstream) so neither layer can be removed without a test failure.


### PR DESCRIPTION
## Summary

Round-2 fixes for PR #136 (T25 — identity UX). Addresses every finding from both reviewers:

- `work/chrome-extension/logs/working/pr-136/code-reviewer-round1.json` — 2 major + 6 minor.
- `work/chrome-extension/logs/working/pr-136/security-auditor-round1.json` — 1 medium BLOCK + 3 low.

### Blocker fixed

- **SA-T25-001** (medium, BLOCK): `onExportPlain()` now gates the cleartext keypair download behind a `confirm("Download unencrypted private key file? …")` dialog via the same ConfirmFn seam the regenerate / import-overwrite paths use. Two new tests in `Identity.export.test.tsx` lock both branches.

### Major fixes

- **PR136-C-01 / SA-T25-003**: created `packages/extension/src/auth/storage-keys.ts` as the single source of truth for `IDENTITY_KEY` and `IDENTITY_SECRET_KEY`. Every read/write site (popup runtime, options runtime, content recall-overlay, Onboarding orchestrator, Restore, plus three test files) now imports from there. Removed the duplicate definitions and the legacy `IDENTITY_STORAGE_KEY` / `IDENTITY_SECRET_STORAGE_KEY` aliases.
- **PR136-C-02**: `importPlain` now forwards `exported_at` from the import envelope as `created_at` (accepts ISO strings and epoch-ms numbers, falls back to `Date.now()` for missing / unparseable / negative / absurdly-future values with a 24h clock-skew tolerance). Six unit tests cover the matrix.
- **PR136-C-03**: added a regression-lock test that pre-seeds canonical `identity` + `identity_secret`, drives the fresh-user lookup branch, and asserts the WASM `generate_keypair` mock is NEVER called and the pre-seeded values are byte-identical after the flow completes.

### Minor fixes

- **PR136-C-04**: byte-range error message now reads "Invalid secret byte at index N: expected an integer in [0, 255]" — identifies both the failure mode AND the offending index, instead of the misleading "Wrong secret length" prefix.
- **PR136-C-05**: new unit tests in `tests/unit/options/runtime-impl.identity.test.ts` cover the byte-range validation matrix (non-number string, non-number object, value > 255).
- **PR136-C-06**: `isLikelyBase58` uses a pre-computed `Set<string>` for O(1) membership in place of the O(58) `String.indexOf` scan.
- **PR136-C-07**: `mintAndPersistKeypair` mirrors the partial-state guard from `IdentityFacade.generate` — throws a typed `PartialIdentityError` when chrome.storage already has either canonical key, rather than silently overwriting a half-populated row.
- **SA-T25-002**: `generate()` now serialises concurrent calls via a module-level `generateInFlight: Promise | null` lock. A second caller awaits the first; after release it re-runs the existence check and trips the clobber guard. Lock released in `finally{}` so a WASM init failure does not wedge future calls.
- **SA-T25-004**: `generate()` mirrors the byte-range normalisation loop from `importPlain` / `exportPlain` so all three storage-write paths share the same invariant (defence-in-depth against a future binding swap that bypasses cose.ts).

## Test plan

- [x] `bun x vite build` — `✓ built in 1.73s`.
- [x] `tests/component/options tests/component/popup tests/unit/options` — 124 / 124 pass in 2.52s.
- [x] `tests/unit/options/runtime-impl.identity.test.ts` (new, 10 tests) — pass.
- [x] `tests/component/popup/Onboarding.autogenIdentity.test.tsx` — 4 / 4 pass (3 new branches: no-overwrite-when-keypair-exists, partial-state guard, plus pre-existing happy + WASM-error).
- [x] `tests/component/options/Identity.export.test.tsx` — 5 / 5 pass (2 new confirm-dialog branches).

## Notes

- Decisions log appended to `work/chrome-extension/decisions.md` under `## 2026-05-11 · T25 — Round-2 review fixes`.
- No new npm deps.
- No raw secret bytes logged.
- Five commits, one per logical group (storage-keys SoT / confirm + TOCTOU / importPlain forwarding / autogen no-op test / partial-state guard) plus a docs commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)