### PR TITLE
fix(chat) + ci: RAG seed idempotency fix + automated MCP/webapp deploy workflows

### DIFF
--- a/.claude/skills/project-knowledge/references/deployment.md
+++ b/.claude/skills/project-knowledge/references/deployment.md
@@ -69,7 +69,21 @@ Variables for `mcp/` (set by user):
 
 **mcp/ binary:** Manual on git tag. CI cross-compiles and attaches to GitHub Release. Docker image pushed to GHCR.
 
-**webapp/ + docs/:** Auto-deploy on push to `main`. Preview on every PR (Cloudflare Pages).
+**webapp/ + docs/:** Auto-deploy on push to `main` via `.github/workflows/deploy-webapp.yml` (builds WASM core + Vite bundle, publishes to Cloudflare Pages, optionally chains a prod chat corpus reseed). Preview on every PR via Cloudflare Pages git integration. Manual republish via Actions UI → "Deploy Webapp" → Run workflow, with optional `reseed_chat_corpus` toggle.
+
+**mcp/ to production VPS:** Manual via `.github/workflows/deploy-mcp.yml` (Actions UI → "Deploy MCP" → Run workflow). Three actions: `apply` (SSH + git pull + cargo build + systemctl restart), `smoke` (verify-only, no SSH), `rollback` (checkout previous tag + rebuild + restart). The `force_reseed` flag injects `MNEMONIC_FORCE_RESEED=1` into `/home/claude/mcp.env` for ONE boot so docs/ changes propagate to the chat's RAG corpus, then removes the var. Auto-deploy on `v*` tag is intentionally disabled — the prod ship decision stays with a human on the 4 GB RAM single-node. See `mcp/src/seed.rs` for the artifact-mtime-aware seed idempotency the workflow relies on.
+
+**Required deploy secrets** (set via `gh secret set -R mnemonik-xyz/monorepo <NAME>`):
+
+| Secret | Used by | Value |
+|--------|---------|-------|
+| `VPS_HOST` | deploy-mcp, deploy-webapp (reseed step) | `150.251.147.215` |
+| `VPS_USER` | deploy-mcp, deploy-webapp (reseed step) | `claude` |
+| `VPS_SSH_PRIVATE_KEY` | deploy-mcp, deploy-webapp (reseed step) | Ed25519 private key, the matching pubkey added to `claude@150.251.147.215:~/.ssh/authorized_keys` |
+| `VPS_KNOWN_HOSTS` | deploy-mcp, deploy-webapp (reseed step) | Output of `ssh-keyscan -t ed25519,rsa 150.251.147.215` — pins the host key, prevents trust-on-first-use MITM |
+| `CLOUDFLARE_API_TOKEN` | deploy-webapp | Pages-scoped API token from Cloudflare dashboard |
+| `CLOUDFLARE_ACCOUNT_ID` | deploy-webapp | The Cloudflare account hosting the Pages project |
+| `CLOUDFLARE_PROJECT_NAME` (variable, not secret) | deploy-webapp | Defaults to `mnemonic-webapp` if unset; override with `gh variable set -R mnemonik-xyz/monorepo CLOUDFLARE_PROJECT_NAME --body <name>` if the Pages project uses a different slug |
 
 **CI tests:** Every push to `main` and `dev`, every PR.
 

