### PR TITLE
fix(mcp/shim): pin test fixtures to v0.2.8 to match binary-version.json

### DIFF
--- a/packages/mcp/test/helpers.ts
+++ b/packages/mcp/test/helpers.ts
@@ -61,7 +61,7 @@ export async function makeBinaryTarball(
  */
 export async function makeWrappedBinaryTarball(
   destTar: string,
-  artifactBase = "mnemonic-mcp-v0.2.4-x86_64-unknown-linux-gnu",
+  artifactBase = "mnemonic-mcp-v0.2.8-x86_64-unknown-linux-gnu",
   binaryName = "mnemonic-mcp",
   body = "#!/bin/sh\necho 'stub mnemonik-mcp'\n",
 ): Promise<{ tarPath: string; sha256: string; archiveName: string }> {

--- a/packages/mcp/test/install-binary.test.ts
+++ b/packages/mcp/test/install-binary.test.ts
@@ -35,7 +35,11 @@ interface TestCtx {
 }
 
 let ctx: TestCtx;
-const TAG = "v0.2.4";
+// Must match `dist/binary-version.json` `tag` field — the shim reads the
+// manifest at runtime to construct the artifact URL, and these tests mock
+// only that URL. If you bump the manifest, bump this too (and the
+// `artifactBase` defaults in test/helpers.ts).
+const TAG = "v0.2.8";
 // Match the dist/binary-version.json darwin-arm64 mapping; tests force the
 // platform via stubbing process.platform.
 const ARTIFACT = `mnemonic-mcp-${TAG}-aarch64-apple-darwin.tar.gz`;


### PR DESCRIPTION
## Why

After #181 bumped `packages/mcp/dist/binary-version.json` `tag` to `v0.2.8`, the shim's vitest fixtures still hardcoded `v0.2.4` for the mock release URL. The shim reads the manifest at runtime to construct the artifact URL — so every `ensureBinaryCached` test hit a 404 trying to fetch `https://release.example/dl/v0.2.8/...` while the mock was registered for the v0.2.4 URL. That broke the v0.2.8 re-tag release: `Publish @mnemonik-xyz/mcp` step failed in `npm test` (run via `prepublishOnly`), and the npm registry stays on 0.2.7.

## Fix

- `packages/mcp/test/install-binary.test.ts`: `TAG` `v0.2.4` -> `v0.2.8` (plus a comment explaining the coupling so future bumps include the test side).
- `packages/mcp/test/helpers.ts`: `artifactBase` default `*-v0.2.4-*` -> `*-v0.2.8-*`.

## Test plan
- [x] `cd packages/mcp && npx vitest run` — 28/28 pass.
- [ ] After merge, re-tag v0.2.8 against the new merge commit. Expect `Publish @mnemonik-xyz/mcp with provenance` to succeed and `npm view @mnemonik-xyz/mcp version` to return `0.2.8`.