### PR TITLE
chore(cli): bump to 0.1.7 to release the browserless-OAuth fix

### DIFF
--- a/packages/cli/bin/mnemonic.ts
+++ b/packages/cli/bin/mnemonic.ts
@@ -45,9 +45,10 @@ export function buildProgram(): Command {
     .name("mnemonic")
     .description("Mnemonic Protocol CLI — verifiable persistent memory")
     // TODO: read from package.json at build/runtime so we don't have
-    // to hand-bump on every release. Hardcoded for 0.1.6 to ship the
-    // mode-flag fix today.
-    .version("0.1.6")
+    // to hand-bump on every release. Hardcoded for 0.1.7 — the
+    // browserless-OAuth fix (#27); 0.1.6 was tagged but never published
+    // to npm, so we skip to 0.1.7 to keep tag history monotonic.
+    .version("0.1.7")
     .option("--json", "machine-readable JSON output")
     .option("--quiet", "suppress non-essential output")
     .option("--no-color", "disable ANSI color")

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemonik-xyz/cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Command-line interface for the Mnemonic Protocol. Thin wrapper around @mnemonik-xyz/sdk that adds Node-only persistence (~/.mnemonic/), interactive OAuth loopback, and TTY-aware output formatting.",
   "license": "Apache-2.0",
   "//": "private: false — npm publish-ready (T14). Scoped package, public access set explicitly.",

--- a/packages/cli/test/bin.test.ts
+++ b/packages/cli/test/bin.test.ts
@@ -52,7 +52,7 @@ describe("buildProgram", () => {
     const p = buildProgram();
     p.exitOverride(); // throw instead of process.exit on --version
     expect(() => p.parse(["node", "mnemonic", "--version"])).toThrow();
-    expect(captured).toContain("0.1.6");
+    expect(captured).toContain("0.1.7");
   });
 
   it("recognises top-level flags --json / --quiet / --no-color", () => {


### PR DESCRIPTION
## Summary

Bumps `@mnemonik-xyz/cli` from 0.1.6 → 0.1.7 to enable the npm release of the browserless-OAuth fix (#27, merged in #140).

### Why 0.1.7 and not 0.1.6

`v0.1.6-cli` was tagged on May 2 against commit `417ec57` (pre-fix), but it never produced a successful npm publish — `@mnemonik-xyz/cli@0.1.5` is still the latest on the registry. Reusing 0.1.6 would either need a destructive force-delete of the orphaned tag or leave a confusing tag-name asymmetry. Bumping to 0.1.7 keeps tag history monotonic with no destructive ops.

### Scope

- `packages/cli/package.json`: `0.1.6` → `0.1.7`
- `packages/cli/bin/mnemonic.ts`: hardcoded `--version` string + adjacent comment
- `packages/cli/test/bin.test.ts`: assertion bumped to match

SDK stays at 0.1.5 — that slot is still free on npm and the SDK code on main is what we want to ship. The release workflow's skip-if-already-published guard (`.github/workflows/release.yml:186-208`) handles the per-package version drift.

## Release plan

After merge, push tag `v0.1.7-cli` to trigger the npm publish workflow.

## Test plan

- [x] `bun test test/bin.test.ts` passes (version assertion).
- [ ] After merge + tag: `npm view @mnemonik-xyz/cli@0.1.7` shows the new version with sigstore provenance.
- [ ] After publish: `yarn add @mnemonik-xyz/cli@0.1.7 && mnemonic init --standalone && mnemonic login && mnemonic sign "hello"` works end-to-end against `mcp.mnemonik.xyz` with no browser interaction.

https://claude.ai/code/session_0146rqGsc7Q6MsdxANAGUhDf

---
_Generated by [Claude Code](https://claude.ai/code/session_0146rqGsc7Q6MsdxANAGUhDf)_