### PR TITLE
ci(release): enable pkg-config cross for aarch64 linux build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,16 @@ jobs:
             export CC_aarch64_unknown_linux_gnu=aarch64-linux-gnu-gcc
             export CXX_aarch64_unknown_linux_gnu=aarch64-linux-gnu-g++
             export OPENSSL_SRC_PERL=/usr/bin/perl
+            # libdbus-sys (transitive of keyring) calls pkg_config in its
+            # build.rs and pkg-config refuses cross-compile unless
+            # explicitly allowed. The arm64 .pc files land at
+            # /usr/lib/aarch64-linux-gnu/pkgconfig after the multi-arch
+            # libdbus-1-dev:arm64 install. Scope the path to the target
+            # triple so the host x86_64 build (in the same matrix) is
+            # unaffected.
+            export PKG_CONFIG_ALLOW_CROSS=1
+            export PKG_CONFIG_PATH_aarch64_unknown_linux_gnu=/usr/lib/aarch64-linux-gnu/pkgconfig
+            export PKG_CONFIG_SYSROOT_DIR_aarch64_unknown_linux_gnu=/
           fi
           cargo build --release --target ${{ matrix.target }} -p mnemonic-mcp --features "openssl-vendored,local-embed"
 


### PR DESCRIPTION
Follow-up to #183. The apt-sources rewrite unblocked `apt-get update` and `libdbus-1-dev:arm64` installation, but the cargo build then panicked at `libdbus-sys`'s build.rs:

```
pkg_config failed: pkg-config has not been configured to support cross-compilation.
```

pkg-config refuses cross-compile by default. After the multi-arch install the arm64 `.pc` files land at `/usr/lib/aarch64-linux-gnu/pkgconfig`; we just have to tell pkg-config to look there for the target triple. Three env vars, all scoped to the aarch64 cross branch of the `if [ matrix.cross = true ]` guard so the x86_64 sibling in the same matrix is unaffected:

- `PKG_CONFIG_ALLOW_CROSS=1`
- `PKG_CONFIG_PATH_aarch64_unknown_linux_gnu=/usr/lib/aarch64-linux-gnu/pkgconfig`
- `PKG_CONFIG_SYSROOT_DIR_aarch64_unknown_linux_gnu=/`

After merge, re-tag `v0.2.8` again. `publish-mcp-shim` / `publish-npm` will skip-if-already-published; `Create Release` updates the existing release; outcome is the missing `mnemonic-mcp-v0.2.8-aarch64-unknown-linux-gnu.tar.gz` asset gets uploaded.