### PR TITLE
feat(release): add macOS Intel (x86_64-apple-darwin) build target

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,16 +95,13 @@ jobs:
   build-macos:
     name: Build ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
-    # v0.2.3: x86_64-apple-darwin dropped from the matrix — macos-13
-    # runners have been unavailable / heavily queued; v1 scope is
-    # Apple Silicon only (binary-version.json artifacts dict now lists
-    # only darwin-arm64; packages/mcp/src/paths.ts raises a clean
-    # "Apple Silicon required" error for darwin-x64 callers).
     strategy:
       matrix:
         include:
           - target: aarch64-apple-darwin
             runner: macos-latest
+          - target: x86_64-apple-darwin
+            runner: macos-13
     steps:
       - uses: actions/checkout@v4
 

--- a/packages/mcp/dist/binary-version.json
+++ b/packages/mcp/dist/binary-version.json
@@ -2,6 +2,7 @@
   "tag": "v0.2.4",
   "artifacts": {
     "darwin-arm64": "mnemonic-mcp-v0.2.4-aarch64-apple-darwin.tar.gz",
+    "darwin-x64": "mnemonic-mcp-v0.2.4-x86_64-apple-darwin.tar.gz",
     "linux-x64": "mnemonic-mcp-v0.2.4-x86_64-unknown-linux-gnu.tar.gz"
   }
 }

--- a/packages/mcp/src/paths.ts
+++ b/packages/mcp/src/paths.ts
@@ -48,23 +48,17 @@ export function manifestPath(): string {
   return join(cacheDir(), "manifest.json");
 }
 
-export type PlatformKey = "darwin-arm64" | "linux-x64";
+export type PlatformKey = "darwin-arm64" | "darwin-x64" | "linux-x64";
 
 export function detectPlatform(): PlatformKey {
   const p = platform();
   const a = arch();
   if (p === "darwin" && a === "arm64") return "darwin-arm64";
+  if (p === "darwin" && a === "x64") return "darwin-x64";
   if (p === "linux" && a === "x64") return "linux-x64";
-  if (p === "darwin" && a === "x64") {
-    throw new Error(
-      "@mnemonik-xyz/mcp v1 ships Apple Silicon (arm64) only; " +
-        "Intel Mac (x86_64) builds are not available. " +
-        "Run on an arm64 Mac or wait for a later release.",
-    );
-  }
   throw new Error(
-    `unsupported platform ${p}/${a}; @mnemonik-xyz/mcp v1 ships ` +
-      `macOS (arm64) and Linux (x86_64) only`,
+    `unsupported platform ${p}/${a}; @mnemonik-xyz/mcp ships ` +
+      `macOS (arm64 + x64) and Linux (x86_64) only`,
   );
 }
 


### PR DESCRIPTION
## Summary

- Add `x86_64-apple-darwin` to the `build-macos` matrix (`macos-13` runner)
- Add `darwin-x64` entry to `packages/mcp/dist/binary-version.json`
- Remove the \"Apple Silicon required\" error from `detectPlatform()` in `paths.ts` — Intel Macs now return `\"darwin-x64\"` instead of throwing

SHA256SUMS and artifact attestation steps pick up the new tarball automatically (no changes needed to the release job).

## Test plan

- [ ] CI `build-macos` job passes for both `aarch64-apple-darwin` (macos-latest) and `x86_64-apple-darwin` (macos-13)
- [ ] All 27 vitest tests pass
- [ ] After merge: cut a new tag so the Intel artifact lands in a GitHub Release, then update `binary-version.json` tag + publish updated `@mnemonik-xyz/mcp`

**Note:** `binary-version.json` still points at `v0.2.3` which has no Intel artifact. A follow-up version bump is needed after merge before Intel users can `npm install -g @mnemonik-xyz/mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)