### PR TITLE
fix(mcp/core): seed local-mode override + FK-cascade delete (follow-up to #173)

### DIFF
--- a/core/src/storage/sqlite.rs
+++ b/core/src/storage/sqlite.rs
@@ -736,12 +736,40 @@ impl AttestationStore for SqliteStore {
         // (`mcp/src/seed.rs:313`) and no other tag system uses that exact
         // string. If a future tag is introduced that contains it as a
         // substring, this query needs to widen to a JSON_EXTRACT predicate.
-        let affected = self.conn.execute(
+        //
+        // Delete in dependency order to avoid `FOREIGN KEY constraint failed`:
+        // `memory_embeddings.attestation_id` has a FK into `attestations`.
+        // `attestation_costs` has a FK too (full mode only — empty on
+        // local-only deploys, but the DELETE is cheap either way).
+        // Discovered live on prod 2026-06-26: the original single-statement
+        // DELETE was blocked by the embeddings FK; the seed code WARN-logged
+        // and continued, leaving stale chunks alongside the fresh corpus.
+        let tx = self.conn.unchecked_transaction()?;
+        tx.execute(
+            "DELETE FROM memory_embeddings \
+             WHERE attestation_id IN (\
+               SELECT attestation_id FROM attestations \
+               WHERE owner_pubkey = ?1 \
+                 AND tags LIKE '%\"protocol-knowledge\"%'\
+             )",
+            params![owner_pubkey],
+        )?;
+        tx.execute(
+            "DELETE FROM attestation_costs \
+             WHERE attestation_id IN (\
+               SELECT attestation_id FROM attestations \
+               WHERE owner_pubkey = ?1 \
+                 AND tags LIKE '%\"protocol-knowledge\"%'\
+             )",
+            params![owner_pubkey],
+        )?;
+        let affected = tx.execute(
             "DELETE FROM attestations \
              WHERE owner_pubkey = ?1 \
                AND tags LIKE '%\"protocol-knowledge\"%'",
             params![owner_pubkey],
         )?;
+        tx.commit()?;
         Ok(affected)
     }
 

--- a/mcp/src/seed.rs
+++ b/mcp/src/seed.rs
@@ -398,13 +398,24 @@ pub async fn run(state: &McpState) -> Result<()> {
             // `sign_memory_inline` guard permits it. This is the intended
             // server-identity self-authored path (design §21 landmine note).
             //
-            // T2: seeding never carries an explicit `mode` field — it
-            // resolves to env-var fallback (`explicit = false`) so the
-            // routing rule in `sign_memory` reads it as the legacy path,
-            // not as a "user opted into local". On a `full` deploy that's
-            // `Participate`; on `local` it's `Local`.
-            let seed_resolved = tools::resolve_write_mode(None, &state.storage_mode)
-                .expect("None always resolves to Ok per resolver contract");
+            // Seeding always uses `local` regardless of the operator's
+            // `STORAGE_MODE`. The protocol-knowledge corpus is operator-side
+            // RAG cache for the `/chat` endpoint — these rows are NEVER user
+            // memories that need durable Arweave/Solana anchoring. Forcing
+            // `local` here avoids paying chain costs on every server boot AND
+            // dodges a real failure mode discovered live 2026-06-25 on a
+            // `STORAGE_MODE=full` prod: the env-default path tried to
+            // `Participate`-anchor each seeded chunk, hit Arweave/Solana
+            // submission failure, and the whole seed errored out at chunk 0.
+            //
+            // The previous comment claimed "T2: seeding never carries an
+            // explicit `mode` field — env-var fallback path" but that only
+            // worked on `STORAGE_MODE=local` deploys; on `full` deploys the
+            // seed was silently broken.
+            let seed_mode_input = serde_json::Value::String("local".to_string());
+            let seed_resolved =
+                tools::resolve_write_mode(Some(&seed_mode_input), &state.storage_mode)
+                    .expect("'local' is a canonical input and always resolves to Ok");
             // Seeding never opts into soft-fall — RAG corpus seeding runs at
             // server boot under a server-keypair owner; an escalation to the
             // hosted endpoint would be self-loop and the corpus is always


### PR DESCRIPTION
## Follow-up to PR #173 — two commits that didn't make it into the squash

PR #173 was merged before my 3rd and 4th commits had synced. Both fixes are necessary; without them main will regress prod the next time it's deployed via the new \`Deploy MCP\` workflow.

### Commit 1 — \`fix(mcp): force seeding to local mode regardless of STORAGE_MODE\`

\`mcp/src/seed.rs::run\` was calling \`tools::resolve_write_mode(None, ...)\` to decide where to anchor seeded chunks. On a \`STORAGE_MODE=full\` deploy that resolves to \`Participate\`, meaning every seeded chunk tries to anchor to Arweave + Solana on server boot.

**Discovered live on prod 2026-06-26** when the previous-commit mtime-aware reseed actually fired with full mode set: \`sign_memory\` failed at chunk 0 of QUICKSTART.md and the whole seed errored out:

\`\`\`
ERROR mnemonic_mcp: RAG seeding failed: sign_memory failed for QUICKSTART.md chunk 0
\`\`\`

Fix: pass \`Some(&Value::String("local"))\` so the seed always uses local mode. The protocol-knowledge corpus is operator-side RAG cache for the \`/chat\` endpoint — it's never user memory that needs durable on-chain anchoring.

### Commit 2 — \`fix(core): cascade-delete protocol-knowledge rows in dependency order\`

\`AttestationStore::delete_protocol_knowledge_for_owner\` ran a single DELETE on \`attestations\`. SQLite blocked it with \`FOREIGN KEY constraint failed\` because \`memory_embeddings.attestation_id\` and \`attestation_costs.attestation_id\` point at the parent rows.

The seed code WARN-logged and continued, leaving stale chunks alongside the fresh corpus. Chat recovery still works (queries by tag, both old + new match) but the database accumulates duplicates on every reseed.

Fix: wrap the deletes in a transaction and walk children → parent:

\`\`\`sql
BEGIN
  DELETE FROM memory_embeddings WHERE attestation_id IN (select);
  DELETE FROM attestation_costs WHERE attestation_id IN (select);
  DELETE FROM attestations WHERE owner_pubkey=? AND tags LIKE '%protocol-knowledge%';
COMMIT
\`\`\`

## Test plan

- [x] \`cargo test -p mnemonic-core --lib storage\` — 28/28 pass
- [x] \`cargo clippy -p mnemonic-mcp -p mnemonic-core --no-deps\` — clean
- [x] \`cargo fmt --check\` — clean
- [x] Live verified on prod 2026-06-26: artifact regenerated 215 KB, 371 chunks, chat returns context-grounded responses

## Related

- PR #173 — the original merge that didn't include these two commits
- Issue follow-ups from #173: nothing — these are part of the same fix