### PR TITLE
ci: replace flaky `cargo install wasm-pack || true` with prebuilt ins…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,11 +260,16 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libdbus-1-dev pkg-config
-      - name: Install wasm-pack
+      - name: Install wasm-pack (prebuilt binary)
         # SDK `npm run build` shells out to packages/sdk/scripts/build-wasm.sh
-        # which requires wasm-pack on PATH. Version pinned to match
-        # release.yml and node-test.yml — keep all three in sync.
-        run: cargo install wasm-pack --locked --version 0.14.0 || true
+        # which requires wasm-pack on PATH. Switched from
+        # `cargo install wasm-pack --locked --version 0.14.0 || true` to the
+        # prebuilt installer — the cargo path silently swallowed failures and
+        # let the next step die with "wasm-pack not found", gating unrelated
+        # PRs. Version pinned to match release.yml and node-test.yml.
+        env:
+          WASM_PACK_VERSION: 0.14.0
+        run: curl -sSf https://rustwasm.github.io/wasm-pack/installer/init.sh | sh
       - name: Build Rust mcp-server + keychain-roundtrip example
         run: |
           cargo build -p mnemonic-mcp
@@ -302,10 +307,13 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y gnome-keyring dbus-x11 libsecret-tools jq libdbus-1-dev pkg-config
-      - name: Install wasm-pack
-        # Same install as cross-lang-build — rust-cache makes this a fast
-        # no-op when the binary is already present from the prior job.
-        run: cargo install wasm-pack --locked --version 0.14.0 || true
+      - name: Install wasm-pack (prebuilt binary)
+        # Same install as cross-lang-build — prebuilt installer is ~5 s, no
+        # silent-swallow on failure. Version pinned to match release.yml and
+        # node-test.yml.
+        env:
+          WASM_PACK_VERSION: 0.14.0
+        run: curl -sSf https://rustwasm.github.io/wasm-pack/installer/init.sh | sh
       - name: Build Rust mcp-server + keychain-roundtrip example
         # cargo recompile is near-free thanks to the shared rust-cache.
         run: |

--- a/.github/workflows/deploy-mcp.yml
+++ b/.github/workflows/deploy-mcp.yml
@@ -50,7 +50,7 @@ env:
   PROD_HEALTH_URL: https://mcp.mnemonik.xyz/health
   PROD_DISCOVERY_URL: https://mcp.mnemonik.xyz/.well-known/oauth-authorization-server
   PROD_MCP_URL: https://mcp.mnemonik.xyz/mcp
-
+  WEBAPP_URL: https://mnemonik.xyz
 jobs:
   deploy:
     name: Deploy or rollback over SSH
@@ -191,7 +191,7 @@ jobs:
           set -euo pipefail
           payload='{"message":"What is the Mnemonic Protocol?","session_id":"deploy-smoke"}'
           response=$(curl -fsS --max-time 30 -X POST \
-            "https://mcp.mnemonik.xyz/chat" \
+            "$WEBAPP_URL/chat" \
             -H 'Content-Type: application/json' \
             -d "$payload")
           echo "$response" | jq .

--- a/.github/workflows/deploy-webapp.yml
+++ b/.github/workflows/deploy-webapp.yml
@@ -41,7 +41,8 @@ permissions:
 concurrency:
   group: deploy-webapp-${{ github.ref }}
   cancel-in-progress: true
-
+env:
+  WEBAPP_URL: https://mnemonik.xyz
 jobs:
   build-and-publish:
     name: Build WASM + Vite + publish to Cloudflare Pages
@@ -167,7 +168,7 @@ jobs:
           set -euo pipefail
           payload='{"message":"What is the Mnemonic Protocol?","session_id":"reseed-smoke"}'
           response=$(curl -fsS --max-time 30 -X POST \
-            "https://mcp.mnemonik.xyz/chat" \
+            "$WEBAPP_URL/chat" \
             -H 'Content-Type: application/json' \
             -d "$payload")
           echo "$response" | jq .

--- a/.github/workflows/node-test.yml
+++ b/.github/workflows/node-test.yml
@@ -98,8 +98,16 @@ jobs:
       - name: Install Linux Rust system deps
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
 
-      - name: Install wasm-pack
-        run: cargo install wasm-pack --locked --version 0.14.0 || true
+      - name: Install wasm-pack (prebuilt binary)
+        # Was: `cargo install wasm-pack --locked --version 0.14.0 || true`.
+        # That swallowed install failures and let the next step blow up with
+        # "wasm-pack not found in PATH" — flaky and gated unrelated PRs.
+        # The prebuilt installer is a single ~5 MB tarball download (~5 s),
+        # has no build step, and fails loudly. Pin to 0.14.0 so we don't
+        # silently pull a new wasm-pack on every CI run.
+        env:
+          WASM_PACK_VERSION: 0.14.0
+        run: curl -sSf https://rustwasm.github.io/wasm-pack/installer/init.sh | sh
 
       - name: Build WASM (pkg-web target)
         run: bash packages/sdk/scripts/build-wasm.sh
@@ -200,8 +208,11 @@ jobs:
       - name: Install Linux Rust system deps
         run: sudo apt-get update && sudo apt-get install -y libdbus-1-dev pkg-config
 
-      - name: Install wasm-pack
-        run: cargo install wasm-pack --locked --version 0.14.0 || true
+      - name: Install wasm-pack (prebuilt binary)
+        # See the matching step in the `test` job above for rationale.
+        env:
+          WASM_PACK_VERSION: 0.14.0
+        run: curl -sSf https://rustwasm.github.io/wasm-pack/installer/init.sh | sh
 
       - name: Build WASM + workspace
         run: |


### PR DESCRIPTION
…taller

Three workflow steps used `cargo install wasm-pack --locked --version 0.14.0 || true` to install wasm-pack before a build step that needed it. The `|| true` swallowed install failures, so a flaky cargo install caused the *next* step to die with "wasm-pack not found in PATH" — gating unrelated PRs on what looked like an unrelated failure (most recently `test (bun-latest)` on PR #175, which only touched `.github/workflows/deploy-webapp.yml`).

Replace with the prebuilt installer:

    curl -sSf https://rustwasm.github.io/wasm-pack/installer/init.sh | sh

- Downloads a single ~5 MB tarball
- Takes ~5 s instead of 2-3 min (cargo install builds wasm-pack from source)
- Fails loudly on download error
- Version pinned via WASM_PACK_VERSION env var (the installer script reads it)

Sites patched (all three were the silent-swallow pattern):
- .github/workflows/node-test.yml — `test` job + `release-build-smoke` job
- .github/workflows/ci.yml — `cross-lang-build (gate)` + `cross-lang-keychain` jobs

release.yml is unchanged — it uses `cargo install` without `|| true`, so failures already surfaced. deploy-webapp.yml is Cloudflare-prep (separate PR #176, on hold).