### PR TITLE
chore(ci): split cross-lang-keychain into build (gate) + keychain (informational)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,10 +222,11 @@ jobs:
   #      daemon-coupling issue on Ubuntu 24.04 (see fde7f72 commit
   #      message) that survived 5 rounds of debugging.
   #
-  # Mixing them led to a 3-month yo-yo of `continue-on-error: true` being
-  # toggled on/off, masking real build regressions (e.g. wasm-pack going
-  # missing in the runner — undetected for the entire #151 merge because
-  # the gate was off). Now split:
+  # Mixing them led to a two-day yo-yo of `continue-on-error: true` being
+  # toggled on/off (4 commits across 2026-05-25 → 2026-05-26: e5e9a83 →
+  # 7b60a3c → fde7f72 → 12a7ec9), masking real build regressions (e.g.
+  # wasm-pack going missing in the runner — undetected for the entire
+  # #151 merge because the gate was off). Now split:
   #   - `cross-lang-build`     → hard required gate. Never continue-on-error.
   #   - `cross-lang-keychain`  → informational. PERMANENTLY continue-on-error
   #                              until the daemon-coupling issue is fixed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,8 +210,77 @@ jobs:
   # entry and asserts byte-equality of secrets. Linux+gnome-keyring only;
   # macOS Keychain and Windows Credential Manager are covered by Wave 5
   # manual smoke tests (no free CI runners with those backends).
+  # ──────────────────────────────────────────────────────────────────────
+  # CI GATE POLICY for cross-language interop
+  # ──────────────────────────────────────────────────────────────────────
+  # This was previously a single `cross-lang-keychain` job that mixed two
+  # concerns with very different stability profiles:
+  #   1. Build all the artifacts required to drive the test (rust + sdk +
+  #      cli). Deterministic — failures are always actionable.
+  #   2. Run the Rust ↔ Node keychain roundtrip under a CI-spawned
+  #      gnome-keyring + D-Bus session. Flaky — sub-test B has a known
+  #      daemon-coupling issue on Ubuntu 24.04 (see fde7f72 commit
+  #      message) that survived 5 rounds of debugging.
+  #
+  # Mixing them led to a 3-month yo-yo of `continue-on-error: true` being
+  # toggled on/off, masking real build regressions (e.g. wasm-pack going
+  # missing in the runner — undetected for the entire #151 merge because
+  # the gate was off). Now split:
+  #   - `cross-lang-build`     → hard required gate. Never continue-on-error.
+  #   - `cross-lang-keychain`  → informational. PERMANENTLY continue-on-error
+  #                              until the daemon-coupling issue is fixed
+  #                              upstream.
+  #
+  # DO NOT flip `continue-on-error` on either job without first updating
+  # the policy section in CLAUDE.md → "## CI gate policy" and getting
+  # explicit reviewer sign-off. The previous yo-yo wasted significant CI
+  # debugging time and shipped at least one regression to main.
+  # ──────────────────────────────────────────────────────────────────────
+
+  cross-lang-build:
+    name: cross-lang-build (gate)
+    # Hard required gate — every artifact the keychain test would need
+    # must build cleanly here. If wasm-pack is missing, if a Rust crate
+    # fails to compile, if the SDK WASM build breaks, if the CLI tsc
+    # fails — this job goes red and PRs block. No continue-on-error.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: workspace
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - name: Install Linux Rust system deps
+        # `libdbus-1-dev pkg-config` for the `keyring` crate's
+        # `sync-secret-service` feature via libdbus-sys build script.
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libdbus-1-dev pkg-config
+      - name: Install wasm-pack
+        # SDK `npm run build` shells out to packages/sdk/scripts/build-wasm.sh
+        # which requires wasm-pack on PATH. Version pinned to match
+        # release.yml and node-test.yml — keep all three in sync.
+        run: cargo install wasm-pack --locked --version 0.14.0 || true
+      - name: Build Rust mcp-server + keychain-roundtrip example
+        run: |
+          cargo build -p mnemonic-mcp
+          cargo build -p mnemonic-core --example keychain-roundtrip
+      - name: Build Node SDK + CLI (sdk first — cli imports from it)
+        run: |
+          npm install --workspaces --include-workspace-root --no-audit --no-fund
+          npm run build --workspace=@mnemonik-xyz/sdk
+          npm run build --workspace=@mnemonik-xyz/cli
+
   cross-lang-keychain:
-    name: cross-lang-keychain
+    name: cross-lang-keychain (informational)
+    needs: cross-lang-build
+    # PERMANENT: see "CI GATE POLICY" comment block above this job and the
+    # matching CLAUDE.md "## CI gate policy" section. The gnome-keyring
+    # daemon-coupling issue (sub-test B) is the reason. Do not flip.
+    continue-on-error: true
     # Upgraded from ubuntu-22.04 → ubuntu-latest (24.04) because `wasm-pack`
     # caches in Swatinem rust-cache@v2 are now built against GLIBC 2.39.
     runs-on: ubuntu-latest
@@ -232,20 +301,19 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gnome-keyring dbus-x11 libsecret-tools jq libdbus-1-dev pkg-config
+      - name: Install wasm-pack
+        # Same install as cross-lang-build — rust-cache makes this a fast
+        # no-op when the binary is already present from the prior job.
+        run: cargo install wasm-pack --locked --version 0.14.0 || true
       - name: Build Rust mcp-server + keychain-roundtrip example
-        # `keychain-roundtrip` is the tiny Rust binary the cross-lang
-        # script invokes — it calls `identity::ensure()` and prints
-        # `{"pubkey":..., "storage":...}`. Much simpler than the full
-        # mcp stdio server and avoids the EOF / embedder-init pitfalls.
+        # cargo recompile is near-free thanks to the shared rust-cache.
         run: |
           cargo build -p mnemonic-mcp
           cargo build -p mnemonic-core --example keychain-roundtrip
