### PR TITLE
fix(ci): green up webapp typecheck + gitleaks after #179

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -37,6 +37,11 @@ tags = ["jwt", "token", "secret", "mnemonic-deeplink"]
 [allowlist]
 description = "test fixtures + synthetic test JWTs / pubkeys"
 paths = [
+    # Webapp unit-test fixtures — synthetic Ed25519 pubkeys / JWT-shaped
+    # strings seeded into localStorage (e.g. `pubkey_base58: "TestSubPubKey123"`
+    # in Sign.test.tsx) to mount pages and assert redaction. Same posture as the
+    # CLI/SDK test entries below: deterministic synthetic fixtures, not real secrets.
+    '''webapp/src/.*\.test\.tsx?$''',
     # CLI test fixtures — synthetic pubkeys + JWTs assert error redaction.
     '''packages/cli/test/.*\.test\.ts''',
     # SDK test fixtures — JWT-shaped strings, mock OAuth flows.

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,10 @@
+# gitleaks false-positive suppressions (fingerprint = commit:file:rule:line).
+# All three are high-entropy strings in generated/manifest files that the
+# generic-api-key heuristic flags but are NOT secrets:
+#   - Cargo.lock checksums (deterministic registry hashes).
+#   - packages/extension/manifest.json "key" (the extension's PUBLIC key).
+# Two predate this branch (present on main); kept here so the full-history
+# scan (ci.yml `Scan full git history`, fetch-depth: 0) stays green.
+735b8f1a0f473486145f6b08f5af97a099db8fbf:Cargo.lock:generic-api-key:1141
+b01a2ab33372395d24642b3d9ada8885b900e8f9:Cargo.lock:generic-api-key:1543
+26c15bdc6dfbd9082dc7a5e9919511ec79327e59:packages/extension/manifest.json:generic-api-key:3

--- a/package-lock.json
+++ b/package-lock.json
@@ -13512,7 +13512,7 @@
     },
     "packages/mcp": {
       "name": "@mnemonik-xyz/mcp",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "license": "Apache-2.0",
       "dependencies": {
         "tar": "^7.4.0"
@@ -13997,6 +13997,7 @@
         "@tailwindcss/vite": "^4.1.5",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -29,6 +29,7 @@
     "@tailwindcss/vite": "^4.1.5",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",


### PR DESCRIPTION
## Fix main CI after #179 (webapp-rethink squash-merge)

PR #179 squash-merged green-on-its-own-branch, but main CI (#144) went red on two checks. This lands the fixes directly on main.

### 1. webapp Typecheck (tsc TS2307)
`Analytics.test.tsx` and `Ledger.test.tsx` import `@testing-library/user-event` (used for clicks + the clipboard-copy test) but it was never declared — it resolved locally via a stray hoisted `node_modules`, so CI's clean install failed `npx tsc -b --noEmit`. Fix: declare it in `webapp/package.json` (+ lockfile).

### 2. gitleaks
- `webapp/src/pages/Sign.test.tsx:50` flagged the synthetic test fixture `pubkey_base58: "TestSubPubKey123"` (seeded into localStorage to mount the page). Fix: extend the existing test-fixture path allowlist in `.gitleaks.toml` to `webapp/src/**/*.test.tsx?` — same posture as the existing CLI/SDK fixture entries.
- Added `.gitleaksignore` suppressing two pre-existing `generic-api-key` false positives in `Cargo.lock` (deterministic registry checksums) and `packages/extension/manifest.json` (the extension's PUBLIC key) so the full-history scan (fetch-depth: 0) stays green.

Verified locally: `npx tsc -b --noEmit` exit 0; `gitleaks detect` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
