### PR TITLE
ci(release): rewrite apt sources for aarch64 linux cross-compile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,11 +55,41 @@ jobs:
 
       - name: Install dependencies (cross aarch64)
         if: matrix.cross == true
-        # `libdbus-1-dev:arm64` via multi-arch — same libdbus-sys requirement
-        # as the native path. If multi-arch install drifts, the build will
-        # fail but `continue-on-error: true` at job level keeps the release
-        # pipeline moving (macOS is the v1 scope).
+        # Ubuntu noble runners default to `/etc/apt/sources.list.d/ubuntu.sources`
+        # (DEB822) pointing only at archive/security.ubuntu.com, which serve
+        # amd64-only. After `dpkg --add-architecture arm64`, plain `apt-get
+        # update` 404s on every `binary-arm64/Packages` URL because the arm64
+        # indexes live on ports.ubuntu.com, not security.ubuntu.com. We
+        # rewrite the sources deterministically before adding the arch:
+        # amd64 keeps the existing mirrors, arm64 gets its own DEB822 file
+        # pointing at ubuntu-ports. `continue-on-error: true` at job level
+        # remains as a safety net.
         run: |
+          set -euo pipefail
+          sudo rm -f /etc/apt/sources.list /etc/apt/sources.list.d/ubuntu.sources
+          sudo tee /etc/apt/sources.list.d/amd64.sources >/dev/null <<'EOF'
+          Types: deb
+          URIs: http://archive.ubuntu.com/ubuntu/
+          Suites: noble noble-updates noble-backports
+          Components: main universe restricted multiverse
+          Architectures: amd64
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+
+          Types: deb
+          URIs: http://security.ubuntu.com/ubuntu/
+          Suites: noble-security
+          Components: main universe restricted multiverse
+          Architectures: amd64
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          EOF
+          sudo tee /etc/apt/sources.list.d/arm64.sources >/dev/null <<'EOF'
+          Types: deb
+          URIs: http://ports.ubuntu.com/ubuntu-ports/
+          Suites: noble noble-updates noble-backports noble-security
+          Components: main universe restricted multiverse
+          Architectures: arm64
+          Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+          EOF
           sudo dpkg --add-architecture arm64
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu pkg-config perl make libdbus-1-dev:arm64


### PR DESCRIPTION
## Why

`Build aarch64-unknown-linux-gnu` has been failing across every recent release run (v0.2.4 → v0.2.8) with:

```
E: Failed to fetch https://security.ubuntu.com/ubuntu/dists/noble/main/binary-arm64/Packages
   404 Not Found
```

Root cause: Ubuntu noble GHA runners default to a single DEB822 sources file at `/etc/apt/sources.list.d/ubuntu.sources` pointing only at `archive.ubuntu.com` + `security.ubuntu.com` — those mirrors serve **amd64 only**. After `dpkg --add-architecture arm64`, plain `apt-get update` tries to fetch arm64 indexes from the same mirrors and 404s on every `binary-arm64` URL. arm64 packages on Ubuntu live at `ports.ubuntu.com/ubuntu-ports`, never on the security/archive mirrors.

## Fix

Rewrite the sources deterministically *before* `dpkg --add-architecture arm64`:
- `amd64.sources` keeps the existing mirrors, `Architectures: amd64`.
- `arm64.sources` is a new DEB822 file pointing at `ubuntu-ports`, `Architectures: arm64`.

`continue-on-error: true` at job level stays in place as a safety net.

## Verification
- `python3 -c 'yaml.safe_load(...)'` — workflow parses, heredocs extract cleanly.
- `bash -n` on the extracted shell — syntax valid.
- The change is scoped to the `if: matrix.cross == true` step, so the x86_64 path is untouched.

## Rollout
After merge, re-tag `v0.2.8` against the new merge commit so the release pipeline reruns with the patched workflow. The `publish-mcp-shim` job has a skip-if-already-published guard (line 346), so the existing npm publication of `@mnemonik-xyz/mcp@0.2.8` is safe across re-runs. Outcome: GitHub release `v0.2.8` gains `mnemonic-mcp-v0.2.8-aarch64-unknown-linux-gnu.tar.gz`.