### PR TITLE
chore(ci): release.yml — switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,6 +148,12 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      # npm Trusted Publishing (OIDC) requires npm CLI >= 11.5.1. Node 22
+      # ships npm 10.x, so upgrade explicitly. Once the global install
+      # finishes, subsequent `npm` invocations resolve to the new binary.
+      - name: Upgrade npm to >=11.5.1 (Trusted Publishing requires it)
+        run: npm install -g npm@latest
+
       # Rust toolchain + wasm-pack are required because the SDK's
       # prepublishOnly hook runs `npm run build` which invokes
       # wasm-pack to produce core/pkg-web/* before tsc + dist/wasm/ copy.
@@ -183,6 +189,12 @@ jobs:
       # 403 with "cannot publish over previously published versions". Compare
       # local package.json version to npm registry; skip if equal.
 
+      # Trusted Publishing (OIDC): npm auto-detects the GitHub Actions
+       # OIDC token via the `id-token: write` permission above. No
+       # NODE_AUTH_TOKEN, no NPM_TOKEN secret — npm publish authenticates
+       # against the trusted-publisher config registered on each package's
+       # npm settings page (see CLAUDE.md "## npm publishing"). Provenance
+       # is signed automatically and verifiable end-to-end.
       - name: Publish @mnemonik-xyz/sdk
         run: |
           LOCAL=$(node -p "require('./packages/sdk/package.json').version")
@@ -192,8 +204,6 @@ jobs:
           else
             npm publish --access public --provenance --workspace packages/sdk
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish @mnemonik-xyz/cli
         run: |
@@ -204,5 +214,3 @@ jobs:
           else
             npm publish --access public --provenance --workspace packages/cli
           fi
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Removes the long-lived `NPM_TOKEN` secret from the npm publish flow and switches to npm's Trusted Publishing (OIDC). Triggered by the 2026-05-29 `EOTP` failure during the v0.2.0 publish — the rotated token still requires an OTP at call time because the account has 2FA-enforced-on-publish, which CI cannot provide. npm's own UI now points at Trusted Publishing as the recommended path (the "Bypass 2FA" token toggle has a security warning attached).

## Changes

- `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` removed from both publish steps (SDK + CLI).
- `npm install -g npm@latest` step added — npm CLI ≥11.5.1 is required for Trusted Publishing; Node 22 ships npm 10.x.
- `id-token: write` permission already present (legacy from provenance work) — kept; that's what npm reads.

## Required setup BEFORE merging (otherwise next release fails)

**On npmjs.com** — repeat for each package:

1. https://www.npmjs.com/package/@mnemonik-xyz/sdk → Settings → Publishing access → Add trusted publisher
2. Publisher: GitHub Actions
3. Organization: \`mnemonik-xyz\`
4. Repository: \`monorepo\`
5. Workflow filename: \`release.yml\`
6. Environment name: *leave blank*
7. Save, then repeat for \`@mnemonik-xyz/cli\`.

**After this PR merges:**
- Retag `v0.2.0-sdk` + `v0.2.0-cli` (or any future bump) — release.yml fires, OIDC handshake replaces token auth, publish succeeds.
- Delete the now-unused `NPM_TOKEN` secret from repo Settings → Secrets and variables → Actions.

## Test plan

- [ ] npm trusted-publisher config registered for both packages (manual, on npm.com)
- [ ] Retag triggers release; `Publish to npm with provenance` job succeeds without any token secret
- [ ] `npm view @mnemonik-xyz/sdk version` → 0.2.0
- [ ] `npm view @mnemonik-xyz/cli version` → 0.2.0
- [ ] Sigstore provenance attestation visible on npm package page

🤖 Generated with [Claude Code](https://claude.com/claude-code)