### PR TITLE
test(mcp): T3.5 — demotion_on_x402_leaves_nonce_reusable integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,13 @@ temp/
 .claude/shared/
 .claude/skills/*
 !.claude/skills/project-knowledge/
+
+# Ruflo runtime + per-developer .claude/ artifacts (per-developer, NOT shared).
+# Mirrors the rules previously added on claude/modes-user-choice-Qkk6X but that
+# were superseded by the broader .claude/skills/* allowlist in cbe8a7e. These
+# directories are runtime/config noise and shouldn't ship.
+.claude-flow/
+.claude/helpers/
+.claude/settings.json
+.mcp.json
+PROJECT_MEMORY.md

--- a/mcp/src/test_support.rs
+++ b/mcp/src/test_support.rs
@@ -247,6 +247,8 @@ pub fn mock_state_for_delivery(
     quota_threshold: u32,
     quota_window: std::time::Duration,
     refetch_timeout: std::time::Duration,
+    treasury_pubkey: &str,
+    usdc_mint: &str,
 ) -> Arc<McpState> {
     let tmp = tempfile::NamedTempFile::new().expect("tempfile");
     let path = tmp.into_temp_path();
@@ -277,8 +279,8 @@ pub fn mock_state_for_delivery(
         embedder: Box::new(StubEmbedder::default()),
         compressor,
         payment_mode: payment_mode.to_string(),
-        treasury_pubkey: String::new(),
-        usdc_mint: String::new(),
+        treasury_pubkey: treasury_pubkey.to_string(),
+        usdc_mint: usdc_mint.to_string(),
         sign_memory_cost_micro_usdc,
         pricing,
         sol_tx_fee_lamports: 0,

--- a/mcp/tests/_helpers/delivery_harness.rs
+++ b/mcp/tests/_helpers/delivery_harness.rs
@@ -258,6 +258,41 @@ impl MockSolana {
         Self { server }
     }
 
+    /// Like [`happy`], plus a `getTransaction` mock that returns a
+    /// synthetic USDC transfer for the supplied `tx_sig`. The transfer
+    /// shows a `cost`-micro-USDC delta on `treasury`'s SPL account for
+    /// `usdc_mint`, which is exactly what `verify_usdc_transfer` walks.
+    ///
+    /// Used by the T3.5 `demotion_on_x402_*` tests so `check_payment`
+    /// passes its USDC-transfer verification without us having to mint a
+    /// real on-chain transaction.
+    pub fn happy_with_x402_payment(
+        tx_sig: &str,
+        treasury: &str,
+        usdc_mint: &str,
+        cost: u64,
+    ) -> Self {
+        let me = Self::happy();
+        let body = format!(
+            r#"{{"jsonrpc":"2.0","id":1,"result":{{"meta":{{"err":null,"preTokenBalances":[{{"accountIndex":0,"owner":"{treasury}","mint":"{usdc_mint}","uiTokenAmount":{{"amount":"0","decimals":6,"uiAmount":0.0,"uiAmountString":"0"}}}}],"postTokenBalances":[{{"accountIndex":0,"owner":"{treasury}","mint":"{usdc_mint}","uiTokenAmount":{{"amount":"{cost}","decimals":6,"uiAmount":0.0,"uiAmountString":"0"}}}}]}}}}}}"#
+        );
+        // The Solana client posts every RPC to `/`; httpmock dispatches by
+        // body content. We match on the tx_sig substring so this mock only
+        // answers `getTransaction` calls for THIS specific signature; any
+        // other signature falls through to httpmock's 404 default, which
+        // makes a misconfigured test fail loudly instead of silently
+        // mocking a different proof.
+        me.server.mock(|when, then| {
+            when.method(POST)
+                .body_includes(r#""method":"getTransaction""#)
+                .body_includes(tx_sig);
+            then.status(200)
+                .header("content-type", "application/json")
+                .body(body);
+        });
+        me
+    }
+
     pub fn base_url(&self) -> String {
         self.server.base_url()
     }
@@ -292,6 +327,43 @@ pub fn build_state_and_router(
         quota_threshold,
         quota_window,
         refetch_timeout,
+        "",
+        "",
+    );
+    let app = Router::new()
+        .route("/mcp", post(mcp_handler))
+        .with_state(state.clone());
+    (state, app)
+}
+
+/// Variant of [`build_state_and_router`] that wires `treasury_pubkey` and
+/// `usdc_mint` into the `McpState` so the x402 payment-gate (`check_payment`
+/// → `verify_usdc_transfer`) has destination addresses to match against.
+///
+/// Used exclusively by the T3.5 `demotion_on_x402_*` tests; for `balance`
+/// or `none` payment modes the regular `build_state_and_router` is enough.
+#[allow(clippy::too_many_arguments)]
+pub fn build_state_and_router_x402(
+    arweave_url: &str,
+    solana_url: &str,
+    cost_micro_usdc: i64,
+    quota_threshold: u32,
+    quota_window: Duration,
+    refetch_timeout: Duration,
+    treasury_pubkey: &str,
+    usdc_mint: &str,
+) -> (Arc<McpState>, Router) {
+    let state = mock_state_for_delivery(
+        "full",
+        "x402",
+        cost_micro_usdc,
+        arweave_url,
+        solana_url,
+        quota_threshold,
+        quota_window,
+        refetch_timeout,
+        treasury_pubkey,
+        usdc_mint,
     );
     let app = Router::new()
         .route("/mcp", post(mcp_handler))
@@ -356,6 +428,50 @@ pub async fn call_sign_memory_participate(
         .uri("/mcp")
         .header("content-type", "application/json")
         .header("authorization", format!("Bearer {bearer}"))
+        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+        .unwrap();
+    let resp = app.clone().oneshot(req).await.unwrap();
+    let status = resp.status();
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    let envelope: Value = serde_json::from_slice(&bytes)
+        .unwrap_or_else(|_| Value::String(String::from_utf8_lossy(&bytes).into()));
+    (status, envelope)
+}
+
+/// Issue a `sign_memory { mode: "participate", content }` with an
+/// `X-Payment` header pointing at the supplied `tx_sig`. The payload is
+/// the raw JSON shape that `payment::extract_x402_proof` accepts (it
+/// tries raw JSON before falling back to base64).
+///
+/// The on-chain payment proof itself is mocked elsewhere (see
+/// [`MockSolana::happy_with_x402_payment`]); this helper only constructs
+/// the HTTP request.
+pub async fn call_sign_memory_participate_x402(
+    app: &Router,
+    tx_sig: &str,
+    content: &str,
+) -> (StatusCode, Value) {
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {
+            "name": "mnemonic_sign_memory",
+            "arguments": {"content": content, "mode": "participate"},
+        },
+    });
+    // Raw JSON shape per X402PaymentProof; extract_x402_proof tries this
+    // first before the base64 fallback so no encoding round-trip is needed.
+    let x_payment = serde_json::json!({
+        "tx_sig": tx_sig,
+        "network": "solana-mainnet",
+    })
+    .to_string();
+    let req = Request::builder()
+        .method("POST")
+        .uri("/mcp")
+        .header("content-type", "application/json")
+        .header("x-payment", x_payment)
         .body(Body::from(serde_json::to_vec(&body).unwrap()))
         .unwrap();
     let resp = app.clone().oneshot(req).await.unwrap();

--- a/mcp/tests/delivery_guarantee.rs
+++ b/mcp/tests/delivery_guarantee.rs
@@ -12,8 +12,12 @@
 //!    `attestation_costs` row, balance restored, counter incremented.
 //! 3. `demotion_on_verify_failure` — different valid COSE bytes (signed by
 //!    another key) → `stage: "verify"`.
-//! 4. `demotion_on_x402` — TODO: requires a different bearer path; covered
-//!    structurally by the refetch test under PAYMENT_MODE=balance.
+//! 4. `demotion_on_x402_leaves_nonce_reusable` — same refetch failure as
+//!    (2) but under PAYMENT_MODE=x402. Asserts the T3-round-2 nonce
+//!    deferral (`mark_x402_nonce` fires only after delivery success):
+//!    after a failed delivery the `x402_nonces` table is empty, so the
+//!    caller can retry with the same `X-Payment` header without being
+//!    told "already consumed".
 //! 5. `quota_exceeded` — 5 consecutive demotions; the 6th `participate` call
 //!    short-circuits with `DeliveryQuotaExceeded` BEFORE any chain call.
 //! 6. `refund_failure_writes_audit_row` — stubbed refund failure → an
@@ -23,8 +27,8 @@
 mod delivery_harness;
 
 use delivery_harness::{
-    balance_for, build_state_and_router, call_sign_memory_participate, seed_api_key_jwt,
-    MockArweave, MockSolana,
+    balance_for, build_state_and_router, build_state_and_router_x402, call_sign_memory_participate,
+    call_sign_memory_participate_x402, seed_api_key_jwt, MockArweave, MockSolana,
 };
 
 use std::time::Duration;
@@ -332,4 +336,120 @@ async fn refund_failure_writes_audit_row() {
         .collect();
     assert!(!cols.iter().any(|c| c == "content_preview"));
     assert!(!cols.iter().any(|c| c == "cose_bytes"));
+}
+
+// ── 7. T3.5 — x402 nonce reusable after demotion ────────────────────────────
+
+/// `demotion_on_x402_leaves_nonce_reusable` — under PAYMENT_MODE=x402, an
+/// induced delivery failure must NOT consume the x402 nonce. This pins the
+/// T3-round-2 deferral (`consume_x402_nonce_after_success` runs only on a
+/// confirmed delivery) end-to-end: an attacker / unlucky caller can retry
+/// with the same `X-Payment` header without seeing a misleading "already
+/// consumed" rejection, and the operator hasn't double-billed.
+///
+/// Mocks `getTransaction` on Solana so `verify_usdc_transfer` passes
+/// without us minting an actual on-chain transaction. The delivery still
+/// fails for the regular T3 reason (corrupted Arweave GET), so the
+/// post-anchor demotion + refund path is what's actually exercised here.
+#[tokio::test]
+async fn demotion_on_x402_leaves_nonce_reusable() {
+    // A real-looking Solana tx signature (base58, ~88 chars). Doesn't have to
+    // verify on-chain — the mock dispatcher just substring-matches on it.
+    const TX_SIG: &str =
+        "5VfYdM3GjRZqkBdYNz2hVnQYsBfP1k8fL3jHkMb7vYqXrJzGw2XaRpUyMcNvDsW4eLkR1tFqGxKyPmAhU6Dv8nQT";
+    // Synthetic operator treasury + mainnet USDC mint. The mock proof says
+    // this exact owner+mint received `CHEAP_COST` micro-USDC.
+    const TREASURY: &str = "TreaSurYMockPayToMnemonik11111111111111111";
+    const USDC_MINT: &str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+
+    // Anchor PUT succeeds; GET returns 404 → refetch budget exhausts, the
+    // delivery check exits at the `refetch` stage — same shape as
+    // `demotion_on_refetch_failure` but under PAYMENT_MODE=x402 instead of
+    // `balance`. (Using `read_fails` rather than `corrupted_get` because
+    // the latter routes through `verify_cose` and ends at stage=`verify`,
+    // which is a separate test in this file.)
+    let arweave = MockArweave::read_fails("AR_TX_X402");
+    arweave.install();
+    let solana =
+        MockSolana::happy_with_x402_payment(TX_SIG, TREASURY, USDC_MINT, CHEAP_COST as u64);
+
+    let (state, app) = build_state_and_router_x402(
+        &arweave.base_url(),
+        &solana.base_url(),
+        CHEAP_COST,
+        5,
+        Duration::from_secs(60),
+        Duration::from_secs(2),
+        TREASURY,
+        USDC_MINT,
+    );
+
+    // Submit the request with X-Payment pointing at TX_SIG.
+    let (status, envelope) = call_sign_memory_participate_x402(&app, TX_SIG, "hello-x402").await;
+    assert_eq!(status, StatusCode::OK);
+
+    // Same -32011 shape as the other demotion tests.
+    let err = envelope["error"]
+        .as_object()
+        .expect("expected JSON-RPC error envelope");
+    assert_eq!(err["code"], -32011);
+    let data = err["data"].as_object().expect("data");
+    assert_eq!(data["stage"], "refetch");
+    assert_eq!(data["row_demoted_to"], "local");
+    let attestation_id = data["attestation_id"]
+        .as_str()
+        .expect("attestation_id in -32011 error data")
+        .to_string();
+
+    let store = state.store.lock().unwrap();
+
+    // Demotion landed in storage.
+    let row_write_mode: String = store
+        .conn()
+        .query_row(
+            "SELECT write_mode FROM attestations WHERE attestation_id = ?",
+            rusqlite::params![attestation_id],
+            |r| r.get::<_, String>(0),
+        )
+        .expect("row exists after demotion");
+    assert_eq!(row_write_mode, "local");
+
+    // ── THE T3.5 LOAD-BEARING ASSERTION ─────────────────────────────────
+    // x402 nonce was NOT consumed: `mark_x402_nonce` fires only via
+    // `consume_x402_nonce_after_success` on a confirmed delivery. A failed
+    // delivery must leave the row absent so retry with the same payment
+    // succeeds without a misleading "already consumed" rejection.
+    let nonce_consumed: bool = store
+        .conn()
+        .query_row(
+            "SELECT EXISTS (SELECT 1 FROM x402_nonces WHERE tx_sig = ?)",
+            rusqlite::params![TX_SIG],
+            |r| r.get::<_, bool>(0),
+        )
+        .expect("x402_nonces query");
+    assert!(
+        !nonce_consumed,
+        "T3 R2 nonce-deferral: failed delivery must leave x402 nonce \
+         reusable. tx_sig=`{TX_SIG}` should NOT appear in x402_nonces, \
+         but it does."
+    );
+
+    // No cost row written: Participate cost-record fires only on success.
+    let costs_count: i64 = store
+        .conn()
+        .query_row(
+            "SELECT COUNT(*) FROM attestation_costs WHERE attestation_id = ?",
+            rusqlite::params![attestation_id],
+            |r| r.get(0),
+        )
+        .unwrap_or(0);
+    assert_eq!(
+        costs_count, 0,
+        "demoted writes must not record an attestation_costs row"
+    );
+
+    drop(store);
+
+    // Counter increments under the per-stage label for operator observability.
+    assert_eq!(state.delivery_metrics.not_confirmed("refetch"), 1);
 }


### PR DESCRIPTION
## Summary

Lands the pre-merge follow-up from PR #156 (`modes-user-choice`) that the pre-deploy-qa report flagged as the one accepted residual: the dedicated end-to-end test for the **x402 nonce-deferral** behavior introduced in T3 round 2.

The production code path (`consume_x402_nonce_after_success` fires only on a confirmed delivery; failure leaves `x402_nonces` empty so the caller can retry with the same `X-Payment` header) was already in place and indirectly covered by unit tests + the balance-mode demotion path. This PR adds the explicit end-to-end assertion.

## What the test asserts

Under `PAYMENT_MODE=x402`:
- the operator's `verify_usdc_transfer` accepts a (mocked) Solana `getTransaction` proof for a known `tx_sig`,
- the request proceeds into `sign_memory_inline`,
- Arweave anchor PUT succeeds, GET 404s → delivery fails at `stage="refetch"`, row demoted to `local`,
- **and `x402_nonces` is EMPTY** — `tx_sig` was not marked consumed, so the caller can retry with the same `X-Payment` header without seeing a misleading "already consumed" rejection.

Plus the standard demotion-flow invariants (`-32011 DeliveryNotConfirmed`, `row_demoted_to: "local"`, no `attestation_costs` row, per-stage metric counter increments).

## Test infrastructure added

- `mcp/src/test_support.rs::mock_state_for_delivery` — gained two trailing args, `treasury_pubkey` and `usdc_mint`, threaded into the `McpState` literal. Existing call site in the harness passes `""`/`""` (no x402).

- `mcp/tests/_helpers/delivery_harness.rs`:
  - `build_state_and_router_x402(..., treasury, usdc_mint)` — sibling of `build_state_and_router`, hardcodes `payment_mode="x402"`.
  - `MockSolana::happy_with_x402_payment(tx_sig, treasury, mint, cost)` — extends the existing httpmock-backed Solana mock with a `getTransaction` response whose `meta.postTokenBalances` shows the treasury+mint balance bumped by `cost` micro-USDC. Body-includes dispatcher matches on `tx_sig` so a misconfigured test fails loudly instead of silently mocking a different proof.
  - `call_sign_memory_participate_x402(app, tx_sig, content)` — issues `tools/call mnemonic_sign_memory { mode: "participate" }` with an `X-Payment` header carrying the raw-JSON proof shape `extract_x402_proof` accepts.

Also bumps `.gitignore` to cover ruflo runtime + per-developer `.claude/` artifacts that the broader `.claude/skills/*` rule (from PR #156) missed.

**No production code changes — purely test infrastructure.**

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-targets --features mnemonic-mcp/test-support -- -D warnings`
- [x] `cargo test --workspace --features mnemonic-mcp/test-support --no-fail-fast` → **534 passed, 0 failed** (was 533, +1)
- [ ] CI on the PR head

## Closes

- PR #156's pre-merge checklist item: **T3.5 — `demotion_on_x402` integration test**

🤖 Generated with [Claude Code](https://claude.com/claude-code)