### PR TITLE
fix(core): ensure() — orphan-probe tolerates any backend error

### DIFF
--- a/core/src/identity/ensure.rs
+++ b/core/src/identity/ensure.rs
@@ -19,6 +19,7 @@ use chrono::Utc;
 use serde_json::Value;
 use solana_sdk::signature::{Keypair, Signer};
 use tempfile::NamedTempFile;
+use tracing::warn;
 
 use crate::identity::keystore::{KeyStore, KeystoreEntry, KeystoreError};
 use crate::identity::{Identity, IdentityStorage};
@@ -164,7 +165,26 @@ fn handle_create(
                 slot
             }
             Err(KeystoreError::PlatformUnavailable { .. }) => None,
-            Err(other) => return Err(other).context("probing OS keychain for orphan entry"),
+            Err(other) => {
+                // The orphan-probe is exploratory, not authoritative — we are
+                // asking "does an entry happen to exist?" before deciding what
+                // to do. If the backend errors for any reason (D-Bus session
+                // missing on headless Linux, gnome-keyring daemon dead,
+                // permissions blip, etc.) the safe answer is "no orphan
+                // found, fall through to file-fallback creation." A hard
+                // error here would crash startup on every headless host that
+                // links the `keyring` crate but lacks a working Secret
+                // Service daemon. The keystore_os::get path only translates
+                // keyring::Error::NoStorageAccess to PlatformUnavailable;
+                // every other variant (notably PlatformFailure for missing
+                // D-Bus session bus) becomes Backend, which is what trips
+                // this branch in production. Treat as unavailable and log.
+                warn!(
+                    target: "mnemonic_core::identity::ensure",
+                    "OS keychain orphan-probe errored: {other} — falling through to file fallback"
+                );
+                None
+            }
         };
         if let Some(existing) = existing {
             let keypair = Keypair::try_from(&existing.secret[..]).map_err(|e| {
@@ -888,6 +908,76 @@ mod tests {
                 & 0o777;
             assert_eq!(mode, 0o600, "file mode must be 0600");
         }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Test: orphan-probe error during create path falls through to file
+    // fallback instead of crashing startup. Regression for the headless-Linux
+    // production crash where keyring::Entry::get_password returns
+    // PlatformFailure (D-Bus session bus absent) which keystore_os maps to
+    // KeystoreError::Backend, not PlatformUnavailable. Before the fix, the
+    // handle_create probe arm panicked the binary; now it logs a warning and
+    // proceeds with file-fallback creation.
+    // ---------------------------------------------------------------------------
+    #[test]
+    fn ensure_tolerates_backend_error_during_orphan_probe() {
+        use crate::identity::keystore_file::FileKeyStore;
+
+        // KeyStore that reports `available() == Ok(true)` (the keychain
+        // backend constructs fine) but `get()` returns a Backend error
+        // (simulating headless-Linux where the daemon is unreachable but the
+        // crate didn't translate that to NoStorageAccess).
+        struct FailingProbeKeyStore;
+        impl KeyStore for FailingProbeKeyStore {
+            fn get(&self) -> Result<Option<KeystoreEntry>, KeystoreError> {
+                Err(KeystoreError::Backend(anyhow::anyhow!(
+                    "simulated headless-Linux D-Bus session absent"
+                )))
+            }
+            fn set(&self, _entry: &KeystoreEntry) -> Result<(), KeystoreError> {
+                Err(KeystoreError::PlatformUnavailable {
+                    reason: "set unreachable in this test path".to_string(),
+                })
+            }
+            fn remove(&self) -> Result<(), KeystoreError> {
+                Ok(())
+            }
+            fn available(&self) -> Result<bool, KeystoreError> {
+                Ok(true)
+            }
+            fn name(&self) -> &'static str {
+                "failing-probe-mock"
+            }
+        }
+
+        let dir = TempDir::new().unwrap();
+        let identity_path = dir.path().join("identity.json");
+        let readme_path = dir.path().join("README.txt");
+
+        let stores = KeyStores {
+            os: Some(Box::new(FailingProbeKeyStore)),
+            file: Box::new(FileKeyStore::new(identity_path.clone())),
+            identity_path: identity_path.clone(),
+            readme_path,
+        };
+
+        let id = ensure_with_stores(stores)
+            .expect("ensure must NOT crash on a Backend error during the orphan probe");
+
+        // Must have fallen through to file-fallback creation.
+        assert!(
+            matches!(id.storage, IdentityStorage::File),
+            "expected file fallback when OS probe errors, got {:?}",
+            id.storage
+        );
+
+        // Legacy-format file (with secret) should be on disk.
+        let written: Value =
+            serde_json::from_slice(&std::fs::read(&identity_path).unwrap()).unwrap();
+        assert!(
+            written.get("secret").is_some(),
+            "file-fallback path must write legacy format with secret"
+        );
     }
 
     // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Production crash fix. The Decision 17 case-b orphan-probe in `handle_create()` returned a hard error on any `KeystoreError` variant other than `PlatformUnavailable`. On headless Linux (no D-Bus session bus), `keyring::Entry::get_password` returns `PlatformFailure` which `keystore_os::get` maps to `KeystoreError::Backend` — not `PlatformUnavailable`. That crashed mnemonic-mcp at startup on the production VPS during the 9a4cf6c deploy attempt; service entered a restart loop, had to roll back to dcbd884 to restore.

## Fix

Narrow: treat ANY backend error during the orphan probe as "no orphan found, fall through to file fallback." The probe is exploratory — if we can't talk to the keychain, we definitely don't have an orphan there. Adding a `tracing::warn!` so the error is visible in logs without crashing.

```rust
Err(other) => {
    warn!(
        target: "mnemonic_core::identity::ensure",
        "OS keychain orphan-probe errored: {other} — falling through to file fallback"
    );
    None
}
```

## Why not at the keystore_os layer

Could have widened `keystore_os::get` to map more `keyring::Error` variants to `PlatformUnavailable`. Rejected because: (a) it would silently swallow errors that callers OTHER than the orphan-probe legitimately want to surface (e.g., reading a known-existing stub's secret should still bail loud on backend error); (b) the semantic of "exploratory probe" is specific to `handle_create`, not all `get()` callsites.

## Test plan

- [x] Added regression test `ensure_tolerates_backend_error_during_orphan_probe` — constructs a KeyStore whose `get()` returns `KeystoreError::Backend` and asserts ensure() returns `Ok` with `IdentityStorage::File`. Without the fix this panics with the production error message.
- [x] All 8 ensure tests pass (7 existing + 1 new).
- [x] `cargo fmt --all -- --check` clean.
- [x] `cargo clippy -p mnemonic-core --all-targets --release -- -D warnings` clean.
- [ ] After merge: redeploy mcp.mnemonik.xyz from main HEAD; service should start cleanly on headless Linux this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)