--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -1,0 +1,198 @@
+name: Deploy MCP
+
+# Ships the `mnemonic-mcp` HTTP server to the production VPS at
+# `mcp.mnemonik.xyz` (150.251.147.215). Borrows the action-choice ergonomics
+# from `mnemonik-dev/coding-fabric`'s `deploy-fabric.yml` while dropping the
+# OpenTofu/Hetzner provisioning layer — the VPS already exists, so this
+# workflow only handles in-place updates of the running service.
+#
+# Trigger model: manual-only by default (workflow_dispatch). A maintainer
+# clicks "Run workflow" → picks `deploy` / `smoke` / `rollback` → optional
+# `tag` field for rollback target. Auto-deploy on `v*` tag is intentionally
+# disabled — the existing `release.yml` builds GitHub Release artifacts but
+# the prod ship decision stays with a human (production downtime risk on a
+# 4 GB RAM single-node).
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'apply (deploy), smoke (verify only), or rollback'
+        type: choice
+        required: true
+        default: smoke
+        options:
+          - apply
+          - smoke
+          - rollback
+      ref:
+        description: 'git ref to deploy or roll back to (defaults to main; e.g. v0.2.4 or a SHA)'
+        type: string
+        required: false
+        default: main
+      force_reseed:
+        description: 'Set MNEMONIC_FORCE_RESEED=1 for one boot so docs/ changes propagate to the chat corpus.'
+        type: boolean
+        required: false
+        default: true
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  # Serialize against parallel deploys / rollbacks. Smoke checks are
+  # cheap enough that we let them queue rather than cancel a deploy.
+  group: deploy-mcp-prod
+  cancel-in-progress: false
+
+env:
+  PROD_HEALTH_URL: https://mcp.mnemonik.xyz/health
+  PROD_DISCOVERY_URL: https://mcp.mnemonik.xyz/.well-known/oauth-authorization-server
+  PROD_MCP_URL: https://mcp.mnemonik.xyz/mcp
+
+jobs:
+  deploy:
+    name: Deploy or rollback over SSH
+    if: ${{ inputs.action == 'apply' || inputs.action == 'rollback' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Verify required secrets are present
+        run: |
+          for var in VPS_HOST VPS_USER VPS_SSH_PRIVATE_KEY VPS_KNOWN_HOSTS; do
+            if [ -z "${!var:-}" ]; then
+              echo "::error::Missing required secret: $var"
+              exit 1
+            fi
+          done
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
+          VPS_KNOWN_HOSTS: ${{ secrets.VPS_KNOWN_HOSTS }}
+
+      - name: Configure SSH client
+        run: |
+          set -euo pipefail
+          install -m 0700 -d ~/.ssh
+          printf '%s\n' "${{ secrets.VPS_SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_ed25519
+          chmod 0600 ~/.ssh/deploy_ed25519
+          printf '%s\n' "${{ secrets.VPS_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 0644 ~/.ssh/known_hosts
+
+      - name: Deploy or rollback on VPS
+        env:
+          ACTION: ${{ inputs.action }}
+          REF: ${{ inputs.ref }}
+          FORCE_RESEED: ${{ inputs.force_reseed }}
+        run: |
+          set -euo pipefail
+          # IMPORTANT: the heredoc body runs on the VPS. Variables we want
+          # to substitute LOCALLY are unquoted (REF, ACTION); literals
+          # destined for the remote shell stay quoted ('$VAR') so they
+          # expand on the remote side. Failures inside the remote script
+          # are surfaced via `set -e` + the non-zero exit propagation
+          # through ssh.
+          ssh -i ~/.ssh/deploy_ed25519 \
+              -o IdentitiesOnly=yes \
+              -o ConnectTimeout=15 \
+              "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" \
+              bash -s <<REMOTE_EOF
+          set -euo pipefail
+          cd /home/claude/monorepo
+
+          echo "::group::git state before deploy"
+          git rev-parse --short HEAD
+          git log --oneline -1 HEAD
+          echo "::endgroup::"
+
+          if [ "$ACTION" = "rollback" ]; then
+            echo "Rolling back to ${REF}"
+            git fetch --tags --quiet origin
+            git checkout --quiet "${REF}"
+          else
+            echo "Deploying ${REF}"
+            git fetch --quiet origin
+            git checkout --quiet "${REF}"
+            git reset --hard "origin/\$(git symbolic-ref --short HEAD 2>/dev/null || echo ${REF})" 2>/dev/null \
+              || git reset --hard "${REF}"
+          fi
+
+          echo "::group::cargo build --release"
+          source ~/.cargo/env
+          cargo build --release -p mnemonic-mcp --features local-embed
+          echo "::endgroup::"
+
+          if [ "$FORCE_RESEED" = "true" ]; then
+            echo "MNEMONIC_FORCE_RESEED=1 will be set for the next boot"
+            # Append to the systemd environment file the service reads. The
+            # variable is consumed once at startup; remove it after the run
+            # so subsequent restarts use the artifact-mtime check instead.
+            sudo sed -i '/^MNEMONIC_FORCE_RESEED=/d' /home/claude/mcp.env
+            echo "MNEMONIC_FORCE_RESEED=1" | sudo tee -a /home/claude/mcp.env >/dev/null
+          fi
+
+          echo "::group::restart service"
+          sudo systemctl restart mnemonic-mcp
+          sleep 6
+          sudo systemctl is-active mnemonic-mcp || (sudo journalctl -u mnemonic-mcp --no-pager -n 50; exit 1)
+          echo "::endgroup::"
+
+          if [ "$FORCE_RESEED" = "true" ]; then
+            echo "Removing MNEMONIC_FORCE_RESEED so the next restart uses mtime-aware idempotency"
+            sudo sed -i '/^MNEMONIC_FORCE_RESEED=/d' /home/claude/mcp.env
+          fi
+
+          echo "::group::post-restart log tail (RAG seed lines)"
+          sudo journalctl -u mnemonic-mcp --no-pager -S '15 seconds ago' \
+            | grep -iE 'seed|protocol-knowledge|Identity:|listening|server origin seeded' \
+            || true
+          echo "::endgroup::"
+          REMOTE_EOF
+
+  smoke:
+    name: Post-deploy smoke
+    needs: deploy
+    # Always run smoke (even on smoke-only invocations where `deploy` is skipped).
+    if: ${{ always() && (needs.deploy.result == 'success' || needs.deploy.result == 'skipped') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: /health
+        run: |
+          set -euo pipefail
+          curl -fsS --max-time 10 "$PROD_HEALTH_URL" | tee /tmp/health.json
+          test "$(jq -r .status </tmp/health.json)" = "ok"
+
+      - name: OAuth discovery advertises both grants
+        run: |
+          set -euo pipefail
+          curl -fsS --max-time 10 "$PROD_DISCOVERY_URL" | tee /tmp/discovery.json
+          jq -e '.grant_types_supported | index("authorization_code") and index("refresh_token")' \
+            </tmp/discovery.json >/dev/null
+
+      - name: Anonymous tools/list returns the full set
+        run: |
+          set -euo pipefail
+          payload='{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+          curl -fsS --max-time 10 -X POST "$PROD_MCP_URL" \
+            -H 'Content-Type: application/json' \
+            -d "$payload" \
+            | jq -e '(.result.tools | length) >= 7' >/dev/null
+
+      - name: Chat returns non-empty context-grounded response
+        # Smoke check for issue surfaced 2026-06-25: chat said "no context about mnemonik"
+        # because the docs/ tree on prod was 3 weeks stale and the seed idempotency
+        # check was bugged. Bare-minimum signal: chat returns a non-empty `response`.
+        # Deeper checks (does the answer cite a known whitepaper section?) belong in
+        # a separate e2e suite.
+        run: |
+          set -euo pipefail
+          payload='{"message":"What is the Mnemonic Protocol?","session_id":"deploy-smoke"}'
+          response=$(curl -fsS --max-time 30 -X POST \
+            "https://mcp.mnemonik.xyz/chat" \
+            -H 'Content-Type: application/json' \
+            -d "$payload")
+          echo "$response" | jq .
+          test -n "$(echo "$response" | jq -r '.response // empty')"

--- a/.github/workflows/deploy-webapp.yml
+++ b/.github/workflows/deploy-webapp.yml
@@ -1,0 +1,174 @@
+name: Deploy Webapp
+
+# Builds the demo webapp (WASM core + Vite bundle) and republishes it to
+# Cloudflare Pages. The webapp's chat demo and install deeplinks live here.
+#
+# Two trigger modes:
+#   - `workflow_dispatch` (recommended) — explicit "Run workflow" click,
+#     with an opt-in flag to ALSO reseed the prod MCP chat corpus after
+#     publishing (use when docs/ content changed and the chat needs to
+#     pick up the new whitepaper / design docs).
+#   - `push` to main when files under `webapp/`, `core/` (WASM bindings),
+#     or `docs/` change — auto-republish so the public site doesn't drift
+#     from main. The `docs/` trigger means a doc-only PR merge will
+#     republish AND reseed the chat corpus automatically.
+#
+# Cloudflare Pages also has a git integration that auto-deploys on push.
+# This workflow is the explicit / scriptable alternative: it lets us
+# (a) trigger a republish manually without an empty commit, (b) chain the
+# MCP reseed step so prod chat doesn't drift, and (c) record the build
+# outcome in Actions for audit.
+
+on:
+  workflow_dispatch:
+    inputs:
+      reseed_chat_corpus:
+        description: 'After publishing, SSH to prod MCP and trigger MNEMONIC_FORCE_RESEED=1 + restart so the chat picks up new docs/.'
+        type: boolean
+        required: false
+        default: false
+  push:
+    branches: [main]
+    paths:
+      - 'webapp/**'
+      - 'core/**'
+      - 'docs/**'
+
+permissions:
+  contents: read
+  deployments: write   # cloudflare/pages-action posts a deployment status
+
+concurrency:
+  group: deploy-webapp-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-publish:
+    name: Build WASM + Vite + publish to Cloudflare Pages
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      cf_url: ${{ steps.cf_publish.outputs.url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify Cloudflare secrets
+        run: |
+          for var in CLOUDFLARE_API_TOKEN CLOUDFLARE_ACCOUNT_ID; do
+            if [ -z "${!var:-}" ]; then
+              echo "::error::Missing required secret: $var"
+              exit 1
+            fi
+          done
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: webapp-wasm
+
+      - name: Install wasm-pack
+        # Pin to a published version; CI cache reuses across runs.
+        run: cargo install wasm-pack --locked --version 0.13.1
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install webapp dependencies
+        working-directory: webapp
+        # `--no-audit --no-fund` to silence noise; the lockfile is at repo
+        # root, so no `npm ci` here.
+        run: npm install --no-audit --no-fund
+
+      - name: Build WASM core + Vite bundle
+        working-directory: webapp
+        run: npm run build
+
+      - name: Publish to Cloudflare Pages
+        id: cf_publish
+        uses: cloudflare/pages-action@v1
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          projectName: ${{ vars.CLOUDFLARE_PROJECT_NAME || 'mnemonic-webapp' }}
+          directory: webapp/dist
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+  reseed-prod-chat:
+    name: Reseed prod chat corpus
+    needs: build-and-publish
+    # Only run when the maintainer asked for it, or when a docs-only change
+    # auto-triggered the workflow (push event with `docs/**` in the paths).
+    if: ${{ inputs.reseed_chat_corpus == true || github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Verify VPS secrets
+        run: |
+          for var in VPS_HOST VPS_USER VPS_SSH_PRIVATE_KEY VPS_KNOWN_HOSTS; do
+            if [ -z "${!var:-}" ]; then
+              echo "::error::Missing required secret: $var — skipping reseed"
+              exit 1
+            fi
+          done
+        env:
+          VPS_HOST: ${{ secrets.VPS_HOST }}
+          VPS_USER: ${{ secrets.VPS_USER }}
+          VPS_SSH_PRIVATE_KEY: ${{ secrets.VPS_SSH_PRIVATE_KEY }}
+          VPS_KNOWN_HOSTS: ${{ secrets.VPS_KNOWN_HOSTS }}
+
+      - name: Configure SSH client
+        run: |
+          set -euo pipefail
+          install -m 0700 -d ~/.ssh
+          printf '%s\n' "${{ secrets.VPS_SSH_PRIVATE_KEY }}" > ~/.ssh/deploy_ed25519
+          chmod 0600 ~/.ssh/deploy_ed25519
+          printf '%s\n' "${{ secrets.VPS_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 0644 ~/.ssh/known_hosts
+
+      - name: Pull latest docs/ on VPS and force-reseed chat corpus
+        # The chat handler in mcp/ recalls from the on-disk corpus, which is
+        # built from the docs/ tree at server boot. The seed idempotency check
+        # (post-fix) is artifact-mtime-aware, so `git pull` followed by
+        # `MNEMONIC_FORCE_RESEED=1`-gated restart guarantees a fresh corpus.
+        run: |
+          set -euo pipefail
+          ssh -i ~/.ssh/deploy_ed25519 \
+              -o IdentitiesOnly=yes \
+              -o ConnectTimeout=15 \
+              "${{ secrets.VPS_USER }}@${{ secrets.VPS_HOST }}" \
+              bash -s <<'REMOTE_EOF'
+          set -euo pipefail
+          cd /home/claude/monorepo
+          git fetch --quiet origin main
+          git checkout --quiet main
+          git reset --hard origin/main
+
+          sudo sed -i '/^MNEMONIC_FORCE_RESEED=/d' /home/claude/mcp.env
+          echo "MNEMONIC_FORCE_RESEED=1" | sudo tee -a /home/claude/mcp.env >/dev/null
+          sudo systemctl restart mnemonic-mcp
+          sleep 6
+          sudo systemctl is-active mnemonic-mcp
+          sudo sed -i '/^MNEMONIC_FORCE_RESEED=/d' /home/claude/mcp.env
+
+          sudo journalctl -u mnemonic-mcp --no-pager -S '15 seconds ago' \
+            | grep -iE 'seed|protocol-knowledge|Identity:|listening' \
+            || true
+          REMOTE_EOF
+
+      - name: Verify chat returns a context-grounded answer
+        run: |
+          set -euo pipefail
+          payload='{"message":"What is the Mnemonic Protocol?","session_id":"reseed-smoke"}'
+          response=$(curl -fsS --max-time 30 -X POST \
+            "https://mcp.mnemonik.xyz/chat" \
+            -H 'Content-Type: application/json' \
+            -d "$payload")
+          echo "$response" | jq .
+          test -n "$(echo "$response" | jq -r '.response // empty')"

--- a/core/src/storage/sqlite.rs
+++ b/core/src/storage/sqlite.rs
@@ -729,6 +729,22 @@ impl AttestationStore for SqliteStore {
         Ok(count)
     }
 
+    fn delete_protocol_knowledge_for_owner(&self, owner_pubkey: &str) -> anyhow::Result<usize> {
+        // `tags` is stored as canonical-CBOR-derived JSON text per the
+        // attestations schema. The substring search is correct because every
+        // seeded chunk carries the literal token `"protocol-knowledge"`
+        // (`mcp/src/seed.rs:313`) and no other tag system uses that exact
+        // string. If a future tag is introduced that contains it as a
+        // substring, this query needs to widen to a JSON_EXTRACT predicate.
+        let affected = self.conn.execute(
+            "DELETE FROM attestations \
+             WHERE owner_pubkey = ?1 \
+               AND tags LIKE '%\"protocol-knowledge\"%'",
+            params![owner_pubkey],
+        )?;
+        Ok(affected)
+    }
+
     fn search(
         &self,
         query_embedding: &[f32],

--- a/core/src/storage/traits.rs
+++ b/core/src/storage/traits.rs
@@ -103,6 +103,23 @@ pub trait AttestationStore {
 
     fn count(&self, signer: &str) -> anyhow::Result<i64>;
 
+    /// Wipe the previously-seeded protocol-knowledge corpus for `owner_pubkey`.
+    ///
+    /// Called by `mcp/src/seed.rs::run` before a forced reseed (`MNEMONIC_FORCE_RESEED=1`
+    /// or detected stale artifact) so the new chunks don't pile up alongside an
+    /// outdated copy. Matches rows where `owner_pubkey = ?` AND the JSON `tags`
+    /// column contains `"protocol-knowledge"` — the canonical tag every seeded
+    /// chunk carries (`mcp/src/seed.rs:313`).
+    ///
+    /// User-signed attestations (`owner_pubkey` = some OAuth pubkey, NOT the
+    /// server's signing pubkey) are never matched: those rows have an OAuth
+    /// `owner_pubkey`, while the seeded corpus has `owner_pubkey = server_pubkey`.
+    /// Returns the number of rows deleted; default impl returns `0` for stores
+    /// that don't seed (e.g. test fakes).
+    fn delete_protocol_knowledge_for_owner(&self, _owner_pubkey: &str) -> anyhow::Result<usize> {
+        Ok(0)
+    }
+
     /// Cosine-similarity search.
     ///
     /// `owner_pubkey` — `Some(pk)` scopes results to a single owner (the

--- a/mcp/src/seed.rs
+++ b/mcp/src/seed.rs
@@ -226,6 +226,18 @@ fn walk_docs_tree(root: &Path) -> Result<Vec<PathBuf>> {
     Ok(files)
 }
 
+/// Modification time of the most recently-modified `.md` file under `root`
+/// (subject to the same exclusion rules as [`walk_docs_tree`]). Returns
+/// `None` if the tree is empty or unreadable — callers treat that as
+/// "can't decide, fall through to a full seed."
+fn newest_md_mtime(root: PathBuf) -> Option<std::time::SystemTime> {
+    walk_docs_tree(&root)
+        .ok()?
+        .into_iter()
+        .filter_map(|p| std::fs::metadata(&p).and_then(|m| m.modified()).ok())
+        .max()
+}
+
 /// Render a relative path as a forward-slash string for tags / headings.
 /// Stays stable across operating systems (Windows backslashes get normalized).
 fn rel_path_string(path: &Path) -> String {
@@ -235,29 +247,75 @@ fn rel_path_string(path: &Path) -> String {
         .join("/")
 }
 
-/// Run the RAG seeding routine. Idempotent: skips if store already has entries.
+/// Run the RAG seeding routine.
+///
+/// Idempotency model (post-fix, 2026-06):
+/// * `MNEMONIC_FORCE_RESEED=1` — always reseed regardless of artifact / DB state.
+///   Set this in CI's deploy step after a successful `git pull` so docs/ changes
+///   propagate to the chat's RAG corpus on the next restart.
+/// * Otherwise — skip iff the artifact `protocol-knowledge.zip` exists AND its
+///   mtime is at least as new as the newest `.md` under `docs/`. This means the
+///   first boot after a docs-tree change auto-reseeds; subsequent boots skip.
+///
+/// Why the change: the legacy idempotency check called `store.count(server_pubkey)`,
+/// but `AttestationStore::count` queries by `signer_pubkey` — and the server
+/// keypair is the signer for EVERY attestation (it co-signs each user write).
+/// Once any user wrote anything, count > 0 forever and the protocol-knowledge
+/// corpus was permanently frozen on the FIRST seed. Surfaced live on
+/// `mcp.mnemonik.xyz` 2026-06-25: 60-day-stale artifact, chat returned
+/// "no context about mnemonik" because the recall corpus pre-dated v0.2
+/// whitepaper revisions and the entire `work/completed/noncustodial-paradigm/`
+/// design corpus.
 pub async fn run(state: &McpState) -> Result<()> {
     let pubkey = identity::pubkey_base58(&state.keypair);
+    let force_reseed = std::env::var("MNEMONIC_FORCE_RESEED")
+        .ok()
+        .filter(|v| matches!(v.trim(), "1" | "true" | "yes" | "on"))
+        .is_some();
 
-    // Check idempotency: skip if store already has attestations
-    {
-        let store = state.store.lock().unwrap();
-        let count = store.count(&pubkey).unwrap_or(0);
-        if count > 0 {
+    // Idempotency: skip iff artifact exists AND artifact mtime >= newest docs mtime.
+    // Force-reseed (env var) bypasses entirely.
+    if !force_reseed {
+        let artifact_dir = std::path::Path::new(&state.rag_chunk_dir);
+        let zip_path = artifact_dir.join("protocol-knowledge.zip");
+        let artifact_mtime = zip_path.metadata().and_then(|m| m.modified()).ok();
+        let docs_newest_mtime = find_docs_root().ok().and_then(newest_md_mtime);
+        let skip = match (artifact_mtime, docs_newest_mtime) {
+            (Some(a), Some(d)) => a >= d,
+            // No artifact OR no docs/ → fall through to full seed logic below
+            // (it logs a clearer message and decides what to do).
+            _ => false,
+        };
+        if skip {
             tracing::info!(
-                "RAG seeding skipped: store already has {count} attestation(s) for {pubkey}"
+                "RAG seeding skipped: artifact at {} is up to date (newer than docs/)",
+                zip_path.display()
             );
-            // Still set artifact path if the zip exists on disk
-            let artifact_dir = std::path::Path::new(&state.rag_chunk_dir);
-            let zip_path = artifact_dir.join("protocol-knowledge.zip");
-            if zip_path.exists() {
-                if let Ok(canonical) = zip_path.canonicalize() {
-                    let mut path_guard = state.artifact_zip_path.lock().unwrap();
-                    *path_guard = Some(canonical.clone());
-                    tracing::info!("Artifact path set: {}", canonical.display());
-                }
+            if let Ok(canonical) = zip_path.canonicalize() {
+                let mut path_guard = state.artifact_zip_path.lock().unwrap();
+                *path_guard = Some(canonical.clone());
+                tracing::info!("Artifact path set: {}", canonical.display());
             }
             return Ok(());
+        }
+        tracing::info!(
+            "RAG seeding: docs/ newer than artifact (or artifact missing) — reseeding for {}",
+            pubkey
+        );
+    } else {
+        tracing::info!(
+            "RAG seeding: MNEMONIC_FORCE_RESEED set — reseeding for {}",
+            pubkey
+        );
+    }
+
+    // If we're reseeding, wipe any previously-seeded protocol-knowledge rows
+    // owned by this server keypair so re-runs don't duplicate the corpus.
+    // Best-effort: failures here log a warning but don't block the seed.
+    {
+        let store = state.store.lock().unwrap();
+        if let Err(e) = store.delete_protocol_knowledge_for_owner(&pubkey) {
+            tracing::warn!("RAG seeding: failed to wipe stale protocol-knowledge rows: {e}");
         }
     }
 


### PR DESCRIPTION
## Two related changes

This PR delivers two pieces of work that go together: the **chat corpus bug** discovered live on `mcp.mnemonik.xyz` 2026-06-25, and the **automated release process** that mirrors the pattern in `mnemonik-dev/coding-fabric`.

---

### Part 1 — fix(mcp): chat RAG seed idempotency

**Root cause:** \`mcp/src/seed.rs::run\` called \`store.count(server_pubkey)\` to decide whether to re-seed the protocol-knowledge corpus. But \`AttestationStore::count\` queries by \`signer_pubkey\`, and the server keypair is the signer for EVERY attestation (it co-signs every user write). Once any OAuth user wrote anything, \`count > 0\` forever and the chat corpus was permanently frozen at whatever was seeded the FIRST time the server booted.

**Surfaced live:**
- \`/home/claude/data/rag_chunks/protocol-knowledge.zip\` was dated \`2026-04-25\` — 60 days stale
- \`/home/claude/monorepo/docs/\` itself was 3 weeks behind main (no \`git pull\` since 2026-06-11)
- Chat returned "no context about mnemonik" because the seeded corpus pre-dated the v0.2 whitepaper revisions AND the entire \`work/noncustodial-paradigm/\` design corpus from PR #172

**Fix:**
- Replace count-based skip with **artifact mtime comparison**: skip iff \`protocol-knowledge.zip\` exists AND its mtime ≥ newest \`docs/**/*.md\` mtime. First boot after a docs change auto-reseeds.
- New env var \`MNEMONIC_FORCE_RESEED=1\` (truthy values: \`1\`/\`true\`/\`yes\`/\`on\`) bypasses the check entirely. The CI workflow sets this for ONE boot after a docs-touching deploy, then removes it.
- New trait method \`AttestationStore::delete_protocol_knowledge_for_owner\` (default impl returns 0, SqliteStore implements). Called before reseed so chunks don't pile up. Matches \`owner_pubkey = ? AND tags LIKE '%\"protocol-knowledge\"%'\` — never touches OAuth-user-signed attestations (they have a different \`owner_pubkey\`).

---

### Part 2 — ci: deploy-mcp + deploy-webapp workflows

Pattern adapted from \`mnemonik-dev/coding-fabric/.github/workflows/deploy-fabric.yml\`: same action-choice ergonomics (\`apply\` / \`smoke\` / \`rollback\`) and SSH-key handling, minus the OpenTofu/Hetzner provisioning layer (the VPS at 150.251.147.215 already exists).

**\`.github/workflows/deploy-mcp.yml\`** — VPS deploy
- \`workflow_dispatch\` only (manual click in Actions UI). Auto-deploy on \`v*\` tag intentionally disabled — prod is a 4 GB RAM single-node, the ship decision stays with a human.
- Three actions: \`apply\` (SSH + git checkout + cargo build --release + systemctl restart), \`smoke\` (verify prod without touching VPS), \`rollback\` (git checkout previous tag + rebuild + restart).
- \`force_reseed\` toggle injects \`MNEMONIC_FORCE_RESEED=1\` into \`/home/claude/mcp.env\` for ONE boot, then removes the var.
- Post-deploy smoke always runs: \`/health\`, OAuth discovery (both grants), \`tools/list\` (≥7 tools), and \`/chat\` (regression guard for the corpus-stale bug).

**\`.github/workflows/deploy-webapp.yml\`** — Webapp republish
- \`workflow_dispatch\` with optional \`reseed_chat_corpus\` toggle.
- \`push\` to main auto-triggers when files under \`webapp/\`, \`core/\`, or \`docs/\` change. A docs-only PR merge will republish AND reseed automatically.
- Builds WASM core + Vite bundle, publishes via \`cloudflare/pages-action@v1\`.
- Chained \`reseed-prod-chat\` job: SSH to VPS, set FORCE_RESEED for one boot, restart, verify chat returns non-empty response.

**\`deployment.md\`** updated with the new triggers + required-secrets table.

---

## Required setup before this PR is useful

After merge, set these secrets on \`mnemonik-xyz/monorepo\`:

| Secret | Used by | Value |
|--------|---------|-------|
| \`VPS_HOST\` | both | \`150.251.147.215\` |
| \`VPS_USER\` | both | \`claude\` |
| \`VPS_SSH_PRIVATE_KEY\` | both | Ed25519 key whose pubkey is in \`claude@VPS:~/.ssh/authorized_keys\` |
| \`VPS_KNOWN_HOSTS\` | both | Output of \`ssh-keyscan -t ed25519,rsa 150.251.147.215\` |
| \`CLOUDFLARE_API_TOKEN\` | webapp | Pages-scoped API token |
| \`CLOUDFLARE_ACCOUNT_ID\` | webapp | Cloudflare account hosting the Pages project |

Plus optional variable:
- \`CLOUDFLARE_PROJECT_NAME\` (variable, not secret) — defaults to \`mnemonic-webapp\` if unset

## Test plan

- [x] \`cargo test -p mnemonic-core --lib storage\` — 28/28 pass
- [x] \`cargo clippy -p mnemonic-mcp -p mnemonic-core --no-deps\` — clean
- [x] \`cargo fmt --check\` — clean
- [ ] After merge: set the 6 required secrets, then trigger \`Deploy MCP\` with \`apply\` + \`force_reseed=true\` to unblock the chat corpus bug live (manual unblock attempted this session via direct SSH did NOT clear the symptom because the OLD seed.rs code was still on prod)
- [ ] Verify chat returns a non-empty response after the deploy
- [ ] Trigger \`Deploy Webapp\` with \`reseed_chat_corpus=false\` to validate the Cloudflare publish path

## Related

- #172 (noncustodial paradigm) — its docs are what's missing from prod chat
- Issue tracker: file a follow-up for the \`store.count(signer)\` semantic gotcha (the trait method is named ambiguously; rename considered for a future cleanup PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)