### PR TITLE
docs: add Mnemonic v0.2 whitepaper revisions draft (#143)

### DIFF
--- a/docs/WHITEPAPER.md
+++ b/docs/WHITEPAPER.md
@@ -1,20 +1,18 @@
 # Mnemonic Protocol: Verifiable Memory Infrastructure for AI Agents
 
-**Draft:** v0.1  
-**Date:** April 2026  
+**Draft:** v0.2  
+**Date:** May 2026  
 **Status:** Working draft  
 
 ---
 
 ## Abstract
 
-AI agents increasingly operate across long-running tasks, tools, sessions, and providers, but their memory remains fragile. Context windows are temporary, vendor-native memory is hard to audit, and conventional vector stores provide persistence without cryptographic provenance. As a result, an agent can claim that it remembered a fact, produced an artifact, or acted on prior context, but external parties have no standard way to verify what was stored, who stored it, when it existed, or whether it was later changed.
+AI agents accumulate operational context across sessions, tools, and providers — preferences learned over time, factual knowledge extracted from interactions, procedures refined through use, working state maintained across turns, and persistent self-descriptions that shape their behavior. This memory is valuable, but it remains fragile: bound to single providers, locked in proprietary formats, unverifiable by outside parties, and unable to follow the operator that produced it from one runtime to another. As agents become more autonomous and operate across longer time horizons, the absence of a memory layer with cryptographic provenance becomes a coordination problem rather than a convenience problem.
 
-Mnemonic Protocol introduces a verifiable memory layer for AI agents. It treats memory as a portable, signed artifact rather than an opaque database row: something an agent can recall, carry across systems, and prove has not been silently changed. Memories can run fully locally for speed and development, or be persisted to decentralized infrastructure so third parties can independently verify integrity, authorship, and timestamped existence.
+Mnemonic Protocol is a verifiable memory layer for AI agents. It treats memory as a portable, signed artifact — content-addressed, typed, lineage-linked, signed by the operator's cryptographic identity, and independently verifiable by any party that holds it. The protocol distinguishes five kinds of memory artifact — episodic, semantic, procedural, working, and identity — each with its own schema and semantics. Memory belongs to the operator who signed it; it can be shared between runtimes through an explicit handshake mediated by capability tokens and brought into a target runtime through a defined rehydration pipeline that includes safe-injection framing to prevent memory-mediated prompt injection across trust boundaries. Because memory is bound to operator identity rather than to any specific runtime, an agent built up under one model provider can switch providers and continue from the accumulated state.
 
-Mnemonic is exposed through the Model Context Protocol (MCP), making it usable by current agent clients over HTTP or stdio. The current implementation is a Rust MCP server with five tools for identity, memory signing, verification, challenge signing, and recall. The broader protocol roadmap extends this foundation toward shared project memory, provenance attestations, portable memory wallets, settlement-aware memory services, and multi-agent trust infrastructure.
-
-The core thesis is simple: trustless agents cannot work without trustless agentic memory. A2A protocols make agents interoperable in motion; Mnemonic makes them coherent over time.
+Mnemonic is independent of where artifacts are stored and how they are anchored. Storage may be local, hosted, or on-chain; anchoring may use any backend that produces a verifiable inclusion proof linking a content-addressed hash to a publicly observable timestamp. Two protocol-level commitments hold across every deployment: verification is free for any party by design, and self-hosting is always available for any operator. These commitments are what make the protocol's trustlessness claim credible — neither the protocol's authors nor any specific operator can gate verification or prevent independent operation. Mnemonic fits underneath agent coordination protocols: A2A makes agents interoperable in motion, the Model Context Protocol makes agents interoperable in capability, and Mnemonic makes them coherent over time. The core thesis is that trustless agents cannot work without trustless agentic memory.
 
 ---
 
@@ -26,7 +24,11 @@ For simple assistants, this is inconvenient. For agents that produce research, c
 
 The common instinct is to make context windows longer or to snapshot more internal model state. That helps with continuity inside one runtime, but it does not solve portability or auditability. Raw attention state is model-specific, opaque, expensive to move, and hard for independent systems to interpret. A proprietary chat history is more readable, but still belongs to the platform that stores it.
 
-Mnemonic starts from a different unit: the semantic memory item. A memory item is human-readable content linked to embeddings, metadata, cryptographic identity, and a verifiable commitment trail. It can be recalled by meaning, inspected by people, signed by agents, and independently checked by other systems.
+Mnemonic starts from a different unit: the typed memory artifact. A memory artifact is human-readable content with a declared cognitive role — episodic, semantic, procedural, working, or identity (see §7.1) — linked to embeddings, metadata, cryptographic identity, and a verifiable commitment trail. It can be recalled by meaning, inspected by people, signed by agents, and independently checked by other systems.
+
+Memory belongs to the operator who signed it, not to the runtime that produced it. The same artifacts are valid across model providers, agent frameworks, and physical machines: an operator that built up memory under one runtime can switch runtimes and continue from the accumulated state without re-signing prior records.
+
+Where those artifacts physically live is a separate concern from the protocol's guarantees. Storage may be local, hosted, on-chain, or any combination — backends are pluggable, not a binary "fast local vs. trustworthy decentralized" choice. Authorship and integrity hold regardless of backend; the backend layer adds availability, latency, and the strength of third-party timestamp claims (see §5).
 
 This shift matters for multi-agent systems. A2A protocols can move messages and tasks between agents, but they do not by themselves provide durable, portable, attestable memory. Mnemonic fits underneath coordination protocols as memory infrastructure: the substrate that lets agents remain coherent over time.
 
@@ -40,90 +42,247 @@ Current agent memory systems typically fall into three categories:
 
 These systems are useful, but they do not provide a portable trust layer. If an agent moves from one runtime to another, its accumulated state may not move with it. If a memory record changes, consumers may not notice. If an agent produces an answer based on prior context, downstream systems may not be able to audit which context existed at the time.
 
-A verifiable agent memory system needs six properties:
+Two further problems compound the trust gap and are not addressed by any of the three categories above.
+
+**Memory has cognitive structure that flat stores erase.** An agent's working state, its accumulated facts about the world, the procedures it has learned, the events it has witnessed, and its persistent self-description play different cognitive roles and warrant different retention, retrieval, and sharing semantics. Systems that treat memory as a homogeneous bag of strings cannot apply per-kind lifecycle, cannot scope access by kind, and cannot make different safety decisions about, for example, transient working state versus durable identity. The cognitive distinctions exist whether or not the storage layer recognizes them; surfacing them in the protocol is what allows correct downstream handling.
+
+**Memory crosses trust boundaries, and the transfer itself is unsolved.** When one agent or runtime hands memory to another, three problems appear at once. Authorization: the receiver should only see what they are entitled to see, and the entitlement should be expressible, transferable, and revocable without trusting a central authority. Verifiable transit: the receiver needs to confirm that what arrived is exactly what the owner signed, that lineage holds, and that any timestamp claims survive the hop. Injection safety: memory content can resemble instructions, and a naive paste of received memory into a target runtime's context creates a memory-mediated prompt injection surface. None of the three current categories provide primitives for any of these.
+
+A verifiable agent memory system needs the following properties:
 
 - **Persistence:** memory survives sessions, providers, and runtime changes.
 - **Semantic recall:** memory can be retrieved by meaning, not only by keyword.
 - **Provenance:** each memory is linked to a cryptographic identity.
 - **Integrity:** tampering can be detected independently.
 - **Portability:** memory is not trapped inside one vendor or framework.
-- **Economic viability:** storage and verification costs remain low enough for real agent workflows.
+- **Cognitive typing:** memory is distinguishable by role (episodic, semantic, procedural, working, identity) so per-kind semantics can apply.
+- **Capability-scoped sharing:** access is authorized by signed, scoped, revocable grants — not by ambient trust in a central operator.
+- **Safe injection across runtimes:** transferred memory enters target runtimes through a defined pipeline that prevents memory-mediated prompt injection.
+- **Economic viability:** storage and verification costs remain low enough for real agent workflows, and verification in particular remains free by design.
 
-## 3. Design Goals
+## 3. Protocol Contract
 
-Mnemonic is designed around the following goals:
+This section enumerates the protocol-level invariants that any compliant Mnemonic deployment must provide. They are protocol commitments, not implementation choices: they hold whether the backend is local, hosted, on-chain, or hybrid, and whether any specific operator is running or not. Concrete implementation status is in §12; specific backend choices, parameters, and costs are in companion documents.
 
-### 3.1 Current Implementation Goals
+- **Typed, signed, content-addressed artifacts.** Memory is encoded deterministically, hashed by content, and signed by the operator's cryptographic identity (see §5.1).
+- **Cognitive typing.** Memory artifacts declare a kind — episodic, semantic, procedural, working, or identity — and per-kind semantics apply downstream (see §7.1).
+- **Lineage as a first-class structure.** Parent–child relationships across artifacts are content-addressed, verifiable, and traversable, supporting provenance audits and Merkle-batched anchoring (see §5.6.1).
+- **Storage-agnostic protocol layer.** Authorship, integrity, lineage, and authorization hold regardless of which backend stores the bytes (see §5.3).
+- **Anchoring as a separable property.** Third-party timestamp is an opt-in addition over signature-based authorship and integrity, not a baseline requirement (see §5.6).
+- **Capability-scoped sharing.** Cross-runtime access to memory is authorized by signed, scoped, revocable capability tokens (see §7.2).
+- **Safe rehydration across runtimes.** Memory entering a target runtime traverses a defined verify → filter → rank → compress → format → frame → inject pipeline that prevents memory-mediated prompt injection (see §7.4, §7.5).
+- **Free verification.** Any party may verify any artifact they hold, with no operator gate (see §5.7.1).
+- **Free self-hosting.** Any operator may run a complete node and participate in the protocol without paying any other operator (see §5.7.1).
+- **Operator pluralism.** No operator is structurally privileged; verification is independent of which operator produced or stored the artifact (see §5.7.3).
 
-- Provide a working MCP server that existing agent clients can use today.
-- Support local development with no blockchain dependency.
-- Produce deterministic, typed, signed artifacts using canonical CBOR and COSE_Sign1.
-- Use blake3 hashes over canonical artifact bytes for current artifacts.
-- Store searchable local state in SQLite.
-- Support optional full-mode persistence through Arweave and Solana.
-- Keep verification available as a first-class operation.
-
-### 3.2 Protocol Roadmap Goals
-
-- Make memory portable across models, providers, agents, and hosts.
-- Support shared project memory namespaces for multi-agent workflows.
-- Extend memory records into provenance attestations for artifacts and decisions.
-- Provide settlement-aware memory infrastructure that agents can pay for directly.
-- Add stronger privacy, lifecycle, and multi-writer semantics before broad multi-party deployment.
-- Ship core protocol primitives as both a native Rust crate and a WebAssembly module, so identical verification logic runs in servers, browsers, and embedded agents.
-- Provide a browser-based demo client that recalls and verifies signed memory artifacts without a server dependency.
+Forward-looking work — what extends this contract beyond v1 — is consolidated in §15 Roadmap.
 
 ## 4. Core Insight
 
-Agent memory should be semantically meaningful, cryptographically attributable, and operationally cheap.
+Agent memory should be semantically meaningful, cryptographically attributable, portable across runtimes, and operationally cheap.
 
-Raw transformer state is the wrong abstraction for portable memory. Attention caches are model-specific, opaque, large, and difficult for humans or independent systems to interpret. Semantic memory items are smaller, inspectable, portable, and compatible with retrieval systems.
+Raw transformer state is the wrong abstraction for portable memory. Attention caches are model-specific, opaque, large, and difficult for humans or independent systems to interpret. Typed memory artifacts are smaller, inspectable, portable, and compatible with retrieval systems.
 
-Mnemonic applies this principle through a layered pipeline:
+Mnemonic applies this principle through two pipelines that share the same protocol primitives: one for producing memory, one for transferring it across a trust boundary into another runtime.
+
+The **sign pipeline** turns content into a verifiable artifact:
 
 ```text
 content
   -> embed
   -> compress
-  -> build typed artifact
+  -> build typed artifact (declared cognitive kind)
   -> canonicalize to CBOR
   -> hash canonical bytes with blake3
   -> sign with Ed25519 as COSE_Sign1
-  -> persist locally or externally
-  -> recall and verify through MCP
+  -> persist to one or more backends
+  -> recall by meaning
+  -> verify against producer, lineage, and (optionally) anchor
 ```
 
-The current implementation uses full embeddings in SQLite for recall. Compressed embeddings are produced and embedded in artifact metadata, supporting portability and future cross-node verification work. Compression uses TurboQuant scalar quantization to 2–4 bits per dimension, yielding up to roughly 32× size reduction so embeddings remain cheap to carry across systems and to anchor on durable storage. Historical research explored compressed candidate generation plus exact reranking; that remains a protocol design direction rather than the current local recall path.
+The **share / rehydrate pipeline** moves a signed artifact from one runtime to another:
+
+```text
+signed artifact + capability token
+  -> sharing handshake (authenticate, scope-check, encrypted transit)
+  -> verify (authorship, integrity, lineage, anchor)
+  -> filter (per capability scope)
+  -> rank, compress, format
+  -> frame (safe-injection markers)
+  -> inject into target runtime context
+```
+
+The two pipelines compose: an artifact signed in one runtime is the input to a share/rehydrate flow that hands it to another, and both flows verify the same canonical bytes against the same producer identity. This composition is what gives the protocol portable memory as a property rather than as an aspiration.
+
+Compression of embeddings serves portability and durable-storage anchoring, not the local recall path: shrinking embeddings keeps artifact metadata cheap to carry across systems and to anchor. The reference implementation uses TurboQuant scalar quantization [[1]](#ref-1); the specific scheme, bit width, and recall implementation are documented separately as implementation choices.
 
 ## 5. Architecture Overview
 
-Mnemonic has two layers:
+Mnemonic is structured in two horizontal layers and a vertical taxonomy of surfaces over them. The two layers are a **protocol layer** that defines artifact format, identity, and verification semantics, and a **backend layer** that determines where artifacts physically live. The protocol layer is storage-agnostic: every guarantee about authorship, integrity, lineage, and authorization holds regardless of which backend is chosen. Backends differ in availability, latency, cost, and the strength of third-party timestamp claims. Surfaces (§5.2) are the consumer-facing entry points into the protocol layer; any surface can drive any backend, so storage is a user choice per artifact, not a property of the surface or the protocol.
 
-- **`mnemonic-core`** provides protocol primitives: canonical CBOR encoding, blake3 hashing, COSE_Sign1 signing, identity (Ed25519 keypairs with DID-sol and DID-key derivation), embedding, TurboQuant compression, storage traits, Solana integration, Arweave integration, and lineage helpers (a parent–child artifact DAG with directional traversal).
-- **`mnemonic-mcp`** exposes those primitives through MCP over HTTP and stdio, plus payment and pricing logic for networked operation.
+### 5.1 Protocol Layer (storage-independent)
 
-The MCP server exposes five tools:
+The protocol layer comprises six primitives, none of which assume anything about where bytes are persisted:
 
-- `mnemonic_whoami`
-- `mnemonic_sign_memory`
-- `mnemonic_verify`
-- `mnemonic_prove_identity`
-- `mnemonic_recall`
+- **Canonical encoding** — deterministic CBOR per RFC 8949 §4.2.
+- **Content addressing** — blake3 over canonical bytes.
+- **Signing envelope** — COSE_Sign1 with Ed25519, producer identity bound via DID (`did:key`, `did:sol`, or other supported methods).
+- **Schema registry** — typed, versioned artifact schemas including `memory.episodic`, `memory.semantic`, `memory.procedural`, `memory.working`, `memory.identity`, `rag.context`, `rag.result`, `agent.state`, `receipt`, and `capability.token`.
+- **Lineage DAG** — content-addressed parent→child references with cycle detection and directional traversal.
+- **Capability tokens** — signed, scoped authorizations over lineage subtrees.
 
-Storage is selected by mode:
+A verifier needs the artifact bytes, the producer's public key, and (optionally) a capability token. It does not need to know which backend served those bytes. This is the core property that makes Mnemonic portable: an artifact verified locally and the same artifact verified after retrieval from on-chain storage return identical integrity and authorship results.
 
-- **Local mode:** SQLite only, synthetic local transaction IDs, no payment gate.
-- **Full mode:** signed artifact bytes can be persisted to Arweave, anchored on Solana, and indexed locally in SQLite.
+### 5.2 Consumer Surfaces
 
-### 5.3 Pipeline Walkthrough (sign / recall / verify)
+The protocol layer is exposed through several surfaces, each suited to a different runtime context. All surfaces consume the same protocol primitives (§5.1) and target the same `StorageBackend` abstraction (§5.3), so any surface can drive any backend the user configures.
 
-The MCP server exposes three primary operational flows. Each is a thin orchestration layer over `mnemonic-core` primitives.
+- **`core`** — the protocol library, shipped as both a native Rust crate and a WebAssembly module. Higher surfaces are built on `core`; it has no opinion on storage or transport.
+- **`cli`** — command-line client for terminals and scripts. Local-first by default; the user may configure cloud or on-chain backends per artifact.
+- **`sdk`** — embeddable library for applications. Self-host capable: an SDK consumer may produce its own on-chain anchor proofs directly, without routing through any hosted service.
+- **`mcp`** — networked MCP server with HTTP and stdio transports. The default surface for agent runtimes that speak MCP; also exposes the operator payment surface for hosted services (§5.7).
+- **`browser-extension`** — in-browser client built on the WASM build of `core`. Fully functional in the browser: local, cloud, and on-chain backends are all reachable.
 
-**`mnemonic_sign_memory`.** A request carrying content text and tags traverses a fixed pipeline. The active embedder (FastEmbed local, OpenAI remote, or `MockEmbedder` in tests) produces a full-precision f32 vector. The vector is run through the TurboQuant scalar quantizer at the configured bit width (2, 3, or 4 bits per dimension; default 4) so the compressed form can be carried inside artifact metadata. The artifact — content, producer DID, timestamp, tags, embedding metadata — is encoded to canonical CBOR with stable field ordering, hashed with blake3, and signed as a COSE_Sign1 envelope using the server's Ed25519 identity. In `local` mode the COSE bytes plus the uncompressed embedding are written to SQLite and the operation returns synthetic `local:` transaction IDs at zero cost. In `full` mode the COSE bytes are uploaded to Arweave (via Irys) and the blake3 hash plus Arweave tx ID are anchored on Solana via an SPL Memo instruction; both real tx IDs are then committed alongside the row in the SQLite `AttestationStore`.
+Which surface to use is an ergonomic choice driven by the embedding context. Which backend to target is an independent choice made by the user per artifact, driven by durability, trust, and cost requirements. The protocol layer constrains neither, and no surface restricts which backends are reachable.
 
-**`mnemonic_recall`.** Recall is local-only by design. The query string is embedded with the same provider used at sign time, then scored against every stored uncompressed f32 embedding in SQLite via cosine similarity, and the top-k rows are returned ordered by score. The compressed bytes that traveled to Arweave are not consulted here: they are proof-of-existence artifacts for third-party verification, not a retrieval index. Recall therefore costs one embed call and one full table scan, with no chain reads.
+### 5.3 The `StorageBackend` Abstraction
 
-**`mnemonic_verify`.** Verification reads the stored artifact (locally, or by fetching the COSE bytes from Arweave in full mode), recomputes the blake3 hash over the canonical CBOR payload, and validates the COSE_Sign1 signature against the claimed Ed25519 producer identity. In full mode the verifier additionally confirms that the on-chain SPL Memo on Solana exists and references the same blake3 hash and Arweave tx ID. The result is one of `verified`, `tampered`, or `not_found`.
+Backends implement a small trait:
+
+```rust
+trait StorageBackend {
+    async fn put(&self, artifact: &SignedArtifact) -> Result<BackendRef>;
+    async fn get(&self, reference: &BackendRef) -> Result<SignedArtifact>;
+    async fn list(&self, filter: &Filter) -> Result<Vec<BackendRef>>;
+    fn capabilities(&self) -> BackendCapabilities;
+}
+```
+
+`BackendCapabilities` declares what guarantees a backend provides: `durability`, `third_party_timestamp`, `censorship_resistance`, `random_access_latency`, `cost_per_write_micro_usdc`. Higher surfaces consult these to surface trade-offs to the user. Search is abstracted separately (`RecallIndex` trait) so semantic recall does not bind to any specific storage backend.
+
+### 5.4 Backend Implementations
+
+| Backend | Durability | 3rd-party timestamp | Latency | Cost/write | Primary use |
+|---|---|---|---|---|---|
+| **Local** (e.g. SQLite) | Operator only | None | <10 ms | 0 | Development, single-agent, working memory |
+| **Cloud** (e.g. object store / managed DB) | Provider SLA | Provider-trusted | 10–100 ms | Low | Production teams, single-org trust boundary |
+| **Content-addressed P2P** (e.g. IPFS/Filecoin) | Network-dependent | Weak (DHT) | 100 ms–s | Very low | Public content, opportunistic availability |
+| **Permanent storage network** (e.g. Arweave) | Permanent (pay-once) | Implicit (block order) | 1–10 s to settle | Low | Long-lived attestations, audit records |
+| **On-chain anchor** | Anchors only (paired with durable storage) | Strong | seconds | Low per anchor (batched) | Trustless timestamp for high-value artifacts |
+| **Hybrid** | Composite | Composite | Composite | Composite | Common configuration in practice |
+
+The table gives the protocol-relevant categories; specific backend identifiers and operational parameters are tracked in implementation documentation. Storage selection happens per artifact: the user (or the application configured by the user) picks one or more backends from the available categories based on the artifact's durability, trust, and cost requirements. Many deployments combine a local index for hot access with one or more durable backends for long-lived or third-party-verifiable artifacts.
+
+### 5.5 Why On-Chain Is Optional
+
+On-chain anchoring is the only backend category that provides independent third-party timestamp without trusting any single operator. It is therefore valuable, but it is also the most expensive: every on-chain transaction costs something. Mnemonic treats on-chain anchoring as one tool among several:
+
+- **Anchor when** an artifact's existence at a specific time must be verifiable by a party that does not trust the operator.
+- **Do not anchor when** local or cloud durability is sufficient — the vast majority of working memory, draft state, and intra-session artifacts fall here.
+- **Batch anchor when** many low-value artifacts can share a single timestamp (see §5.6).
+
+The protocol's guarantees about authorship and integrity require no chain at all — only signatures and canonical encoding. Chain anchoring adds **third-party timestamp** and **non-repudiation against operator collusion**, which are valuable but separable properties.
+
+### 5.6 Anchoring
+
+Anchoring produces a verifiable claim that an artifact existed at or before a given time, checkable by any party without trusting the artifact's producer or the operator that stored it. Signatures alone give authorship and integrity; anchoring adds independent timestamp and non-repudiation against operator backdating. These are separable properties, and the protocol exposes them separately rather than collapsing them into a single boolean.
+
+Anchoring is the only protocol operation whose marginal cost is bounded below by an external system. The protocol minimizes that cost through batching and remains agnostic to the choice of anchor backend.
+
+#### 5.6.1 Merkle batching via the lineage DAG
+
+The lineage DAG (§5.1) provides what batched anchoring requires. A batch root is a derived artifact whose parents are the artifacts in the batch:
+
+```
+BatchRoot = derive(
+    schema     = "batch.root",
+    parent_ids = [H_1, H_2, ..., H_N]
+)
+```
+
+Because the batch root's canonical bytes contain its parents' content-addressed ids, and its own id is the hash of those bytes, modifying any leaf breaks the chain up to the root. The lineage DAG functions as a Merkle commitment without additional structure. Only the batch root is anchored; inclusion of any single artifact is proved via the lineage path. Batches compose into trees for logarithmic inclusion proofs at large N. Flat versus tree batching is a deployment parameter, not a protocol commitment.
+
+The amortized per-artifact anchoring cost decreases proportionally with batch size. The user chooses batch parameters per their latency tolerance for anchor finality.
+
+#### 5.6.2 Backend-agnostic anchor proofs
+
+The protocol accepts any anchor backend that produces a verifiable inclusion proof linking a content-addressed hash to a publicly observable timestamp. The contribution of a backend is captured in an `anchor_proof` record: a backend identifier, a backend-specific reference, the anchored hash, and the timestamp.
+
+Backends differ in finality latency, cost per anchor, trust assumption, and timestamp granularity. The protocol takes no position on the right trade-off across these axes. The reference implementation supports specific backends; their identification and operational parameters are specified in implementation documentation rather than in this protocol document.
+
+#### 5.6.3 Self-anchoring
+
+The protocol distinguishes between *producing* an anchor and *accepting* an anchor proof. Any user can submit an anchor transaction independently of any hosted service and present the resulting proof to the protocol; verification uses the same logic regardless of who produced the anchor. This is the structural property that keeps the protocol open — hosted anchoring is convenience, not a gate. The `sdk` and `browser-extension` surfaces both support direct self-anchoring; `mcp` additionally supports anchoring on behalf of users that prefer a hosted path.
+
+#### 5.6.4 Verification states
+
+Anchoring is asynchronous. The protocol defines explicit states reflecting whether an artifact has settled, is in flight, or remains unanchored: **signed but not anchored**, **anchor pending**, **anchored**, **anchor failed**. A verifier always knows which state an artifact is in. The protocol never claims an anchor exists when it does not, and never claims an absence of anchor when one is in flight.
+
+#### 5.6.5 What anchoring does and does not guarantee
+
+Anchoring adds existence at or before a known time, tamper-evidence for all artifacts under the anchored root, and non-repudiation against operator backdating. Anchoring does not provide content availability, authorization to read, correctness of the artifact's claims, or sub-settlement-time finality. Signed-but-unanchored artifacts remain fully valid for authorship and integrity. Anchoring upgrades verifiability against operator collusion and adds a public timestamp.
+
+### 5.7 Protocol Economics
+
+The protocol takes positions on what must remain free and what may be paid, but takes no position on how any particular operator prices the services they offer. The result is an economic model in which the protocol itself is unmonetizable while the services built on top of it are freely monetizable. This separation is intentional: it is what allows the protocol to remain a public good even when individual operators are commercial.
+
+#### 5.7.1 Operations the protocol guarantees are free
+
+Two operations are free by protocol design and cannot be gated by any operator:
+
+- **Verification.** Any party may verify the authorship, integrity, lineage, and anchoring of any artifact they hold. Verification requires no operator service, no account, and no permission. This is the foundation of the protocol's trustlessness claim — if verification can be gated, the protocol's guarantees become contingent on whoever holds the gate.
+- **Self-hosting.** Any user may run a complete node, sign and verify locally, and participate in the protocol without paying any other operator. The full set of protocol operations is available to any user running their own implementation across the `cli`, `sdk`, and `browser-extension` surfaces.
+
+These two guarantees are structural protections against capture. They mean that no party — including the protocol's original authors — can hold the protocol's core functionality hostage.
+
+#### 5.7.2 Operations operators may charge for
+
+Operations whose cost is bounded below by real compute, storage, bandwidth, or external-system fees may be charged for by the operator providing them. These are service-layer choices and the protocol takes no position on whether they are priced, subsidized, or free at any particular operator:
+
+- Producing anchors against backends that have non-zero cost.
+- Hosting durable storage on behalf of users.
+- Running embedding, recall, or query workloads at scale.
+- Operating high-availability or dedicated infrastructure.
+- Providing managed identity, capability, or audit services.
+
+Charging is a feature of operator deployment, not of the protocol. An operator may choose to offer any of these for free, at cost, or at a margin. Users uncomfortable with one operator's pricing are free to use another, run their own, or operate without that service entirely.
+
+#### 5.7.3 Operator pluralism
+
+The protocol does not privilege any operator. There is no canonical hosted service, no preferred node, no central registry of authorized operators. Any party may run a Mnemonic node, accept artifacts from other operators, anchor on behalf of users, and charge for any of these services. Verification of an artifact is independent of which operator produced it.
+
+This pluralism is what makes the free-tier guarantees credible. An operator that abuses its position — by raising prices, degrading service, or restricting access — does not control the protocol; users can migrate to other operators or to self-hosting without losing accumulated state, because all artifacts are portable by signature and verifiable independently.
+
+#### 5.7.4 Payment as a protocol primitive
+
+The protocol provides primitives for operators that wish to charge for services: payment-gated tool calls, balance-tracking accounts, and standard micropayment patterns over established settlement rails. These primitives are tools, not mandates. An operator that wishes to provide free service simply does not enable payment gating; an operator that wishes to charge enables it. The same protocol code supports both modes.
+
+Operators that charge are responsible for the economics of their own services: pricing, free quotas, subsidies, revenue allocation, and treasury management. These are commercial decisions of individual operators and are not specified by the protocol.
+
+#### 5.7.5 What this economic model rules out
+
+The combination of free verification, free self-hosting, operator pluralism, and optional payment rules out several common failure modes of protocol economics:
+
+- **Verification capture.** No operator can charge for the act of checking whether an artifact is genuine.
+- **Publishing capture.** No operator can prevent a user from signing and storing artifacts; the user can always run their own node.
+- **Lock-in.** Artifacts produced under one operator are verifiable by any other operator and by self-hosted nodes. There is no operator-specific format or operator-specific verification path.
+- **Single-operator dependency for protocol liveness.** Even if a particular hosted operator becomes unavailable, the protocol continues to function across all other operators and self-hosters.
+
+The protocol does not rule out commercial activity. It rules out commercial activity that depends on holding the protocol itself hostage.
+
+#### 5.7.6 Implementation-level economics
+
+Specific pricing, free-tier quotas, subsidy models, treasury accounting, and revenue strategy are operator-level concerns documented separately from the protocol specification. Different implementations and different hosted operators will make different choices. The protocol document specifies only what those choices must respect: verification stays free, self-hosting stays available, and no operator becomes structurally privileged over others.
+
+### 5.8 Pipeline Walkthrough (sign / recall / verify)
+
+The protocol exposes three primary operational flows: signing a new memory, recalling stored memories by meaning, and verifying that a held artifact is genuine.
+
+**Sign.** A request carrying content and metadata traverses a fixed pipeline. The configured embedder produces a full-precision embedding vector; the vector is compressed so a small form can be carried inside artifact metadata for portability and durable-storage anchoring. The artifact — content, declared cognitive kind, producer identity, timestamp, tags, embedding metadata — is encoded to canonical CBOR with stable field ordering, hashed by content, and signed under a COSE_Sign1 envelope with the operator's Ed25519 identity. The signed artifact is then persisted to whichever backends the user has selected for that artifact: a local index for fast access, and any subset of cloud, content-addressed network, or on-chain backends for durability and third-party verifiability. When the user requests an anchor, the content hash and a backend reference are submitted to the chosen anchor backend; the resulting proof is committed alongside the artifact.
+
+**Recall.** A query is embedded with the same provider used at sign time, scored against the stored full-precision embeddings by cosine similarity, and the top-k matches are returned ordered by score. Recall reads from the local index regardless of where else the artifacts are stored: the local index is the hot path for retrieval, while remote backends serve durability and third-party verification. Compressed embeddings in artifact metadata serve portability and cross-node proof-of-existence, not retrieval.
+
+**Verify.** Verification reads the artifact bytes from whichever backend holds them, recomputes the content hash over the canonical-encoded payload, and validates the signature against the claimed producer identity. If the artifact carries an anchor proof, the verifier additionally confirms that the anchor exists on the claimed anchor backend and references the same content hash. The result is one of `verified`, `tampered`, or `not_found`.
 
 For a deeper walkthrough including module boundaries and lock discipline, see [docs/how-it-works.md](./how-it-works.md).
 
@@ -131,104 +290,144 @@ For a deeper walkthrough including module boundaries and lock discipline, see [d
 
 Mnemonic artifacts are typed, versioned, and canonical.
 
-The current schema registry includes:
+The schema registry distinguishes five kinds of memory artifact, each with its own schema and semantics (see §7.1), alongside the artifact types produced by surrounding agent workflows and the capability artifacts that authorize sharing:
 
-- `memory`
-- `rag.context`
-- `rag.result`
-- `agent.state`
-- `receipt`
+- `memory.episodic` — time-ordered events, observations, and interactions
+- `memory.semantic` — factual assertions about the world, typically as structured claims
+- `memory.procedural` — learned skills, routines, and workflows
+- `memory.working` — transient goals, subgoals, scratch state, and pending actions
+- `memory.identity` — persistent persona attributes, preferences, communication style, and operational policies
+- `rag.context` — retrieved context bundles
+- `rag.result` — generated results derived from retrieved context
+- `agent.state` — state snapshots
+- `receipt` — operational receipts
+- `capability.token` — signed, scoped authorizations over lineage subtrees (see §7.2)
 
-Each schema defines required fields, optional fields, and stable canonical CBOR field ordering. Published schemas are immutable within a version. Changes require version bumps.
+Each schema defines required fields, optional fields, and stable canonical CBOR field ordering. Published schemas are immutable within a version. Changes require version bumps. The earlier flat `memory` schema is retained as a deprecated alias and resolves to `memory.episodic` for backward compatibility; new artifacts should use one of the five typed kinds directly.
 
-This model lets Mnemonic evolve beyond single memory items into a general attestation layer for agent workflows: retrieved context, generated results, state snapshots, receipts, and lineage-linked artifacts.
+This model lets Mnemonic evolve beyond single memory items into a general attestation layer for agent workflows: typed memory by cognitive role, retrieved context, generated results, state snapshots, receipts, capability authorizations, and lineage-linked artifacts.
 
-## 7. Trust Model
+## 7. Memory Composition and Sharing
 
-Mnemonic currently guarantees:
+The artifact model in §6 gives a single signed memory its shape. §7 specifies how those artifacts compose into multi-runtime workflows: how cognitive role drives per-kind semantics, how access is scoped via capability tokens, how memory crosses trust boundaries through a defined handshake, and how it enters a target runtime through a rehydration pipeline that includes safe-injection framing [[3]](#ref-3). The whitepaper states the protocol-level claims; structures, exchange details, stage interfaces, and marker grammars are specified in [docs/spec/memory-composition.md](./spec/memory-composition.md).
 
-- **Integrity:** current artifacts are hashed over canonical CBOR bytes.
-- **Authorship:** artifacts are signed by an Ed25519 identity.
-- **Local verifiability:** local-mode records can be checked against SQLite state.
-- **External verifiability:** full-mode records can be checked against persisted artifacts and chain anchors when available.
-- **Version awareness:** current CBOR+COSE artifacts and legacy JSON/SHA-256 artifacts are handled separately.
+### 7.1 Cognitive Typing
 
-Mnemonic does not yet guarantee:
+The five `memory.*` kinds declared in §6 (`episodic`, `semantic`, `procedural`, `working`, `identity`) are not stylistic tags. They reflect distinct cognitive roles and warrant different retention, retrieval, sharing, and safety semantics. The kind is part of the canonical artifact and is verified alongside content, so downstream tooling reads the declared kind and applies kind-appropriate policy without renegotiating with the producer. Per-kind defaults — retention horizons, retrieval scoring, sharing posture, framing strictness — are specified in the memory-composition spec.
 
-- End-to-end encryption in the active MCP sign/verify path.
-- Correctness of the memory content itself.
-- Completeness of an agent's memory history.
-- ZK proof that an embedding was computed faithfully.
-- ZK proof that a retrieval result is the true top-k from a committed corpus.
-- Safe multi-party shared memory semantics.
+### 7.2 Capability Tokens
 
-These limitations are intentional to state clearly: Mnemonic V1 prioritizes practical memory integrity and provenance before more expensive proof systems.
+Cross-runtime access to memory is authorized by signed, scoped, revocable capability tokens. A capability token is itself a typed artifact (`capability.token`), content-addressed, and verifiable by anyone holding it. Tokens carry a subject, a scope (over lineage subtrees, kinds, tag predicates, or explicit ids), a permission set, and an expiry; delegation is supported through a chain of authority; revocation is a counter-signed attestation. The protocol does not require online revocation checks on every use — short-lived tokens are the preferred pattern for high-value operations, and longer-lived tokens carry explicit online-check policy in their metadata. Token structure, scope grammar, and revocation semantics are specified in the memory-composition spec.
 
-## 8. Positioning In The Agent Stack
+### 7.3 Sharing Handshake
 
-Mnemonic is not a replacement for A2A protocols, orchestration systems, or vector databases.
+Memory crosses a trust boundary through a defined handshake between two runtimes. The handshake produces mutual authentication, an effective scope as the intersection of the capability token's scope and the sender's policy at handshake time, an encrypted transport for the artifact bytes, and a co-signed share receipt anchored in the lineage DAG so the transfer itself becomes auditable. The handshake is the protocol-level boundary between memory at rest and memory in flight. Exchange details, transport bindings, and receipt structure are specified in the memory-composition spec.
 
-A2A protocols handle discovery, coordination, task exchange, and message passing. Mnemonic fits underneath that layer as durable memory, provenance, portability, and trust infrastructure.
+### 7.4 Rehydration Pipeline
+
+When a signed artifact enters a target runtime, it traverses a defined pipeline: **verify → filter → rank → compress → format → frame → inject**. The pipeline is deterministic and replayable: two implementations given the same inputs and configuration produce identical output at every stage, which makes the entire rehydration auditable from the source artifacts plus the recorded capability evaluation. Stage-by-stage interfaces, the ranker abstraction, and compression budgets are specified in the memory-composition spec.
+
+### 7.5 Safe Injection (Framing)
+
+Memory content can resemble instructions, and naively concatenating retrieved memory into a target runtime's prompt creates a memory-mediated prompt injection surface. The protocol's framing layer wraps retrieved memory in safe-injection markers that declare provenance and posture (reference content, not instruction). Identity-kind memory carries stricter framing than other kinds, reflecting its higher potential as an injection vector. Framing is a protocol-level contract enforced at the rehydration boundary; it is not a unilateral guarantee, because honoring the markers depends on receiving-runtime cooperation, and compliance is itself an attestation that target runtimes publish. Marker grammars, per-kind strictness, and compliance-attestation structure are specified in the memory-composition spec.
+
+### 7.6 Portability Across Runtimes
+
+The portability claim composes the prior subsections. A signed artifact whose authorship and integrity verify locally remains verifiable after transfer; capability tokens and the sharing handshake establish what may move and on what terms; the rehydration pipeline transforms transferred bytes into target-runtime context without losing provenance; framing protects the receiving runtime from memory-mediated injection. The result is that operator identity, not runtime identity, is what binds memory together over time. An operator that accumulated memory under one runtime and one provider may switch and continue from the accumulated state without re-signing prior records.
+
+## 8. Trust Model
+
+Mnemonic's trust model separates what the protocol guarantees from what it does not. The guarantees rest on signatures and canonical encoding alone; backend choices, anchoring, and capability tokens are layered above to add third-party timestamp, scoped sharing, and auditable transfer. Everything outside the guarantee list is explicitly out of scope for v1.
+
+The protocol guarantees:
+
+- **Integrity** — artifacts are content-addressed over canonical encoded bytes; tampering after signing is detectable by anyone holding the artifact.
+- **Authorship** — artifacts are signed by an Ed25519 operator identity; the producer is independently verifiable.
+- **Lineage verifiability** — parent–child relationships across artifacts are content-addressed; tampering with any artifact in a lineage chain breaks the chain up to the root.
+- **Backend-independent verification** — verification holds regardless of which backend served the bytes. The same artifact retrieved from a local index, from a content-addressed network, or after on-chain anchoring returns the same authorship and integrity result.
+- **Optional third-party timestamp** — when an anchor is requested, existence at or before the anchor time is verifiable by any party that does not trust the operator (§5.6).
+- **Capability-scoped sharing** — cross-runtime access is authorized by signed, scoped, revocable capability tokens; receivers can independently verify the authorization chain (§7.2).
+- **Auditable transfer** — the sharing handshake produces a co-signed share receipt anchored in the lineage DAG; the share event itself is an attestable artifact (§7.3).
+- **Safe-injection contract** — retrieved memory is wrapped in markers that declare provenance and posture; the contract is honored when target runtimes publish framing-compliance attestations (§7.5).
+- **Free verification** — verification requires no operator service, no account, and no permission (§5.7.1).
+
+The protocol does not guarantee:
+
+- **Correctness of memory content** — the protocol verifies who wrote what and when, not whether the content is true.
+- **Completeness of memory history** — operators may sign a subset of their state; the protocol does not detect selective omission.
+- **At-rest encryption of memory content** — the canonical artifact format is plaintext under the operator's signature; transport encryption is provided by the sharing handshake (§7.3), but at-rest encryption is an operator-level concern.
+- **Receiving-runtime safety beyond the framing contract** — if a target runtime does not honor framing markers, the protocol cannot prevent memory-mediated prompt injection unilaterally. Compliance is observable via the target runtime's framing-compliance attestation.
+- **Concurrent multi-writer shared namespaces** — the protocol authorizes pairwise transfers via capability tokens, but does not yet specify conflict resolution, ordering, or convergence semantics for namespaces with multiple concurrent writers.
+- **ZK proofs of embedding correctness** — there is no protocol-level proof that an embedding was computed faithfully from the claimed content under the claimed model.
+- **ZK proofs of retrieval correctness** — there is no protocol-level proof that a returned top-k is the true top-k against a committed corpus.
+
+These boundaries are intentional. The v1 protocol commits only to what signatures and canonical encoding can enforce, plus what capability tokens and the sharing handshake can authorize and attest. ZK proofs of computation, multi-writer convergence, and at-rest encryption are credible extensions, but they add cost and complexity that the v1 scope deliberately defers (§15 Roadmap).
+
+## 9. Positioning In The Agent Stack
+
+Mnemonic is not a replacement for A2A protocols, the Model Context Protocol (MCP), orchestration systems, or vector databases. It sits underneath these layers as memory infrastructure.
+
+A2A protocols handle discovery, coordination, task exchange, and message passing between agents. MCP standardizes how agents access tools, resources, and external capabilities within a runtime. Mnemonic fits underneath both as durable memory, provenance, lineage, and trust infrastructure: where A2A and MCP make agents interoperable in motion and in capability, Mnemonic keeps them coherent over time.
 
 In one sentence:
 
-> A2A makes agents interoperable in motion; Mnemonic makes them coherent over time.
+> A2A makes agents interoperable in motion; MCP makes them interoperable in capability; Mnemonic makes them coherent over time.
 
-## 9. Use Cases
+## 10. Use Cases
 
 Mnemonic supports a family of agent-memory patterns. The 10 subsections below are short summaries; each links to a deep-dive document under `docs/usecases/`.
 
-### 9.1 Shared Project Memory Namespace
+### 10.1 Shared Project Memory Namespace
 
 Multiple A2A agents read from and write to a shared project-level memory namespace, so findings, decisions, contradictions, and source references accumulate on the project rather than inside any single agent. New agents joining the workflow retrieve accumulated context instead of starting from zero.
 [See deep-dive in docs/usecases/shared-project-memory-namespace.md.]
 
-### 9.2 Shared Memory Layer
+### 10.2 Shared Memory Layer
 
 Mnemonic acts as a persistent shared memory substrate underneath A2A coordination, surviving sessions, providers, and runtime changes while offering semantic retrieval and verifiable provenance. This replaces fragile context windows, ad-hoc databases, and vendor-locked memory with a portable common surface.
 [See deep-dive in docs/usecases/shared-memory-layer.md.]
 
-### 9.3 Provenance And Attestation Layer
+### 10.3 Provenance And Attestation Layer
 
 Mnemonic records what an agent produced, what inputs it used, when it produced the output, and how the output connects to earlier artifacts, turning opaque message passing between agents into auditable knowledge production. Downstream consumers can independently check authorship, integrity, and timestamped existence of each claim.
 [See deep-dive in docs/usecases/provenance-attestation-layer.md.]
 
-### 9.4 Trust And Reputation Layer
+### 10.4 Trust And Reputation Layer
 
 Historical memory and contribution records can power trust signals — which agents are reliable in a domain, whose outputs are reused, which contributors are noisy or adversarial — that orchestrators use beyond declared capabilities. Mnemonic links agent identity, memory entries, downstream usage, and validation outcomes into a durable reputation surface.
 [See deep-dive in docs/usecases/trust-reputation-layer.md.]
 
-### 9.5 Portable Memory Wallet
+### 10.5 Portable Memory Wallet
 
 Memory belongs to the agent or its operator rather than a provider: an operator can write memory while running on Claude, switch the runtime to GPT or a local model, and continue working from the same attested store without re-signing or re-attesting prior records. Memory snapshots are portable, verifiable, rehydratable, and independent from a single inference provider.
 [See deep-dive in docs/usecases/portable-memory-wallet.md.]
 
-### 9.6 Settlement-Aware Memory Infrastructure
+### 10.6 Settlement-Aware Memory Infrastructure
 
 Networked memory services need metering and payment; Mnemonic already supports balance and x402-style HTTP payment flows so agents can autonomously pay for memory writes, recall, and verification. This evolves into agent-payable memory infrastructure where verification remains open and paid operations sustain node operators.
 [See deep-dive in docs/usecases/settlement-aware-memory-infrastructure.md.]
 
-### 9.7 Task Memory Ledger
+### 10.7 Task Memory Ledger
 
 Each task exchanged in an A2A workflow leaves a durable record — request hash, assigned agent, summary, intermediate notes, output, artifact references, completion status, ordering anchors — that subsequent agents can retrieve. This prevents repeated context loss across the many short-lived tasks typical in multi-agent execution.
 [See deep-dive in docs/usecases/task-memory-ledger.md.]
 
-### 9.8 Artifact Attestation Service
+### 10.8 Artifact Attestation Service
 
 Mnemonic attests, indexes, and retrieves artifacts produced by A2A workflows — reports, code patches, evidence bundles, recommendations, structured outputs — by storing artifact hash, producing identity, upstream references, and semantic summary. Consumers can later prove who produced an artifact, when, and from which inputs.
 [See deep-dive in docs/usecases/artifact-attestation-service.md.]
 
-### 9.9 Agent Continuity Layer
+### 10.9 Agent Continuity Layer
 
 When an agent moves across runtimes, providers, or infrastructure because of cost, model upgrades, framework migration, or compliance, Mnemonic preserves prior memory items, project context, artifact history, and decisions so the agent retains accumulated context. Continuity is decoupled from the specific platform the agent runs on today.
 [See deep-dive in docs/usecases/agent-continuity-layer.md.]
 
-### 9.10 Reliability Oracle For Orchestration
+### 10.10 Reliability Oracle For Orchestration
 
 Orchestrators query Mnemonic for memory-backed trust signals — accepted vs rejected outputs, downstream reuse, citation quality, contradiction rate, reviewer corrections — to route work beyond stated capabilities. Mnemonic holds the historical evidence needed to answer reliability questions about agents and contributions.
 [See deep-dive in docs/usecases/reliability-oracle-for-orchestration.md.]
 
-## 10. Related Work
+## 11. Related Work
 
 Mnemonic sits at the intersection of:
 
@@ -239,38 +438,43 @@ Mnemonic sits at the intersection of:
 - verifiable computation
 - machine-native payments
 
-The closest research and product directions include decentralized RAG, trustless agentic memory, ZK embedding proofs, verifiable ANN retrieval, and source reliability oracles. Mnemonic's current bet is pragmatic: hash commitments and signed artifacts are cheaper and deployable today, while ZK embedding or retrieval proofs remain credible future extensions.
+The closest research and product directions include decentralized RAG, trustless agentic memory and cryptographically-verified memory transfer [[3]](#ref-3), ZK embedding proofs, verifiable ANN retrieval (including the inverted-file cascade approach in [[2]](#ref-2)), embedding quantization with bounded distortion [[1]](#ref-1), and source reliability oracles. Mnemonic's current bet is pragmatic: hash commitments and signed artifacts are cheaper and deployable today, while ZK embedding or retrieval proofs remain credible future extensions.
 
-## 11. Current Implementation Status
+## 12. Current Implementation Status
 
-The current canonical implementation is the Rust MCP server in this repository.
+The current canonical implementation is the Rust MCP server in this repository. It exercises one path through the v0.2 architecture (§5) and does not yet expose the full protocol surface; this section names the gap.
 
 Implemented today:
 
 - HTTP and stdio MCP transports.
-- Five Mnemonic tools.
-- Ed25519 server identity, with DID-sol and DID-key derivation exposed through `mnemonic_whoami`.
+- Five MCP tools: sign memory, recall, verify, whoami, prove identity.
+- Ed25519 operator identity with DID-sol and DID-key derivation.
 - Canonical CBOR artifact encoding.
 - COSE_Sign1 artifact signing.
-- blake3 hashing for current artifacts.
+- blake3 content hashing.
 - TurboQuant compression of embeddings (2–4 bits per dimension) carried in artifact metadata.
-- SQLite local recall over full embeddings.
+- Local recall over full embeddings via SQLite.
 - Local lineage index: parent–child artifact DAG with cycle detection and directional BFS traversal (`Ancestors`, `Descendants`, `Both`).
-- `local` and `full` storage modes.
-- Optional Solana and Arweave persistence in full mode.
+- Binary `local` / `full` storage modes (predecessor of the per-artifact backend selection in §5.3).
+- Optional Arweave persistence and Solana anchoring in `full` mode.
 - Payment modes: `none`, `balance`, `x402`, and `both`.
 
-Not current implementation behavior:
+Not yet implemented:
 
-- End-to-end encrypted snapshots.
-- Compressed shadow-index retrieval as the local recall path.
-- Multi-party shared namespaces.
-- Reliability oracle.
-- On-chain node registry.
-- Agent SDK abstraction.
-- ZK proof of embedding or retrieval correctness.
+- Per-artifact `StorageBackend` selection (§5.3); the current impl uses the binary `local`/`full` mode framing.
+- Cognitive typing on artifacts: the five `memory.*` kinds (§7.1); the current impl uses the deprecated flat `memory` schema.
+- Capability tokens (§7.2) and the revocation feed.
+- Sharing handshake with co-signed receipts anchored in lineage (§7.3).
+- Rehydration pipeline stages — filter, rank, compress, format, frame, inject (§7.4); only the verify stage is implemented.
+- Safe-injection framing markers and the framing-compliance attestation (§7.5).
+- WASM build of `core` and the browser-extension surface (§5.2).
+- Standalone `sdk` and `cli` surfaces as separate distribution targets (§5.2); their functionality currently lives inside the MCP binary.
+- At-rest encryption of memory content.
+- Multi-writer shared namespaces.
+- Reliability oracle and on-chain node registry.
+- ZK proofs of embedding or retrieval correctness.
 
-## 12. Evaluation Plan
+## 13. Evaluation Plan
 
 A production-grade whitepaper should include empirical results for:
 
@@ -284,20 +488,20 @@ A production-grade whitepaper should include empirical results for:
 
 Historical prototype documents include retrieval and compression benchmarks, but this paper should only publish results that match the current Rust implementation or are clearly labeled as prior research.
 
-## 13. Limitations And Open Questions
+## 14. Limitations And Open Questions
 
 Open areas before broad production deployment:
 
-- Security and privacy boundaries.
-- Encryption architecture and key recovery.
-- Memory write semantics: append, merge, overwrite, contradiction handling.
-- Lifecycle policy: pruning, compaction, export, deletion, retention classes.
-- Multi-writer consistency and shared namespace authorization.
-- Robustness to noisy, duplicate, contradictory, or adversarial memories.
-- Product packaging: local tool, SDK, node network, hosted service, or hybrid.
-- Compliance and governance for sensitive memory data.
+- **Security and privacy boundaries** — including at-rest encryption architecture and key recovery; the protocol provides transport encryption via the sharing handshake (§7.3) but takes no position on at-rest encryption.
+- **Memory write semantics** — append, merge, overwrite, and contradiction handling, especially for `memory.semantic` artifacts that may carry conflicting factual claims.
+- **Lifecycle policy** — pruning, compaction, export, deletion, and retention classes. Per-kind defaults from §7.1 set the direction, but specific policies and operator overrides are open.
+- **Multi-writer consistency and shared-namespace authorization** — pairwise sharing via capability tokens is specified (§7.2–§7.3), but namespaces with multiple concurrent writers need conflict resolution, ordering, and convergence semantics.
+- **Robustness to noisy, duplicate, contradictory, or adversarial memories** — including recall-time disambiguation and reliability scoring inputs.
+- **Framing-compliance ecosystem** — the registry of which target runtimes publish compliance attestations (§7.5), the format of those attestations across runtime families, and the inclusion criteria.
+- **Cross-implementation interop testing** — conformance tests across the `core`, `cli`, `sdk`, `mcp`, and `browser-extension` surfaces (§5.2), and across native and WASM builds of `core`.
+- **Compliance and governance** for sensitive memory data — regulatory boundaries, jurisdiction handling, and audit primitives.
 
-## 14. Roadmap
+## 15. Roadmap
 
 The roadmap below is organized around a single positioning, locked in 2026-05-01: **Mnemonic is verifiable memory for trustless agents.** Phases 1–3 deliver the core memory primitive; Phases 4–5 compose it into the trustless-agent stack (A2A + ERC-8004) so signed memory becomes a first-class layer underneath multi-agent coordination and on-chain identity.
 
@@ -307,6 +511,8 @@ The roadmap below is organized around a single positioning, locked in 2026-05-01
 - Document the artifact format and verification model.
 - Improve local developer experience.
 - Keep local mode fast, free, and offline.
+- Ship core protocol primitives as both a native Rust crate and a WebAssembly module, so identical verification logic runs in servers, browsers, and embedded agents.
+- Provide a browser-based demo client that recalls and verifies signed memory artifacts without a server dependency.
 
 ### Phase 2: Product-Grade Memory Semantics
 
@@ -344,7 +550,7 @@ After Phase 5: Mnemonic is the only primitive in the trustless-agent stack that 
 
 Detailed plan, task breakdown, and decision rationale: `work/a2a-bridge/` (`user-spec.md`, `tech-spec.md`, `tasks/`, `backlog.md`, `decisions.md`, `research/positioning-trustless-agents.md`).
 
-## 15. Conclusion
+## 16. Conclusion
 
 Agents need more than longer context windows. They need memory that persists, travels, and can be verified.
 
@@ -356,14 +562,14 @@ The long-term goal is broader: memory that agents can own, share, pay for, audit
 
 ## References
 
-1. Model Context Protocol. https://modelcontextprotocol.io/
-2. Arweave Protocol. https://arweave.org/
-3. Solana Documentation. https://solana.com/docs
-4. COSE: CBOR Object Signing and Encryption. RFC 9052.
-5. BLAKE3 Cryptographic Hash Function. https://github.com/BLAKE3-team/BLAKE3
-6. Zandieh, A. and Mirrokni, V. *TurboQuant: Online Vector Quantization with Near-Optimal Distortion Rate.*
-7. Coinbase. *x402: HTTP 402 Payment Required for Machine-to-Machine Payments.* https://x402.org/
-8. [Mnemonic Protocol Foundational Paper](./research/paper.pdf)
+<a id="ref-1"></a>
+1. Zandieh, A. and Mirrokni, V. *[TurboQuant: Online Vector Quantization with Near-Optimal Distortion Rate](https://arxiv.org/abs/2504.19874).* arXiv:2504.19874.
+
+<a id="ref-2"></a>
+2. *[Sublinear Verifiable Recall: An Inverted-File Cascade for Compressed Embedding Retrieval in the Mnemonic Protocol](https://www.researchgate.net/publication/404381758_Sublinear_Verifiable_Recall_An_Inverted-File_Cascade_for_Compressed_Embedding_Retrieval_in_the_Mnemonic_Protocol).*
+
+<a id="ref-3"></a>
+3. *[Portable Agent Memory: A Protocol for Cryptographically-Verified Memory Transfer Across Heterogeneous AI Agents](https://arxiv.org/abs/2605.11032).* arXiv:2605.11032.
 
 ---
 

--- a/docs/spec/memory-composition.md
+++ b/docs/spec/memory-composition.md
@@ -1,0 +1,208 @@
+# Memory Composition and Sharing Specification
+
+**Companion to:** [WHITEPAPER.md](../WHITEPAPER.md) §7
+**Status:** v0.2 draft
+**Scope:** Protocol-level specification of cognitive typing, capability tokens, sharing handshake, rehydration pipeline, and safe-injection framing.
+
+This document specifies the protocol-level details that §7 of the whitepaper introduces. The whitepaper states the protocol's contract; this document specifies the structures, exchanges, and stage interfaces that conforming implementations must provide. Anything not specified here is implementation-defined.
+
+---
+
+## 1. Cognitive Typing
+
+The five `memory.*` kinds declared in the artifact schema registry reflect distinct cognitive roles and have distinct retention, retrieval, sharing, and safety semantics. The kind is part of the canonical artifact and is verified alongside content.
+
+### 1.1 Kinds
+
+- **`memory.episodic`** — time-ordered events, observations, and interactions. Retrieval combines temporal proximity with semantic similarity; salience decays with time and reinforcement updates it.
+- **`memory.semantic`** — factual assertions about entities, relations, and references. Retrieval is structured + semantic; contradictions across artifacts are first-class signals rather than errors.
+- **`memory.procedural`** — learned skills, routines, and workflows. Versioned by content hash; usage history feeds reliability scoring.
+- **`memory.working`** — transient goals, subgoals, scratch state, and pending actions for the current task. High churn, short retention by default, rarely shared outside the producing agent.
+- **`memory.identity`** — persistent persona attributes, preferences, communication style, and operational policies. Low write frequency, strong access control, audit-worthy on change.
+
+### 1.2 Per-kind Defaults
+
+| Kind | Default retention | Retrieval | Sharing posture | Framing strictness |
+|---|---|---|---|---|
+| episodic | indefinite, decay-weighted | time × similarity | sharable with scope | normal |
+| semantic | indefinite | structured + similarity | broadly sharable | normal |
+| procedural | indefinite, versioned | similarity + usage | broadly sharable | normal |
+| working | task-scoped, short | similarity within task | rarely shared | normal |
+| identity | indefinite | targeted | rarely shared | strict |
+
+Defaults are overridable by operator policy; the kind determines the default treatment, not the only permitted treatment. Overrides MUST be explicit (set in policy or signed in artifact metadata); silent override is non-conformant.
+
+---
+
+## 2. Capability Tokens
+
+A capability token is a `capability.token` typed artifact (see WHITEPAPER §6 artifact schemas). It is signed by an authorizer (the operator controlling the source memory) and verified by anyone holding it.
+
+### 2.1 Fields
+
+- **`subject`** — the public identity authorized to act under this token
+- **`scope`** — what subset of memory is authorized:
+  - **`lineage_subtree`** — root artifact id; authorizes the subtree rooted at that artifact
+  - **`kind_filter`** — one or more `memory.*` kinds
+  - **`tag_filter`** — tag predicate (conjunction of equality / membership / negation clauses)
+  - **`artifact_ids`** — explicit id list
+  - **`scope_intersection`** — combinations of the above are intersected, not unioned
+- **`permissions`** — any subset of `read`, `list`, `share-onward`, `quote`
+- **`expiry`** — optional absolute time bound; absent means unbounded (in which case the caller policy governs)
+- **`revocation_reference`** — token id; revocable by a counter-signed attestation under the authorizer's identity
+- **`chain_of_authority`** — for delegated tokens, references to upstream tokens that delegate authority to this token's authorizer
+
+### 2.2 Verification
+
+A token is valid for a request when ALL of the following hold:
+
+1. The token's COSE_Sign1 signature verifies against the authorizer's public key
+2. The current time is before `expiry` (if present)
+3. The request matches the token's effective `scope` and a subset of its `permissions`
+4. No revocation attestation exists for this token id under the authorizer's identity, per the token's online-check policy (§2.3)
+5. For delegated tokens, every upstream link in `chain_of_authority` independently satisfies conditions 1–4
+
+A verifier MUST fail the check if any condition fails. A verifier MUST NOT silently substitute a stricter scope or partial permission set.
+
+### 2.3 Revocation
+
+Revocation is a counter-signed attestation by the original authorizer (or by an authority delegated to revoke under the chain of authority) recording:
+- the revoked token id
+- the time of revocation
+- the revoker identity
+
+Verifiers consult revocation attestations per the token's online-check policy:
+
+- **`offline`** — no online check; trust expiry alone. Suitable for short-lived tokens.
+- **`online_recommended`** — verifier SHOULD consult the revocation feed but MAY proceed without it if unavailable.
+- **`online_required`** — verifier MUST consult the revocation feed; absence of confirmation MUST fail the check.
+
+Short-lived tokens with `offline` policy are the preferred pattern for high-frequency, low-value operations. Long-lived tokens with `online_required` are appropriate for long-running delegations where revocation latency matters.
+
+---
+
+## 3. Sharing Handshake
+
+The sharing handshake establishes the protocol-level boundary between memory at rest in the source runtime and memory in flight to a target runtime.
+
+### 3.1 Exchange
+
+1. **Receiver presents** a capability token and an identity proof (signature over a session challenge)
+2. **Sender verifies** the token (per §2.2), and computes the effective scope as `intersection(token.scope, sender.current_policy)`
+3. **Sender returns** a session key (KEM agreement with receiver public key), the list of scoped artifact references, and the sender's identity signature
+4. **Both parties** co-sign a share receipt artifact recording: sender, receiver, token id, effective scope, timestamp, session id
+5. **Receipt is anchored** in the lineage DAG of both parties' memory; the share itself becomes an auditable artifact
+
+### 3.2 Transport
+
+The protocol REQUIRES that artifact bytes in flight are encrypted under the session key. The protocol DOES NOT mandate a specific KEM / AEAD suite; supported suites are listed in implementation documentation and negotiated during step 3 of the exchange.
+
+### 3.3 Share Receipt
+
+A share receipt is a typed artifact carrying:
+
+- `sender` — public identity
+- `receiver` — public identity
+- `token_id` — capability token id under which the share was authorized
+- `effective_scope` — the intersected scope actually granted
+- `session_id` — opaque session identifier
+- `timestamp` — handshake completion time
+- Co-signature from both parties
+
+The receipt is the auditable record of the share event. Either party MAY produce the receipt independently from their side; the handshake is symmetric and the receipt is dual-signed.
+
+---
+
+## 4. Rehydration Pipeline
+
+The rehydration pipeline turns artifact bytes received from a sharing handshake into runtime-injectable context. The pipeline is **deterministic**: two implementations given the same inputs and the same configuration produce identical output at every stage.
+
+### 4.1 Stages
+
+```
+artifact bytes
+  -> verify   (authorship, integrity, lineage, anchor)
+  -> filter   (apply capability scope)
+  -> rank     (score against current task)
+  -> compress (reduce to context budget)
+  -> format   (render to runtime-appropriate form)
+  -> frame    (wrap with safe-injection markers; see §5)
+  -> inject   (hand off to runtime context)
+```
+
+### 4.2 Stage Interfaces
+
+- **Verify** — input: COSE_Sign1 bytes + producer public key + optional anchor proof. Output: one of `verified`, `tampered`, `not_found`. A non-`verified` artifact MUST NOT proceed to filter.
+- **Filter** — input: verified artifacts + capability token. Output: subset matching the token's effective scope and permissions. Out-of-scope artifacts MUST be dropped, not silently masked.
+- **Rank** — input: filtered artifacts + task descriptor. Output: scored ranking. The ranker is an abstraction; conforming implementations MAY use embedding similarity, structured query match, learned ranking, or hybrid strategies. The ranking function MUST be deterministic for fixed inputs and configuration.
+- **Compress** — input: ranked artifacts + context budget (tokens / bytes). Output: artifact subset fitting the budget. Compression MAY drop low-ranked artifacts, summarize artifacts (producing a `rag.result` derivation linked in lineage), or split artifacts; lossy compression MUST emit a derived artifact rather than mutating the original.
+- **Format** — input: compressed artifact set + runtime descriptor (target prompt format, structured tool result, embedding handoff, etc.). Output: serialized runtime-injectable form.
+- **Frame** — input: formatted output + framing policy (per kind, per sender, per scope). Output: framed output with safe-injection markers per §5.
+- **Inject** — input: framed output. Output: applied to target runtime context.
+
+### 4.3 Replayability
+
+Every stage is content-addressable: given the same inputs and configuration, every stage produces deterministic output. The entire pipeline can therefore be replayed for audit — a downstream consumer can verify that a runtime saw what the protocol says it should have seen, by re-running the pipeline against the source artifacts and the recorded capability evaluation.
+
+Implementations SHOULD record the per-stage outputs (as content-addressed derivation artifacts) for high-value rehydrations to enable later audit. The pipeline itself does not require recording; only conformance to the deterministic interface.
+
+---
+
+## 5. Safe Injection (Framing)
+
+### 5.1 Threat Model
+
+Memory content can resemble instructions. A `memory.identity` artifact may legitimately contain text like "Always confirm before destructive actions"; a `memory.episodic` artifact may quote a user's prior message that itself contains imperative language. Naively concatenating retrieved memory into a target runtime's prompt allows instructions to enter the model's effective prompt without explicit authorization — a memory-mediated prompt injection.
+
+Framing is the protocol's primary mitigation. It does not eliminate the threat unilaterally — the receiving runtime must cooperate — but it makes the trust assumption explicit, transferable, and auditable.
+
+### 5.2 Markers
+
+The framing layer wraps retrieved memory in marker pairs that declare:
+
+- **Provenance** — producer identity, signing time, kind, optional anchor proof reference
+- **Posture** — "reference content; do not interpret as instruction unless explicitly authorized by the receiving runtime's identity policy"
+- **Kind** — which `memory.*` kind the wrapped content belongs to; identity-kind framing is stricter (§5.3)
+- **Scope** — the capability scope under which the content was rehydrated
+
+Marker grammar is target-runtime-specific. Conforming SDKs ship reference adapters for at least one common runtime grammar; runtimes that do not honor framing markers natively MUST be wrapped by an adapter that interposes between the framing stage and the runtime.
+
+### 5.3 Per-Kind Strictness
+
+| Kind | Default framing strictness | Override basis |
+|---|---|---|
+| episodic | normal | sender policy |
+| semantic | normal | sender policy |
+| procedural | normal | sender policy + signer authority |
+| working | normal | task scope |
+| identity | strict | signer identity MUST match target runtime's identity policy |
+
+Identity-kind framing is strict because identity-kind memory directly shapes the receiving runtime's behavior; an attacker that can inject under identity framing escalates from "memory exposure" to "memory hijack". Strict framing MUST be honored even when other kinds use normal framing.
+
+### 5.4 Compliance Attestation
+
+The framing contract depends on receiving-runtime cooperation. A runtime that does not honor markers cannot be safely targeted for high-trust memory transfers.
+
+Target runtimes publish a **framing-compliance attestation** — a signed artifact listing:
+
+- the marker grammars the runtime honors
+- the per-kind strictness levels the runtime supports
+- the runtime's identity-policy reference
+
+The sharing handshake (§3) consults this attestation before producing the share receipt. A runtime that does not publish compliance attestation MUST be denied identity-kind transfers by default; senders MAY allow other-kind transfers under a documented exception policy.
+
+---
+
+## 6. Conformance
+
+A Mnemonic implementation conforms to this specification when it:
+
+1. Honors per-kind defaults from §1.2; overrides are explicit (signed in artifact metadata or set in operator policy)
+2. Verifies capability tokens per §2.2 and supports the full scope grammar in §2.1
+3. Honors token online-check policies per §2.3
+4. Implements the sharing handshake per §3.1, including co-signed receipts anchored in the lineage DAG
+5. Implements all rehydration pipeline stages per §4.2 with deterministic output for fixed inputs
+6. Wraps rehydrated memory with safe-injection markers per §5.2 and supports at least one reference marker grammar
+7. Publishes a framing-compliance attestation per §5.4 if the implementation is acting as a target runtime for shared memory
+
+Implementations MAY extend the schema registry, the scope grammar, the ranker family, the marker grammar, the KEM/AEAD suite list, and the per-kind defaults, provided extensions are signed and discoverable. Extensions MUST NOT change the meaning of the structures defined here.

--- a/work/whitepaper-v0.2/revisions-draft.md
+++ b/work/whitepaper-v0.2/revisions-draft.md
@@ -1,0 +1,332 @@
+# Mnemonic Protocol Whitepaper — Revisions Draft
+
+**Status:** Working draft of revised sections, May 2026
+**Source:** Design conversation, May 2026
+**Scope:** Revised Abstract; new §5 Architecture with §5.1–§5.6; new §7 Memory Composition and Sharing; notes on existing sections requiring alignment.
+
+---
+
+## How to use this document
+
+This file contains drafted revisions to the Mnemonic whitepaper. Each section below carries a header indicating whether it is **revised**, **new**, or a **note about existing content** that needs alignment.
+
+The revisions follow four discipline rules:
+
+1. The whitepaper describes the protocol in general terms.
+2. Implementation details, specific backend names, costs, and numeric parameters live in companion documents (`docs/implementation/*`, `ECONOMICS.md`, ADRs, pricing pages), not in the whitepaper.
+3. The whitepaper takes positions on protocol properties, not on operator-specific service offerings.
+4. Verification and self-hosting are guaranteed free across all deployments; this is structural, not promotional.
+
+---
+
+## REVISED — Abstract
+
+AI agents accumulate operational context across sessions, tools, and providers — preferences learned over time, factual knowledge extracted from interactions, procedures refined through use, working state maintained across turns, and persistent self-descriptions that shape their behavior. This memory is valuable, but it remains fragile: bound to single providers, locked in proprietary formats, unverifiable by outside parties, and unable to follow the operator that produced it from one runtime to another. As agents become more autonomous and operate across longer time horizons, the absence of a memory layer with cryptographic provenance becomes a coordination problem rather than a convenience problem.
+
+Mnemonic Protocol is a verifiable memory layer for AI agents. It treats memory as a portable, signed artifact — content-addressed, typed, lineage-linked, signed by the operator's cryptographic identity, and independently verifiable by any party that holds it. The protocol distinguishes five kinds of memory artifact — episodic, semantic, procedural, working, and identity — each with its own schema and semantics. Memory belongs to the operator who signed it; it can be shared between runtimes through an explicit handshake mediated by capability tokens and brought into a target runtime through a defined rehydration pipeline that includes safe-injection framing to prevent memory-mediated prompt injection across trust boundaries. Because memory is bound to operator identity rather than to any specific runtime, an agent built up under one model provider can switch providers and continue from the accumulated state.
+
+Mnemonic is independent of where artifacts are stored and how they are anchored. Storage may be local, hosted, or on-chain; anchoring may use any backend that produces a verifiable inclusion proof linking a content-addressed hash to a publicly observable timestamp. Two protocol-level commitments hold across every deployment: verification is free for any party by design, and self-hosting is always available for any operator. These commitments are what make the protocol's trustlessness claim credible — neither the protocol's authors nor any specific operator can gate verification or prevent independent operation. Mnemonic fits underneath agent coordination protocols: A2A makes agents interoperable in motion, the Model Context Protocol makes agents interoperable in capability, and Mnemonic makes them coherent over time. The core thesis is that trustless agents cannot work without trustless agentic memory.
+
+---
+
+## NEW — §5 Architecture Overview
+
+Mnemonic is structured in two layers: a **protocol layer** that defines artifact format, identity, and verification semantics, and a **backend layer** that determines where artifacts physically live. The protocol layer is storage-agnostic. Every guarantee about authorship, integrity, lineage, and authorization holds regardless of which backend is chosen. Backends differ only in availability, latency, cost, and the strength of third-party timestamp claims.
+
+### §5.1 Protocol Layer (storage-independent)
+
+The protocol layer comprises six primitives, none of which assume anything about where bytes are persisted:
+
+- **Canonical encoding** — deterministic CBOR per RFC 8949 §4.2.
+- **Content addressing** — blake3 over canonical bytes.
+- **Signing envelope** — COSE_Sign1 with Ed25519, producer identity bound via DID (`did:key`, `did:sol`, or other supported methods).
+- **Schema registry** — typed, versioned artifact schemas including `memory.episodic`, `memory.semantic`, `memory.procedural`, `memory.working`, `memory.identity`, `rag.context`, `rag.result`, `agent.state`, `receipt`, and `capability.token`.
+- **Lineage DAG** — content-addressed parent→child references with cycle detection and directional traversal.
+- **Capability tokens** — signed, scoped authorizations over lineage subtrees.
+
+A verifier needs the artifact bytes, the producer's public key, and (optionally) a capability token. It does not need to know which backend served those bytes. This is the core property that makes Mnemonic portable: a Mnemonic artifact verified locally and the same artifact verified after retrieval from on-chain storage return identical integrity and authorship results.
+
+### §5.2 The `StorageBackend` Abstraction
+
+Backends implement a small trait:
+
+```rust
+trait StorageBackend {
+    async fn put(&self, artifact: &SignedArtifact) -> Result<BackendRef>;
+    async fn get(&self, reference: &BackendRef) -> Result<SignedArtifact>;
+    async fn list(&self, filter: &Filter) -> Result<Vec<BackendRef>>;
+    fn capabilities(&self) -> BackendCapabilities;
+}
+```
+
+`BackendCapabilities` declares what guarantees a backend provides: `durability`, `third_party_timestamp`, `censorship_resistance`, `random_access_latency`, `cost_per_write_micro_usdc`. Higher layers consult these to route artifacts. Search is abstracted separately (`RecallIndex` trait) so semantic recall does not bind to any specific storage backend.
+
+### §5.3 Backend Implementations
+
+| Backend | Durability | 3rd-party timestamp | Latency | Cost/write | Primary use |
+|---|---|---|---|---|---|
+| **Local** (SQLite) | Operator only | None | <10 ms | 0 | Development, single-agent, working memory |
+| **Cloud** (S3 / object store / Postgres) | Provider SLA | Provider-trusted | 10–100 ms | Low | Production teams, single-org trust boundary |
+| **IPFS / Filecoin** | Network-dependent | Weak (DHT) | 100 ms–s | Very low | Public content, opportunistic availability |
+| **Arweave** | Permanent (pay-once) | Implicit (block order) | 1–10 s to settle | Low | Long-lived attestations, audit records |
+| **On-chain anchor** | Anchors only (paired with durable storage) | Strong | seconds | Low per anchor (batched) | Trustless timestamp for high-value artifacts |
+| **Hybrid** | Composite | Composite | Composite | Composite | Default for real deployments |
+
+Most deployments run **hybrid**: local SQLite as the hot path for every artifact, with cloud or on-chain backends layered on for artifacts requiring durability or independent verification. The choice per artifact is governed by policy and capability, not by the protocol.
+
+### §5.4 Why On-Chain Is Optional
+
+On-chain anchoring is the only backend that provides independent third-party timestamp without trusting any single operator. It is therefore valuable, but it is also the most expensive: every on-chain transaction costs something. Mnemonic treats on-chain anchoring as one tool in the kit:
+
+- **Anchor when** an artifact's existence at a specific time must be verifiable by a party that does not trust the operator.
+- **Do not anchor when** local or cloud durability is sufficient — the vast majority of working memory, draft state, and intra-session artifacts fall here.
+- **Batch anchor when** many low-value artifacts can share a single timestamp (see §5.5).
+
+The protocol's guarantees about authorship and integrity require no chain at all — only signatures and canonical encoding. Chain anchoring adds **third-party timestamp** and **non-repudiation against operator collusion**, which are valuable but separable properties.
+
+### §5.5 Anchoring
+
+Anchoring produces a verifiable claim that an artifact existed at or before a given time, checkable by any party without trusting the artifact's producer or the operator that stored it. Signatures alone give authorship and integrity; anchoring adds independent timestamp and non-repudiation against operator backdating. These are separable properties, and the protocol exposes them separately rather than collapsing them into a single boolean.
+
+Anchoring is the only protocol operation whose marginal cost is bounded below by an external system. The protocol minimizes that cost through batching and remains agnostic to the choice of anchor backend.
+
+#### §5.5.1 Merkle batching via the lineage DAG
+
+The lineage DAG (§5.1) provides what batched anchoring requires. A batch root is a derived artifact whose parents are the artifacts in the batch:
+
+```
+BatchRoot = derive(
+    schema     = "batch.root",
+    parent_ids = [H_1, H_2, ..., H_N]
+)
+```
+
+Because the batch root's canonical bytes contain its parents' content-addressed ids, and its own id is the hash of those bytes, modifying any leaf breaks the chain up to the root. The lineage DAG functions as a Merkle commitment without additional structure. Only the batch root is anchored; inclusion of any single artifact is proved via the lineage path. Batches compose into trees for logarithmic inclusion proofs at large N. Flat versus tree batching is a deployment parameter, not a protocol commitment.
+
+The amortized per-artifact anchoring cost decreases proportionally with batch size. Operators choose batch parameters according to their latency tolerance for anchor finality.
+
+#### §5.5.2 Backend-agnostic anchor proofs
+
+The protocol accepts any anchor backend that produces a verifiable inclusion proof linking a content-addressed hash to a publicly observable timestamp. The contribution of a backend is captured in an `anchor_proof` record: a backend identifier, a backend-specific reference, the anchored hash, and the timestamp.
+
+Backends differ in finality latency, cost per anchor, trust assumption, and timestamp granularity. The protocol takes no position on the right trade-off across these axes. The reference implementation supports specific backends; their identification and operational parameters are specified in implementation documentation rather than in this protocol document.
+
+#### §5.5.3 Self-anchoring
+
+The protocol distinguishes between *producing* an anchor and *accepting* an anchor proof. Any operator can submit an anchor transaction independently of any hosted service and present the resulting proof to the protocol; verification uses the same logic regardless of who produced the anchor. This is the structural property that keeps the protocol open — hosted anchoring is convenience, not a gate.
+
+#### §5.5.4 Verification states
+
+Anchoring is asynchronous. The protocol defines explicit states reflecting whether an artifact has settled, is in flight, or remains unanchored: **signed but not anchored**, **anchor pending**, **anchored**, **anchor failed**. A verifier always knows which state an artifact is in. The protocol never claims an anchor exists when it does not, and never claims an absence of anchor when one is in flight.
+
+#### §5.5.5 What anchoring does and does not guarantee
+
+Anchoring adds existence at or before a known time, tamper-evidence for all artifacts under the anchored root, and non-repudiation against operator backdating. Anchoring does not provide content availability, authorization to read, correctness of the artifact's claims, or sub-settlement-time finality. Signed-but-unanchored artifacts remain fully valid for authorship and integrity. Anchoring upgrades verifiability against operator collusion and adds a public timestamp.
+
+### §5.6 Protocol Economics
+
+The protocol takes positions on what must remain free and what may be paid, but takes no position on how any particular operator prices the services they offer. The result is an economic model in which the protocol itself is unmonetizable while the services built on top of it are freely monetizable. This separation is intentional: it is what allows the protocol to remain a public good even when individual operators are commercial.
+
+#### §5.6.1 Operations the protocol guarantees are free
+
+Two operations are free by protocol design and cannot be gated by any operator:
+
+- **Verification.** Any party may verify the authorship, integrity, lineage, and anchoring of any artifact they hold. Verification requires no operator service, no account, and no permission. This is the foundation of the protocol's trustlessness claim — if verification can be gated, the protocol's guarantees become contingent on whoever holds the gate.
+- **Self-hosting.** Any operator may run a complete node, sign and verify locally, and participate in the protocol without paying any other operator. The full set of protocol operations is available to any operator running their own implementation.
+
+These two guarantees are structural protections against capture. They mean that no party — including the protocol's original authors — can hold the protocol's core functionality hostage.
+
+#### §5.6.2 Operations operators may charge for
+
+Operations whose cost is bounded below by real compute, storage, bandwidth, or external-system fees may be charged for by the operator providing them. These are service-layer choices and the protocol takes no position on whether they are priced, subsidized, or free at any particular operator:
+
+- Producing anchors against backends that have non-zero cost.
+- Hosting durable storage on behalf of users.
+- Running embedding, recall, or query workloads at scale.
+- Operating high-availability or dedicated infrastructure.
+- Providing managed identity, capability, or audit services.
+
+Charging is a feature of operator deployment, not of the protocol. An operator may choose to offer any of these for free, at cost, or at a margin. Users uncomfortable with one operator's pricing are free to use another, run their own, or operate without that service entirely.
+
+#### §5.6.3 Operator pluralism
+
+The protocol does not privilege any operator. There is no canonical hosted service, no preferred node, no central registry of authorized operators. Any party may run a Mnemonic node, accept artifacts from other operators, anchor on behalf of users, and charge for any of these services. Verification of an artifact is independent of which operator produced it.
+
+This pluralism is what makes the free-tier guarantees credible. An operator that abuses its position — by raising prices, degrading service, or restricting access — does not control the protocol; users can migrate to other operators or to self-hosting without losing accumulated state, because all artifacts are portable by signature and verifiable independently.
+
+#### §5.6.4 Payment as a protocol primitive
+
+The protocol provides primitives for operators that wish to charge for services: payment-gated tool calls, balance-tracking accounts, and standard micropayment patterns over established settlement rails. These primitives are tools, not mandates. An operator that wishes to provide free service simply does not enable payment gating; an operator that wishes to charge enables it. The same protocol code supports both modes.
+
+Operators that charge are responsible for the economics of their own services: pricing, free quotas, subsidies, revenue allocation, and treasury management. These are commercial decisions of individual operators and are not specified by the protocol.
+
+#### §5.6.5 What this economic model rules out
+
+The combination of free verification, free self-hosting, operator pluralism, and optional payment rules out several common failure modes of protocol economics:
+
+- **Verification capture.** No operator can charge for the act of checking whether an artifact is genuine.
+- **Publishing capture.** No operator can prevent a user from signing and storing artifacts; the user can always run their own node.
+- **Lock-in.** Artifacts produced under one operator are verifiable by any other operator and by self-hosted nodes. There is no operator-specific format or operator-specific verification path.
+- **Single-operator dependency for protocol liveness.** Even if a particular hosted operator becomes unavailable, the protocol continues to function across all other operators and self-hosters.
+
+The protocol does not rule out commercial activity. It rules out commercial activity that depends on holding the protocol itself hostage.
+
+#### §5.6.6 Implementation-level economics
+
+Specific pricing, free-tier quotas, subsidy models, treasury accounting, and revenue strategy are operator-level concerns documented separately from the protocol specification. Different implementations and different hosted operators will make different choices. The protocol document specifies only what those choices must respect: verification stays free, self-hosting stays available, and no operator becomes structurally privileged over others.
+
+### §5.7 Pipeline Walkthrough
+
+*Note: The existing §5.3 "Pipeline Walkthrough" content from the v0.1 whitepaper moves here unchanged. It already describes the sign / recall / verify flow correctly across local and full modes and does not require rewriting.*
+
+---
+
+## NEW — §7 Memory Composition and Sharing
+
+*(Existing §7 "Trust Model" becomes §8; subsequent sections shift down by one.)*
+
+Memory is not a homogeneous blob. An agent's working state, its accumulated facts about the world, the procedures it has learned, the events it has witnessed, and its persistent self-description all play different cognitive roles and warrant different lifecycle, retrieval, and access semantics. The protocol exposes this structure directly through typed memory artifacts, and provides primitives for authorizing and transferring memory across the runtimes that operate on it.
+
+This section describes those primitives. It does not specify retrieval algorithms, scoring functions, or implementation parameters — only the protocol contracts that any compliant implementation must respect.
+
+### §7.1 Memory composition
+
+The protocol distinguishes five kinds of memory artifact, each with its own schema in the registry:
+
+- **Episodic memory** records time-ordered events, observations, and interactions. It captures what happened.
+- **Semantic memory** records factual assertions about the world, typically as structured claims with confidence scores. It captures what is believed to be true.
+- **Procedural memory** records learned skills, routines, and workflows. It captures how to do things.
+- **Working memory** records transient goals, subgoals, scratch state, and pending actions. It captures what is currently being attempted.
+- **Identity memory** records persistent persona attributes, preferences, communication style, and operational policies. It captures who the operator is.
+
+These distinctions are not merely organizational. Each kind has different retention semantics, different retrieval characteristics, different sharing implications, and different requirements for safe injection into a target runtime. A protocol that treats memory as a homogeneous store cannot make these distinctions; a protocol that recognizes them can route, scope, and transfer each kind appropriately.
+
+The five kinds compose. A semantic fact may be derived from an episodic observation; a procedural skill may reference identity preferences; working state may draw on all four others. The lineage DAG (§5.1) captures these derivation relationships across kinds.
+
+### §7.2 Capability tokens
+
+Memory is owned by the identity that signed it. By default, no other party may read it. Sharing requires explicit authorization, expressed as a capability token: a signed artifact whose schema declares it as a permission grant rather than a memory entry.
+
+A capability token carries four pieces of information:
+
+- **Scope** — which artifacts the token applies to, expressed in terms of the lineage DAG (a specific artifact, a subtree under a specific root, all artifacts of a given kind, or all artifacts matching a tag predicate).
+- **Permissions** — which operations the token authorizes (read, derive, redact, export, rehydrate, or operations specific to the schema being authorized).
+- **Audience** — the identity authorized by the token, expressed as a DID. A token bound to a specific audience cannot be reused by another party.
+- **Expiry** — the time after which the token is no longer valid.
+
+Tokens are signed by the issuing identity using the same envelope used for all other signed artifacts (§5.1), and are verified by the same machinery. There is no separate token format and no separate verifier.
+
+Tokens are themselves artifacts. They have content-addressed ids, they appear in the lineage DAG, they may be anchored, and they may be revoked by issuing a successor token that explicitly invalidates them. A holder of a token can verify the token's authenticity and current validity using only the protocol's standard verification primitives.
+
+### §7.3 The sharing handshake
+
+A party wishing to access memory held by another operator does not have direct access to that memory; the protocol mediates the transfer through a handshake whose contract is the following:
+
+1. The requester obtains the content-addressed id of the desired artifact and the owner's identity through any means external to the protocol. The protocol does not specify a discovery mechanism in v1.
+2. The requester transmits to the owner their public key, a signed challenge proving control of the corresponding private key, and any capability token they hold authorizing the request.
+3. The owner verifies the challenge signature, evaluates the capability token against the requested artifact, and applies any additional policy.
+4. If the request is authorized, the owner serializes the artifact along with the lineage ancestors required for its verification, compresses the result, encrypts to the requester's public key using established key-exchange primitives, and transmits the resulting bundle.
+5. The requester decrypts, decompresses, and verifies the artifact through the standard verification pipeline.
+
+The protocol specifies the handshake contract but not the transport. Memory may be transferred over any channel capable of carrying an encrypted byte string. The contract is enforced by what the parties produce and verify, not by where the bytes travel.
+
+### §7.4 Rehydration
+
+A verified artifact is not yet useful to a target runtime. To act on memory, the runtime requires the memory rendered into its active context, in a form that respects its token budget, instruction hierarchy, and safety constraints. The protocol calls this transformation rehydration.
+
+Rehydration is a pipeline of stages, each of which any compliant implementation must perform:
+
+1. **Verify** — confirm authorship, integrity, lineage, and (where applicable) anchoring of the artifact and its transitive ancestors.
+2. **Filter** — exclude artifacts not authorized by the capability tokens presented for this rehydration.
+3. **Rank** — order remaining artifacts by relevance to the current task. The ranking function is implementation-defined; the protocol requires only that its inputs include the artifact, the task context, and the artifact's metadata.
+4. **Compress** — fit the ranked set into the target runtime's context budget, preserving high-ranked content verbatim and condensing lower-ranked content according to the implementation's strategy.
+5. **Format** — render the compressed content in a form appropriate for the target runtime's conventions.
+6. **Frame** — wrap the formatted content in structural markers that the target runtime treats as data rather than as instructions (§7.5).
+7. **Inject** — place the framed content into the target runtime's context in a position consistent with the runtime's instruction hierarchy.
+
+Each stage has defined inputs, outputs, and failure semantics. An implementation may parameterize any stage but may not skip stages or reorder them; the contract exists because each stage protects properties that downstream stages rely on.
+
+### §7.5 Safe injection
+
+Memory transferred from one runtime to another can carry, intentionally or otherwise, content that resembles instructions. A naive injection that places transferred memory directly into a runtime's input stream creates an attack surface in which the source memory can hijack the target runtime's behavior.
+
+The protocol requires that all rehydrated memory be wrapped in typed boundary markers and accompanied by an explicit directive identifying the content as data rather than as instructions. Content within those markers is escaped at the boundary level to prevent boundary breakout, at the role-marker level to prevent role hijacking, and at the instruction-pattern level to neutralize known injection vectors. Content that does not match the schema declared for its boundary is quarantined and excluded from the framed output.
+
+The specific framing syntax is implementation-defined; the requirement that framing be present and enforced is protocol-defined. An implementation that omits framing does not produce protocol-compliant rehydration output.
+
+### §7.6 Portability model
+
+Memory belongs to the identity that signed it. That identity may operate any number of runtimes — different model providers, different agent frameworks, different physical machines — and the protocol guarantees that memory signed under that identity remains verifiable, transferable, and rehydratable across all of them without re-signing or re-attesting prior records.
+
+This is the protocol's portable-memory property: an operator who builds up memory under one runtime can switch runtimes and continue from the accumulated state, because the runtime is a consumer of the operator's memory, not its owner.
+
+The portability model in v1 covers a single owning identity operating across multiple runtimes. Multi-operator scenarios, in which different owning identities share memory across organizational boundaries, are a strict extension of this model: the same primitives — typed artifacts, capability tokens, the handshake, rehydration — apply, but with additional discovery, registry, and cross-identity trust concerns that v1 leaves out of scope.
+
+---
+
+## Existing sections requiring alignment edits
+
+The following existing whitepaper sections were not redrafted in this conversation. They contain framing that does not match the new structure and need light edits before the revised whitepaper is internally consistent.
+
+### §1 Introduction
+
+Currently references "local for development, decentralized for verification" as the storage model. Should be aligned with the storage-agnostic framing of the new §5: storage is one of several pluggable backends, not a binary mode.
+
+### §2 Problem Statement
+
+Currently emphasizes the technical fragility of agent memory but does not surface the cognitive structure of memory or the sharing problem. Should be expanded slightly to motivate the §7 primitives (cognitive typing, capabilities, rehydration, safe injection).
+
+### §3 Design Goals
+
+The "Current Implementation Goals" and "Protocol Roadmap Goals" subsections list cognitive memory structure, capability tokens, and rehydration as future work. Several of these are now core protocol primitives per §7 and should move to the current-goals list. The list of cryptographic primitives in 3.1 is implementation detail and should be trimmed.
+
+### §4 Core Insight
+
+Currently describes the protocol pipeline as `embed → compress → canonicalize → hash → sign → persist → recall → verify`. This is the *sign* pipeline. The full protocol contract now also includes the *share/rehydrate* pipeline introduced in §7. The core insight section should mention both flows.
+
+### §6 Artifact Model
+
+Currently lists schemas (`memory`, `rag.context`, `rag.result`, `agent.state`, `receipt`). Should be updated to reflect the cognitive memory taxonomy from §7.1 (`memory.episodic`, `memory.semantic`, `memory.procedural`, `memory.working`, `memory.identity`) and `capability.token`. The `memory` schema becomes a deprecated alias or is replaced by the five typed kinds.
+
+### §8 Trust Model (was §7)
+
+Should be cross-referenced with §5.6 (Protocol Economics) commitments. The "Mnemonic does not yet guarantee" list should be updated to remove items now addressed by §7 (capability-scoped access, multi-runtime portability) and to keep items genuinely out of scope (multi-party shared namespaces, ZK proofs).
+
+### §9 Use Cases (was §9)
+
+Several use cases — Shared Project Memory Namespace (§9.1), Portable Memory Wallet (§9.5), Agent Continuity Layer (§9.9) — now read as deployments of §7 primitives rather than as standalone features. They should be tightened to reference §7 and §5 rather than restate primitives.
+
+### §11 Current Implementation Status (was §11)
+
+The "Implemented today" list is accurate per the May 2026 monorepo state. The "Not current implementation behavior" list should be updated to include capability tokens, the rehydration pipeline, safe-injection framing, and the sharing handshake as not-yet-implemented protocol primitives. This keeps the gap between protocol specification and current implementation honest.
+
+---
+
+## Companion documents this whitepaper references
+
+The whitepaper is intentionally agnostic about implementation-level details. Those details should live in companion documents in the repository:
+
+| Document | Contents |
+|---|---|
+| `docs/implementation/anchoring.md` | Specific anchor backends supported, their cost characteristics, latency, and trust assumptions |
+| `docs/implementation/schemas/` | Concrete field definitions for each schema in the registry, including the five memory kinds and capability tokens |
+| `docs/implementation/framing.md` | Concrete framing syntax for safe injection, escape rules, and quarantine semantics |
+| `docs/implementation/crypto.md` | Specific cryptographic primitives, including key-exchange derivation for the sharing handshake |
+| `ECONOMICS.md` | Specific pricing, free-tier quotas, subsidy plan, treasury accounting (operator-specific, not protocol-specific) |
+| `docs/adr/` | Architecture decision records covering specific implementation choices (default anchor backend, etc.) |
+| `docs/operator-guide.md` | Deployment guidance, including batch size selection, backend configuration, and operator-level economic choices |
+
+---
+
+*End of revisions draft. Suggested next step: review this document, integrate the new sections into the existing whitepaper file, perform the alignment edits listed above on the existing sections, and commit as a v0.2 whitepaper.*
+
+---
+
+## Provenance
+
+- **Attestation ID:** `1ee91ba4-6e1e-4ea1-9843-af7885139177`
+- **Content hash (blake3 of canonical CBOR):** `33cac0e59ddf021df6bb682440a20af314c8b1a31a71f6e9f6a5200209203e23`
+- **Solana tx:** `3trZxfswfFRVCoXzHUHwETsewSt6CZ5BP3NjcCPXHXwU8kQ297yKq3VvCJDDw8ocVpw9v4L2R2q2Ad6W9VWimBza`
+- **Arweave tx:** `CubJzDPLBaLF7fo67KB9RWXgex1QV8RsaWPWWkEaLoT3`
+- **Producer:** `2jdrmxfLqiCtRNL1u5ZdLaKKdq6Wg8iPqvJSohQhLq4x`
+- **Signed at:** 2026-05-16T04:07:03Z


### PR DESCRIPTION
* docs: v0.2 abstract — typed-memory + storage/anchoring split

Replace abstract with v0.2 framing: five-kind memory taxonomy (episodic/semantic/procedural/working/identity), capability tokens, sharing handshake, rehydration, safe injection. Decouple storage backend from anchoring backend. Add the two structural commitments (free verification, free self-hosting) as protocol-level invariants. Bump draft header to v0.2 / May 2026.

Working draft of full revisions checked into work/whitepaper-v0.2/ for the chapter-by-chapter pass.

Source attestation: 1ee91ba4-6e1e-4ea1-9843-af7885139177 (Solana 3trZxfsw..., Arweave CubJzDPL..., blake3 33cac0e5...).

* docs: v0.2 §6 — typed memory taxonomy + capability.token

Expand the schema registry list in §6 to surface the five cognitive memory kinds (episodic, semantic, procedural, working, identity) and the capability.token schema introduced in §7. Retain rag.context, rag.result, agent.state, and receipt. Note that the flat `memory` schema becomes a deprecated alias resolving to `memory.episodic`.

Cross-references §7.1 (composition) and §7.2 (capability tokens), which land in a later commit.

* docs: v0.2 §1 — align Introduction with typed memory and pluggable storage

Reframe the core unit from "semantic memory item" to "typed memory artifact" with cognitive roles (episodic/semantic/procedural/working/ identity), since "semantic memory item" now collides with memory.semantic as a specific kind in the v0.2 taxonomy.

Add the operator-owned portability framing (memory follows the operator across runtimes) and the storage-agnostic framing (backends are pluggable, not a binary local/decentralized mode). Both points were implicit in v0.1 and are now load-bearing in v0.2; surfacing them in §1 keeps the rest of the document coherent.

Forward-refs §5 and §7.1.

* docs: v0.2 §2 — surface cognitive structure and the sharing problem

Add two named compounding problems missing from v0.1:

1. Memory has cognitive structure that flat stores erase — motivates the typed five-kind taxonomy as a protocol-layer concern.
2. Memory crosses trust boundaries, and the transfer itself is unsolved — names the three sub-problems (authorization, verifiable transit, injection safety) that §7 primitives address.

Expand the property list from 6 to 9: keep persistence / semantic recall / provenance / integrity / portability; add cognitive typing, capability-scoped sharing, safe injection across runtimes; sharpen economic viability to call out free verification as structural.

* docs: v0.2 §3 — Protocol Goals vs Forward Goals, trim impl detail

Rename §3.1 from "Current Implementation Goals" to "Protocol Goals" and §3.2 from "Protocol Roadmap Goals" to "Forward Goals". The v0.1 labels conflated protocol commitments with implementation choices. Implementation status now lives only in §11; backend specifics, costs, and parameters live in companion documents per the v0.2 discipline rules.

Protocol Goals (§3.1) now lists ten protocol commitments, including the items that v0.2 elevates from "future" to current: cognitive typing, lineage as first-class, storage agnosticism, anchoring as separable, capability-scoped sharing, safe rehydration, free verification, free self-hosting, operator pluralism. Drops named backends (CBOR, COSE_Sign1, blake3, SQLite, Arweave, Solana, MCP) and the "support local development" line — those are §11 implementation status, not protocol-level goals.

Forward Goals (§3.2) keeps the items still genuinely out of v1 scope: multi-operator shared memory, stronger privacy/encryption, lifecycle policy, broader provenance attestations, settlement-aware flows, reliability scoring, ZK proofs, WASM crate, browser demo.

* docs: v0.2 §3 — rename to Protocol Contract; relocate forward goals

"Design Goals" is a product-spec convention, not a whitepaper one. The 10-item protocol commitments list is structural enough to keep, but reads more honestly as a protocol contract — properties any compliant deployment must provide — than as aspirational design goals.

Drop the §3.1 / §3.2 sub-headings and flatten the protocol-commitments list to be the direct content of §3. Add a closing pointer to §14 where forward-looking work lives.

Most §3.2 v0.2 forward goals were already in §14 Roadmap (privacy in Phase 2, lifecycle in Phase 2, shared namespaces in Phase 3, broader provenance in Phase 3, settlement in Phase 4, reliability in Phase 4, ZK in Phase 4). The two items not yet captured — WASM crate parity and browser demo client — land in Phase 1 under developer experience.

* docs: v0.2 §4 — add share/rehydrate pipeline alongside sign pipeline

v0.1 §4 showed only the sign pipeline (content → embed → ... → recall and verify). The v0.2 protocol contract also includes a share/rehydrate flow (§7.3 handshake + §7.4 rehydration + §7.5 safe injection), and the core-insight section should name both.

Add the share/rehydrate pipeline diagram next to the sign pipeline, plus a line noting they compose: the sign flow produces an artifact that the share/rehydrate flow can hand to another runtime, and both verify the same canonical bytes against the same producer identity. This is what makes portable memory a property rather than an aspiration.

Other changes:
- "semantic memory items" → "typed memory artifacts" (consistent with §1 swap; "semantic" now collides with memory.semantic as a kind)
- Add "portable across runtimes" to the lead-in principle
- Trim the closing paragraph: drop TurboQuant naming and the 2–4 bit / 32× numbers per the discipline rule that specific algorithms and numeric parameters belong in companion docs. Retain the principle that compression is for portability/anchoring, not local recall.

* docs: v0.2 §5.3 — strip impl-specific names from Pipeline Walkthrough

The v0.2 revisions draft said §5.3 "moves to §5.7 unchanged" but the existing text violates the v0.2 discipline rule that implementation details, specific backend names, and numeric parameters live in companion documents.

Stripped from the three flow descriptions:
- "The MCP server" / "`mnemonic-core` primitives" → "the protocol"
- "mnemonic_sign_memory / mnemonic_recall / mnemonic_verify" tool names → "Sign / Recall / Verify"
- "FastEmbed local, OpenAI remote, MockEmbedder" → "the configured embedder"
- "TurboQuant scalar quantizer at 2/3/4 bits per dimension, default 4" → "the vector is compressed"
- "f32 vector" → "full-precision embedding vector"
- "SQLite" / "AttestationStore" / "the row" → "the local index"
- "Arweave (via Irys)" / "Solana via SPL Memo" → "the chosen anchor backend" / "on-chain backends"
- "local: transaction IDs at zero cost" / "full table scan with no chain reads" → dropped (cost/perf detail)
- "local mode / full mode" → "deployment's policy" (the binary mode framing is replaced by the v0.2 backend-policy framing)

Recall description no longer claims to be "local-only by design"; instead it states that recall reads from the local index regardless of where else artifacts are stored, which is the protocol-level claim.

§5.3 will move to §5.7 cleanly during the §5 rewrite.

* docs: v0.2 §5 — full Architecture rewrite with Consumer Surfaces

Replace v0.1's two-layer architecture (core + mcp) and binary "Local mode / Full mode" storage list with the v0.2 storage-agnostic architecture. Storage is no longer a mode; it is a user choice per artifact. The protocol provides all three storage categories (local, cloud, on-chain), and any surface can drive any backend.

Structure:
- §5 intro now describes the two horizontal layers (protocol + backend) and the vertical surfaces over them.
- §5.1 Protocol Layer — six storage-independent primitives.
- §5.2 Consumer Surfaces (NEW) — core, cli, sdk, mcp, browser-extension. All surfaces consume the same primitives and reach the same backends; surface choice is ergonomic, backend choice is the user's per artifact. Explicitly names sdk and browser-extension as self-host-capable for direct on-chain anchoring.
- §5.3 StorageBackend abstraction — small trait, capability declaration.
- §5.4 Backend Implementations — table covers Local / Cloud / P2P / Permanent / On-chain anchor / Hybrid. Specific implementations are examples; identifiers live in companion docs.
- §5.5 Why On-Chain Is Optional — three rules of thumb.
- §5.6 Anchoring (§5.6.1–§5.6.5) — Merkle batching via lineage DAG, backend-agnostic anchor proofs, self-anchoring (cli/sdk/browser-ext all self-anchor; mcp adds hosted-anchor convenience), verification states, what anchoring does/doesn't guarantee.
- §5.7 Protocol Economics (§5.7.1–§5.7.6) — free verification, free self-hosting, what operators may charge for, operator pluralism, payment as primitive, what this rules out, implementation-level economics off-loaded to companion docs.
- §5.8 Pipeline Walkthrough — body unchanged from a344e5f cleanup, with one fix: "the deployment's policy selects" → "the user has selected".

Updated §3 cross-refs to match the §5.6 / §5.7 shift caused by inserting §5.2 Consumer Surfaces. Forward-refs to §7.2 / §7.4 / §7.5 still pending the §7 insert.

* docs: v0.2 §7 — insert Memory Composition and Sharing; renumber §8–§16

New §7 Memory Composition and Sharing resolves the forward-refs from §3 / §4 / §6 (cognitive typing, capability tokens, sharing handshake, rehydration pipeline, safe injection, portability).

Subsections:
- §7.1 Cognitive Typing — the five memory.* kinds (episodic, semantic, procedural, working, identity) and the per-kind retrieval, retention, sharing, and safety treatments. Kind is part of the canonical artifact and verified alongside content.
- §7.2 Capability Tokens — signed, scoped, revocable authorizations (subject, scope, permissions, expiry, revocation reference, chain of authority). Counter-signed revocation; short-lived tokens preferred for high-value operations.
- §7.3 Sharing Handshake — mutual auth, scope intersection, encrypted transport, co-signed share receipt anchored in lineage DAG.
- §7.4 Rehydration Pipeline — verify → filter → rank → compress → format → frame → inject. Deterministic, replayable, auditable per stage.
- §7.5 Safe Injection (Framing) — wrap retrieved memory in safe- injection markers so content cannot escape into instruction. Identity- kind artifacts carry stricter framing. Framing depends on receiving- runtime cooperation and is itself attestable.
- §7.6 Portability Across Runtimes — the composition claim: operator identity, not runtime identity, binds memory over time.

Renumbering applied to all sections following the insert:
- §7 Trust Model            → §8
- §8 Positioning            → §9
- §9 Use Cases              → §10  (incl. §9.1–§9.10 → §10.1–§10.10)
- §10 Related Work          → §11
- §11 Implementation Status → §12
- §12 Evaluation Plan       → §13
- §13 Limitations           → §14
- §14 Roadmap               → §15
- §15 Conclusion            → §16

Cross-refs in §3 updated: "§11" → "§12" (implementation status), "§14 Roadmap" → "§15 Roadmap". All §7.x forward-refs in §3/§4/§6 now resolve to real subsections.

* docs: trim §7 to protocol-contract claims; move detail to spec companion

§7 as initially written did two jobs at once: stating protocol-level contracts (which belong in the whitepaper) and specifying field-by-field structures, exchange protocols, and stage interfaces (which belong in a companion spec). This commit separates them.

Whitepaper §7 (now ~28 lines, was ~80):
- §7.1 Cognitive Typing — one paragraph: kinds drive per-kind retention/retrieval/sharing/safety; kind verified with content
- §7.2 Capability Tokens — one paragraph: signed/scoped/revocable, content-addressed, verified by anyone; details in spec
- §7.3 Sharing Handshake — one paragraph: mutual auth + scope intersection + encrypted transport + co-signed receipt in lineage
- §7.4 Rehydration Pipeline — one sentence naming the seven stages, one sentence on determinism and replayability
- §7.5 Safe Injection (Framing) — one paragraph: threat, markers, per-kind strictness, runtime cooperation, compliance attestation
- §7.6 Portability Across Runtimes — unchanged (already short)

Every subsection ends with a pointer to docs/spec/memory-composition.md where the field-level detail now lives.

New docs/spec/memory-composition.md (208 lines):
- §1 Cognitive Typing — kinds with full per-kind defaults table
- §2 Capability Tokens — fields (subject/scope/permissions/expiry/ revocation/chain), verification rules, revocation policies
- §3 Sharing Handshake — five-step exchange, transport requirements, share receipt structure
- §4 Rehydration Pipeline — stage diagram, per-stage interfaces, replayability requirement, lossy-compression derivation rule
- §5 Safe Injection — threat model, marker requirements, per-kind strictness table, compliance-attestation requirement
- §6 Conformance — seven-point implementation checklist

The §8 Trust Model section (was §7 in v0.1) still has v0.1 framing leaks (mentions "local-mode"/"full-mode"/"SQLite") that will be addressed in a separate cleanup commit.

* docs: v0.2 §8 — Trust Model cleanup; align with v0.2 architecture

Keep the v0.1 structure (guarantees / not-yet-guarantees / closing note) but bring each item in line with the v0.2 protocol surface.

Guarantees expanded from 5 → 9 to reflect what §5/§6/§7 now provide:

  Removed:
  - "Local verifiability: local-mode records can be checked against SQLite state" — v0.1 mode framing + impl-specific backend name
  - "External verifiability: full-mode records can be checked against persisted artifacts and chain anchors when available" — same
  - "Version awareness: legacy JSON/SHA-256 artifacts handled separately" — backward-compat impl note, not a protocol guarantee; belongs in §12 Implementation Status

  Added:
  - Lineage verifiability — content-addressed parent→child chains
  - Backend-independent verification — same result from any backend
  - Optional third-party timestamp — anchoring as separable property
  - Capability-scoped sharing — signed/scoped/revocable tokens
  - Auditable transfer — co-signed share receipts in lineage DAG
  - Safe-injection contract — framing markers + compliance attestation
  - Free verification — no operator gate

  Kept and rephrased:
  - Integrity — now references canonical encoding (no longer named CBOR)
  - Authorship — Ed25519 operator identity

Not-yet-guarantees refined to match v0.2 surface:

  Removed:
  - "Safe multi-party shared memory semantics" — too broad; pairwise sharing IS now provided by §7. Refined to the narrower remaining gap
  - "End-to-end encryption in the active MCP sign/verify path" — too impl-specific. Refined to "At-rest encryption of memory content"

  Added:
  - At-rest encryption of memory content (canonical format is plaintext under signature; transport encryption IS provided by §7.3 handshake)
  - Receiving-runtime safety beyond the framing contract (captures the framing-compliance dependency from §7.5)
  - Concurrent multi-writer shared namespaces (the refined remainder of the old "Safe multi-party shared memory semantics")

  Kept:
  - Correctness of memory content
  - Completeness of memory history
  - ZK embedding correctness
  - ZK retrieval correctness

Closing paragraph rewritten: protocol commits only to what signatures and canonical encoding can enforce, plus what capability tokens and sharing handshake can authorize and attest. Points to §15 Roadmap for the deferred extensions.

* docs: v0.2 §9 / §12 / §14 — final consistency pass against v0.2 surface

§9 Positioning In The Agent Stack:
- Add MCP next to A2A as a stack layer Mnemonic sits underneath. Matches the Abstract's three-layer framing.
- Expand the closing one-sentence to: "A2A makes agents interoperable in motion; MCP makes them interoperable in capability; Mnemonic makes them coherent over time."

§12 Current Implementation Status:
- Reframe the section intro: the current implementation exercises one path through the v0.2 architecture and does not yet expose the full protocol surface; this section names the gap.
- "Implemented today" list cleaned up: name "MCP tools" generically; drop "current artifacts" qualifier from blake3 hashing; clarify binary local/full modes as predecessor of §5.3 per-artifact selection.
- "Not yet implemented" list expanded against the v0.2 surface:
  - Per-artifact StorageBackend selection (§5.3)
  - Cognitive typing (the five memory.* kinds; §7.1)
  - Capability tokens (§7.2)
  - Sharing handshake (§7.3)
  - Rehydration pipeline filter/rank/compress/format/frame/inject (§7.4)
  - Safe-injection framing + compliance attestation (§7.5)
  - WASM build of core + browser-extension surface (§5.2)
  - Standalone sdk and cli distribution targets (§5.2)
  - At-rest encryption of memory content (§8) Kept the original items: multi-writer shared namespaces, reliability oracle / on-chain registry, ZK proofs.

§14 Limitations And Open Questions:
- Drop "Product packaging" — now answered by §5.2 consumer surfaces.
- Add specificity to existing items: link encryption to §7.3, link semantic-contradiction to memory.semantic kind, link lifecycle to §7.1 per-kind defaults, link multi-writer to §7.2/§7.3 capability tokens vs the namespace gap.
- Add "Framing-compliance ecosystem" — the §7.5 registry/attestation format/inclusion-criteria open question.
- Add "Cross-implementation interop testing" — conformance across core / cli / sdk / mcp / browser-extension and native vs WASM builds.
- Add specificity to compliance: regulatory boundaries, jurisdiction, audit primitives.

Abstract: no edit — already aligned (uses v0.2 terminology throughout: verifiable memory layer, portable signed artifact, five kinds, capability tokens, rehydration pipeline, safe-injection framing, free verification, self-hosting always available, three-layer A2A/MCP/Mnemonic framing).

* docs: replace References section with three protocol-relevant papers

Drop the mixed list of vendor docs (MCP, Arweave, Solana), spec links (COSE RFC, BLAKE3, x402), and the self-referential "Foundational Paper" link. Keep three references that are directly relevant to the protocol:

1. TurboQuant (Zandieh & Mirrokni) — the embedding quantization method used for portable compressed embeddings (§4, §5.6).
2. Sublinear Verifiable Recall (researchgate) — inverted-file cascade for compressed embedding retrieval, the candidate technique for the future verifiable-retrieval research direction in §11.
3. Portable Agent Memory (arXiv:2605.11032) — protocol for cryptographically- verified memory transfer across heterogeneous AI agents; directly adjacent work to §7 Memory Composition and Sharing.

External protocol references (Arweave, Solana, MCP, RFCs) are linked from implementation documentation where they are actually invoked.

* docs: add inline citations linking to References entries

Replace bare-URL references with markdown-linked titles, add HTML anchors per entry (#ref-1, #ref-2, #ref-3), and cite each reference inline at its natural point in the body:

- §4 Core Insight — cite TurboQuant [1] where compression is described as serving portability and anchoring.
- §7 intro — cite Portable Agent Memory [3] where the rehydration pipeline and safe-injection framing are introduced (this is the closest adjacent work).
- §11 Related Work — cite all three: Portable Agent Memory [3] alongside "trustless agentic memory and cryptographically-verified memory transfer"; Sublinear Verifiable Recall [2] alongside "verifiable ANN retrieval"; TurboQuant [1] alongside "embedding quantization with bounded distortion".

Each citation links to the corresponding entry anchor in the References section, so readers can click through from the body to the bibliography entry (and from there to the external URL).

The TurboQuant entry stays without an external URL — none was provided.

* docs: add arXiv link to TurboQuant reference

TurboQuant (Zandieh et al., 2025) is on arXiv as 2504.19874. Adding the URL so the reference entry is clickable like the other two.

Full author list on the paper is Zandieh, Daliri, Hadian, and Mirrokni; keeping the existing "Zandieh, A. and Mirrokni, V." short form to match the citation style already in the doc.

---------