### PR TITLE
chore(release): bump versions to 0.2.8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "mnemonic-core"
-version = "0.2.4"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3200,7 +3200,7 @@ dependencies = [
 
 [[package]]
 name = "mnemonic-mcp"
-version = "0.2.4"
+version = "0.2.8"
 dependencies = [
  "anyhow",
  "axum",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mnemonic-core"
-version = "0.2.4"
+version = "0.2.8"
 edition = "2021"
 description = "Mnemonic Protocol core library — verifiable memory attestation for AI agents"
 

--- a/mcp/Cargo.toml
+++ b/mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mnemonic-mcp"
-version = "0.2.4"
+version = "0.2.8"
 edition = "2021"
 description = "Mnemonic MCP server — verifiable memory attestation primitive for AI agents"
 

--- a/packages/mcp/dist/binary-version.json
+++ b/packages/mcp/dist/binary-version.json
@@ -1,7 +1,7 @@
 {
-  "tag": "v0.2.4",
+  "tag": "v0.2.8",
   "artifacts": {
-    "darwin-arm64": "mnemonic-mcp-v0.2.4-aarch64-apple-darwin.tar.gz",
-    "linux-x64": "mnemonic-mcp-v0.2.4-x86_64-unknown-linux-gnu.tar.gz"
+    "darwin-arm64": "mnemonic-mcp-v0.2.8-aarch64-apple-darwin.tar.gz",
+    "linux-x64": "mnemonic-mcp-v0.2.8-x86_64-unknown-linux-gnu.tar.gz"
   }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mnemonik-xyz/mcp",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "MCP shim for Mnemonic Protocol. Downloads + verifies the matching mnemonik-mcp Rust binary from GitHub Releases on first invocation; provides install/install --check/mcp-stdio/doctor subcommands. No postinstall script — lazy install on first run. See Decisions 8/9 in work/agent-native-distribution/tech-spec.md.",
   "license": "Apache-2.0",
   "private": false,


### PR DESCRIPTION
## Summary

Required to actually ship the fastembed `cache_dir` fix (#180). The `v0.2.8` tag was pushed at the same time as #180 merged, but the release workflow's `LOCAL == REMOTE` guard short-circuited the npm publish because `packages/mcp/package.json` was still at `0.2.7`. Meanwhile the shim's `dist/binary-version.json` still pointed at `v0.2.4` assets, so even a fresh install would download the pre-fix binary.

Bumps in this PR:
- `core/Cargo.toml`            `0.2.4` → `0.2.8`
- `mcp/Cargo.toml`             `0.2.4` → `0.2.8`
- `packages/mcp/package.json`  `0.2.7` → `0.2.8`
- `packages/mcp/dist/binary-version.json` `{tag, artifacts}` → `v0.2.8`
- `Cargo.lock` refresh

## Re-release plan

After merge:
1. `git tag -d v0.2.8 && git push origin :refs/tags/v0.2.8` to drop the stale tag.
2. Re-tag `v0.2.8` against the new merge commit so the release workflow runs with the correct versions.
3. Confirm `npm view @mnemonik-xyz/mcp version` returns `0.2.8` and the GitHub release contains both the macOS arm64 and linux x64 tarballs (linux arm64 is non-blocking by repo policy).

## Test plan
- [x] `cargo check -p mnemonic-core -p mnemonic-mcp --features local-embed` clean.
- [ ] Post-merge: release workflow green for the re-pushed tag; npm registry shows `0.2.8`.