-      - name: Install wasm-pack
-        # SDK `npm run build` shells out to packages/sdk/scripts/build-wasm.sh
-        # which requires wasm-pack on PATH. Version pinned to match
-        # release.yml and node-test.yml — keep all three in sync.
-        run: cargo install wasm-pack --locked --version 0.14.0 || true
-      - name: Build Node CLI (sdk first — cli imports from it)
+      - name: Build Node SDK + CLI (sdk first — cli imports from it)
+        # npm install + sdk WASM rebuild repeats here (~30s). Acceptable
+        # cost for keeping the test job self-contained vs. plumbing
+        # artifact upload/download.
         run: |
           npm install --workspaces --include-workspace-root --no-audit --no-fund
           npm run build --workspace=@mnemonik-xyz/sdk

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,21 @@ Read these via the `project-knowledge` skill — they're the source of truth.
 
 `.github/workflows/ci.yml` runs on push to `main` and every PR: rustfmt check, clippy with `-D warnings`, `cargo test --workspace`, gitleaks (working tree + full history). `.github/workflows/release.yml` runs on `v*` tags: cross-compile mcp binary, build Docker image, publish to GHCR/crates.io. Toolchain pinned via `rust-toolchain.toml`.
 
+### CI gate policy
+
+The cross-language interop coverage is intentionally split into two jobs with different gate semantics — do not collapse them or flip the toggles without following the procedure below.
+
+- **`cross-lang-build (gate)`** — hard required gate. Builds the Rust binaries + SDK WASM + CLI dist that the keychain interop test would need. Deterministic. Never carries `continue-on-error`. If this is red, real build infra is broken (e.g. wasm-pack missing, libdbus header gone) and the PR must block.
+- **`cross-lang-keychain (informational)`** — `needs: cross-lang-build`, permanently `continue-on-error: true`. Drives the actual Rust ↔ Node keychain roundtrip under a CI-spawned `gnome-keyring` + D-Bus session. Sub-test B has an unresolved daemon-coupling issue on Ubuntu 24.04 (see commit `fde7f72` — survived 5 rounds of debugging). The job stays in the matrix as a visible signal but does not gate.
+
+**Yo-yo prevention rule:** the `continue-on-error: true` on `cross-lang-keychain` is permanent until the daemon-coupling sub-test B is fixed upstream. Do not flip it on/off — that pattern previously masked a `wasm-pack`-missing build regression that shipped to main untouched during PR #151. If you believe the test is now stable enough to gate, the procedure is:
+
+1. Reproduce 10 consecutive green runs of the script on Ubuntu 24.04.
+2. Land a single PR that simultaneously removes `continue-on-error: true` AND updates this section, naming the fix commit that closed the daemon-coupling root cause.
+3. Get a reviewer sign-off on that PR explicitly acknowledging the gate change.
+
+If you only want to gate the build path (the actual regression-catcher), the `cross-lang-build` job already does that — no toggling needed.
+
 ## Stream Timeout Prevention
 
 1. Do each numbered task ONE AT A TIME. Complete one task fully, confirm it worked, then move to the next.


### PR DESCRIPTION
## Summary

Follow-up to #152, which merged the underlying `wasm-pack` install fix but not the structural job split. This PR carries the split + the CLAUDE.md "CI gate policy" section that codifies why we don't toggle `continue-on-error` on the keychain job anymore.

The single `cross-lang-keychain` job mixed two concerns with very different stability profiles:

1. **Build artifacts** (rust + sdk + cli) — deterministic, every failure actionable.
2. **Run Rust ↔ Node keychain roundtrip** under a CI-spawned gnome-keyring + D-Bus session — flaky, sub-test B has an unresolved daemon-coupling issue on Ubuntu 24.04 (see `fde7f72` — survived 5 debug rounds).

Mixing them led to a two-day yo-yo of `continue-on-error: true` being flipped on/off across 4 commits (`e5e9a83` → `7b60a3c` → `fde7f72` → `12a7ec9`, 2026-05-25 → 2026-05-26), which masked the `wasm-pack`-missing build regression that shipped into main during #151 and only surfaced in #152.

## What changes

- **New `cross-lang-build (gate)` job** — hard required gate. Builds rust binaries + SDK WASM + CLI dist. No `continue-on-error`. Catches the class of build issues #152's wasm-pack fix addressed.
- **`cross-lang-keychain` → `cross-lang-keychain (informational)`** — `needs: cross-lang-build`, permanently `continue-on-error: true`. Stays in the matrix as a visible signal but does not gate until the gnome-keyring daemon-coupling root cause is fixed upstream.
- **CLAUDE.md `## CI gate policy` section** — documents the rule and the procedure for ever flipping the toggle (10 consecutive green runs + named root-cause commit + reviewer sign-off in a single PR). No more unilateral flips.

## Trade-offs

- Test job repeats `npm install` + SDK WASM rebuild (~30s on top of the gate job). Rust-cache makes the cargo half nearly free. Could be eliminated with artifact upload/download but the YAML complexity wasn't worth ~30s/run.
- Both jobs install `wasm-pack` independently. Cached after first install, so subsequent runs are no-ops.

## Test plan

- [ ] PR triggers both `cross-lang-build (gate)` and `cross-lang-keychain (informational)` checks
- [ ] `cross-lang-build` is required for merge (status: required in branch protection — confirm visible in PR check list)
- [ ] `cross-lang-keychain` shows up but does not block (continue-on-error semantics — status will be a yellow "neutral" if it fails the script)
- [ ] If gnome-keyring sub-test B fails as expected, the build gate stays green and PR can merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)