### PR TITLE
fix(cli): ensure() — implement Decision 17 case (c) integrity check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,11 @@ jobs:
         run: |
           cargo build -p mnemonic-mcp
           cargo build -p mnemonic-core --example keychain-roundtrip
+      - name: Install wasm-pack
+        # SDK `npm run build` shells out to packages/sdk/scripts/build-wasm.sh
+        # which requires wasm-pack on PATH. Version pinned to match
+        # release.yml and node-test.yml — keep all three in sync.
+        run: cargo install wasm-pack --locked --version 0.14.0 || true
       - name: Build Node CLI (sdk first — cli imports from it)
         run: |
           npm install --workspaces --include-workspace-root --no-audit --no-fund

--- a/packages/cli/src/identity/ensure.ts
+++ b/packages/cli/src/identity/ensure.ts
@@ -18,11 +18,46 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
+import { ed25519 } from "@noble/curves/ed25519";
+import bs58 from "bs58";
+
 import { Keypair } from "@mnemonik-xyz/sdk";
 
 import { OsKeyStore } from "./keystore-os.js";
 import { FileKeyStore } from "./keystore-file.js";
-import { KeystoreError, type KeyStore } from "./keystore.js";
+import {
+  KeystoreError,
+  type KeyStore,
+  type KeystoreEntry,
+} from "./keystore.js";
+
+/**
+ * Derive the base58-encoded Ed25519 pubkey from a 64-byte secret (seed +
+ * pubkey, matching `solana_sdk::signature::Keypair::to_bytes()`). Only the
+ * first 32 bytes (seed) are used for derivation — the trailing 32 bytes are
+ * the keypair's claimed pubkey and are NOT trusted by this function.
+ */
+function derivePubkeyBase58(secret: number[]): string {
+  const seed = Uint8Array.from(secret.slice(0, 32));
+  return bs58.encode(ed25519.getPublicKey(seed));
+}
+
+/**
+ * Decision 17 case (c): keychain entry integrity check. If the stored
+ * `pubkey_base58` is non-empty and does not derive from the stored secret
+ * bytes, the keychain entry is corrupted — fail loud rather than silently
+ * adopting the wrong pubkey. Mirrors the Rust `handle_create` integrity
+ * check in core/src/identity/ensure.rs. NEVER log secret bytes.
+ */
+function assertKeystoreEntryIntegrity(existing: KeystoreEntry): string {
+  const derived = derivePubkeyBase58(existing.secret);
+  if (existing.pubkey_base58 !== "" && existing.pubkey_base58 !== derived) {
+    throw new Error(
+      `OS keychain entry integrity mismatch — stored pubkey ${existing.pubkey_base58} does not match secret-derived pubkey ${derived} (Decision 17 case c)`,
+    );
+  }
+  return derived;
+}
 
 /**
  * Common helper: return `true` iff a thrown KeystoreError represents the
@@ -262,7 +297,11 @@ async function createIdentity(stores: KeyStores): Promise<EnsureResult> {
       const existing = await stores.os.get();
       osUsable = true;
       if (existing !== null) {
-        const recovered_pubkey = existing.pubkey_base58;
+        // Decision 17 case (c): integrity-check the entry before adopting.
+        // Throws loud Error on mismatch — caller surfaces to user, no silent
+        // pubkey divergence. Derived pubkey is the source of truth (matches
+        // Rust's `handle_create`).
+        const recovered_pubkey = assertKeystoreEntryIntegrity(existing);
         await doWriteStub(stores.identityPath, recovered_pubkey);
         // Silent rebuild per Decision 17 (b) — no `log(...)` call.
         return {

--- a/packages/cli/test/identity/ensure.test.ts
+++ b/packages/cli/test/identity/ensure.test.ts
@@ -13,6 +13,9 @@ import fs from "node:fs/promises";
 import { randomBytes } from "node:crypto";
 import { describe, it, expect } from "vitest";
 
+import { ed25519 } from "@noble/curves/ed25519";
+import bs58 from "bs58";
+
 import {
   ensureWithStores,
   shouldSkipEnsure,
@@ -72,11 +75,21 @@ async function writeStubFile(
   await fs.writeFile(identityPath, content, { mode: 0o600 });
 }
 
-// A fake KeystoreEntry for tests that don't need a real WASM-generated key.
+// A deterministic-but-real Ed25519 KeystoreEntry for tests that don't need
+// the full WASM Keypair.generate() machinery. The 32-byte seed is a fixed
+// `i % 256` pattern so the derived pubkey is stable across runs; the
+// trailing 32 bytes hold the actual derived public key, matching the
+// `solana_sdk::signature::Keypair::to_bytes()` convention. Required by the
+// Decision 17 case (c) integrity check.
 function fakeEntry(): KeystoreEntry {
+  const seed = Uint8Array.from(Array.from({ length: 32 }, (_, i) => i % 256));
+  const pubkey = ed25519.getPublicKey(seed);
+  const secret = new Uint8Array(64);
+  secret.set(seed, 0);
+  secret.set(pubkey, 32);
   return {
-    secret: Array.from({ length: 64 }, (_, i) => i % 256),
-    pubkey_base58: "FakeBase58PubkeyForTestingPurposesOnly1234567890",
+    secret: Array.from(secret),
+    pubkey_base58: bs58.encode(pubkey),
   };
 }
 
@@ -160,6 +173,48 @@ describe("ensure recovers orphan keychain silently (Decision 17 case b)", () => 
     expect("keychain_ref" in parsed).toBe(true);
     expect("secret" in parsed).toBe(false);
     expect(parsed.pubkey_base58).toBe(original.pubkey_base58);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Scenario 1c — Decision 17 case (c): keychain entry exists but the stored
+// pubkey does not match the pubkey derived from the stored secret. Spec
+// contract: fail loud, do not silently adopt the wrong pubkey, do not
+// overwrite the keychain. Mirrors Rust's `handle_create` integrity check.
+// ---------------------------------------------------------------------------
+
+describe("ensure rejects corrupted keychain entry (Decision 17 case c)", () => {
+  it("throws integrity-mismatch error when stored pubkey diverges from secret", async () => {
+    const dir = tmpDir();
+    const osStore = new MemoryKeyStore();
+    // Build an entry whose stored pubkey deliberately disagrees with the
+    // pubkey derivable from the secret. The secret remains a valid Ed25519
+    // 64-byte blob — only the `pubkey_base58` field is wrong.
+    const good = fakeEntry();
+    const corrupted: KeystoreEntry = {
+      secret: good.secret,
+      pubkey_base58: "WrongStoredPubkey1111111111111111111111111111",
+    };
+    await osStore.set(corrupted);
+
+    const stores = await makeStores(dir, osStore);
+
+    await expect(ensureWithStores(stores)).rejects.toThrow(
+      /OS keychain entry integrity mismatch/,
+    );
+
+    // Keychain must NOT have been mutated by the failed adoption attempt.
+    const after = await osStore.get();
+    expect(after).not.toBeNull();
+    expect(after!.pubkey_base58).toBe(corrupted.pubkey_base58);
+    expect(after!.secret).toEqual(corrupted.secret);
+
+    // No stub file should have been written.
+    const stubExists = await fs
+      .access(stores.identityPath)
+      .then(() => true)
+      .catch(() => false);
+    expect(stubExists).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Node `createIdentity()` case-(b) recovery path silently adopted the keychain entry's stored `pubkey_base58` without verifying it derived from the stored secret bytes — a spec-violating asymmetry against Rust's `handle_create()` in `core/src/identity/ensure.rs`, which bails loud on mismatch (Decision 17 case c).
- Surfaced during T15 macOS smoke run (see `work/invisible-identity/decisions.md` 2026-05-25): on a corrupted keychain entry where stored pubkey diverges from the secret, Node would have silently written the wrong pubkey into the stub.
- Now derives the pubkey from the secret seed (first 32 bytes) via `@noble/curves/ed25519` + `bs58` and throws with the exact Rust message: `OS keychain entry integrity mismatch — stored pubkey X does not match secret-derived pubkey Y (Decision 17 case c)`. The derived pubkey (not the stored one) becomes the source of truth for the stub, matching Rust.

## Test plan

- [x] `npx vitest run test/identity/ensure.test.ts` — 15/15 pass, including new "Scenario 1c" mismatch test (throw + keychain-unchanged + no-stub-written)
- [x] `npx vitest run` (full CLI suite) — 143/145 pass (2 unrelated skips)
- [x] `npx tsc --noEmit` — clean
- [x] Existing Decision 17 case-(b) regression test still passes under the stricter integrity check (test helper `fakeEntry()` rewritten to produce a real deterministic Ed25519 keypair so the byte-counting fake no longer flunks the new derivation check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)