### PR TITLE
fix(webapp): serve API same-origin, drop all sample/fallback data

### DIFF
--- a/.claude/skills/project-knowledge/references/deployment.md
+++ b/.claude/skills/project-knowledge/references/deployment.md
@@ -72,7 +72,7 @@ Variables for `mcp/` (set by user):
 
 **webapp/ + docs/:** Auto-deploy on push to `main` via `.github/workflows/deploy-webapp.yml` (builds WASM core + Vite bundle, publishes to Cloudflare Pages, optionally chains a prod chat corpus reseed). Preview on every PR via Cloudflare Pages git integration. Manual republish via Actions UI → "Deploy Webapp" → Run workflow, with optional `reseed_chat_corpus` toggle.
 
-**Two independent deploy targets (`webapp-rethink` Decision 9):** the static webapp and the mcp API server ship separately — the webapp is a standalone static artifact (`mnemonik.xyz`) and the mcp server is a headless JSON+OAuth API on its own origin (`mcp.mnemonik.xyz`); the mcp server renders no HTML. The webapp `npm run build` now also runs `scripts/prerender.mjs`, so `dist/` carries prerendered HTML for `/`, `/ledger`, `/analytics`, `/blog`, one `dist/blog/<slug>/index.html` per published post, `robots.txt`, and a dynamic `sitemap.xml`. **`VITE_MCP_BASE` must be set to the mcp origin at build time** — it is the cross-origin API base for the SPA, the prerender's `GET /blog` source, and the `%VITE_MCP_BASE%` substitution for the Micropub/feed `<link>`s (left literal if unset; prod = `https://mcp.mnemonik.xyz`). The mcp origin must already be in the `cors_policy.rs` allowlist (it is). A blog publish optionally pings `BLOG_REBUILD_HOOK` (above) to re-trigger this webapp build so agent-published posts become crawlable within minutes.
+**Same-origin webapp + a dedicated MCP subdomain (`webapp-rethink` Decision 9, revised):** the webapp is served at the apex `mnemonik.xyz` and talks to its OWN backend API on the SAME origin — the apex nginx proxies the webapp's read/publish surface (`/artifacts`, `/analytics/*`, `/stats`, `/blog*`, `/chat`, `/api/*`, `/oauth/*`, `/.well-known/*`) to the local `mnemonic-mcp` binary on `127.0.0.1:3000`. The `mcp.mnemonik.xyz` subdomain is reserved EXCLUSIVELY for the MCP JSON-RPC + OAuth surface that external MCP clients use; do NOT route webapp API calls through it. **`VITE_MCP_BASE` must be EMPTY / unset for the production build** so every SPA fetch and the Micropub/feed `<link>`s are origin-relative (`src/lib/api.ts`, `lib/ledger.ts`, `lib/blog.ts` all default to `""`; `index.html` uses plain `/blog` + `/blog/feed.xml`). `npm run build` also runs `scripts/prerender.mjs`, so `dist/` carries prerendered HTML for `/`, `/ledger`, `/analytics`, `/blog`, one `dist/blog/<slug>/index.html` per published post, `robots.txt`, and a dynamic `sitemap.xml`. Because `/blog` and `/blog/<slug>` are both prerendered pages AND backend endpoints, the apex nginx disambiguates by method + `Accept` (JSON readers send `Accept: application/json`; POST publishes → backend; everything else → the prerendered page). The webapp client surfaces a fetch failure as an honest error state — there is NO sample/placeholder fallback. A blog publish optionally pings `BLOG_REBUILD_HOOK` (above) to re-trigger this webapp build so agent-published posts become crawlable within minutes.
 
 **Pre-public-launch security follow-ups (`webapp-rethink` audit, tracked — NOT merge-blocking):** before the blog is publicly promoted, resolve (1) Sybil spam — the per-pubkey publish rate limit is bypassable via free keypair + open OAuth registration, so a public blog needs an agent allowlist / moderation (Decision 5 open item); (2) authorship impersonation — post `author` is arbitrary caller text and the COSE signer is the SERVER key (`claims.sub` not persisted), so any authed agent can claim authorship, contradicting Decision 5's "provable authorship" — persist+verify `claims.sub` or relabel the badge; (3) `GET /artifacts?q=` runs an ONNX embedding unauthenticated/uncached/unrated → CPU DoS, add a `/stats`-style cache or rate limit.
 
@@ -243,21 +243,10 @@ sudo systemctl daemon-reload && sudo systemctl enable mnemonic-mcp
 # 9. Start/restart MCP
 sudo systemctl restart mnemonic-mcp
 
-# 10. Configure nginx (first deploy only)
-sudo tee /etc/nginx/sites-available/mnemonic << 'NGINX'
-server {
-    listen 80;
-    server_name mnemonik.xyz;
-    root /home/claude/monorepo/webapp/dist;
-    index index.html;
-    location / { try_files $uri $uri/ /index.html; }
-    location /mcp { proxy_pass http://127.0.0.1:3000; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
-    location /chat { proxy_pass http://127.0.0.1:3000; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; proxy_read_timeout 120s; }
-    location /download-knowledge { proxy_pass http://127.0.0.1:3000; proxy_set_header Host $host; }
-    location /health { proxy_pass http://127.0.0.1:3000; }
-    location /admin { return 403; }
-}
-NGINX
+# 10. Configure nginx (apex webapp host). Canonical config is tracked in-tree at
+#     mcp/deploy/nginx-apex.conf (serves webapp/dist + proxies the webapp's
+#     same-origin API surface to :3000). Install it verbatim:
+sudo cp /home/claude/monorepo/mcp/deploy/nginx-apex.conf /etc/nginx/sites-available/mnemonic
 sudo ln -sf /etc/nginx/sites-available/mnemonic /etc/nginx/sites-enabled/mnemonic
 sudo rm -f /etc/nginx/sites-enabled/default
 chmod 755 /home/claude /home/claude/monorepo /home/claude/monorepo/webapp/dist

--- a/mcp/deploy/nginx-apex.conf
+++ b/mcp/deploy/nginx-apex.conf
@@ -1,0 +1,113 @@
+# nginx server block for the apex webapp host: https://mnemonik.xyz
+#
+# Purpose: serve the static webapp (webapp/dist) AND proxy the webapp's OWN
+# backend API surface to the local mnemonic-mcp binary on 127.0.0.1:3000.
+#
+# Design (webapp-rethink Decision 9, revised): the webapp and its API are
+# SAME-ORIGIN. The SPA fetches /artifacts, /analytics/*, /stats, /blog*, /chat,
+# /api/*, /oauth/* from its own origin (VITE_MCP_BASE is empty at build time).
+# The mcp.mnemonik.xyz subdomain is reserved EXCLUSIVELY for the MCP JSON-RPC +
+# OAuth surface that external MCP clients (Claude.ai, Cursor, ...) talk to — see
+# nginx-mcp-subdomain.conf. Do NOT route webapp API calls through the subdomain.
+#
+# Deployed to /etc/nginx/sites-available/mnemonic on the VPS, symlinked from
+# /etc/nginx/sites-enabled/mnemonic. This file is the canonical source of truth
+# for the apex block (the live config had drifted from deployment.md — keep them
+# in sync from here on). After `certbot --nginx -d mnemonik.xyz` the listen-443
+# + ssl_certificate directives match the layout below so a rerun is a no-op.
+
+# HTTP -> HTTPS redirect (+ ACME challenge passthrough for certbot).
+server {
+    listen 80;
+    listen [::]:80;
+    server_name mnemonik.xyz;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+    }
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+# HTTPS terminator: static webapp + reverse proxy to mnemonic-mcp.
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name mnemonik.xyz;
+
+    ssl_certificate     /etc/letsencrypt/live/mnemonik.xyz/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/mnemonik.xyz/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    # Static SPA build output.
+    root /home/claude/monorepo/webapp/dist;
+    index index.html;
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    # Publish bundles (POST /blog) + sign bundles stay small; 256 KB is ample.
+    client_max_body_size 256k;
+
+    # ── Webapp backend API (same-origin → mnemonic-mcp on :3000) ─────────────
+    # These paths are JSON/stream endpoints, NOT SPA routes. Note the trailing
+    # slash on /analytics/ so the SPA route /analytics (no slash) still falls
+    # through to the static handler below.
+    location = /stats        { proxy_pass http://127.0.0.1:3000; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location = /artifacts    { proxy_pass http://127.0.0.1:3000; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /analytics/     { proxy_pass http://127.0.0.1:3000; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /api/           { proxy_pass http://127.0.0.1:3000; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /oauth/         { proxy_pass http://127.0.0.1:3000; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location /.well-known/   { proxy_pass http://127.0.0.1:3000; proxy_set_header Host $host; proxy_set_header X-Real-IP $remote_addr; }
+    location = /download-knowledge { proxy_pass http://127.0.0.1:3000; proxy_set_header Host $host; }
+    location = /health       { proxy_pass http://127.0.0.1:3000; access_log off; }
+
+    location = /chat {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_read_timeout 120s;
+    }
+
+    # Legacy: the same service answers /mcp on both hosts (deployment.md).
+    location = /mcp {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_buffering off;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Connection "";
+    }
+
+    # ── Blog: prerendered HTML for crawlers/browsers, JSON for the API ───────
+    # /blog and /blog/<slug> collide: each is BOTH a prerendered static page
+    # (dist/blog[/<slug>]/index.html) and a backend endpoint (GET JSON list /
+    # detail, POST Micropub publish). Disambiguate by method + Accept: JSON
+    # readers (the SPA sends `Accept: application/json`) and POST publishes go to
+    # the backend; everything else (text/html navigations, crawlers) gets the
+    # prerendered page. The atom feed is always backend XML.
+    location = /blog/feed.xml {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+    location = /blog {
+        if ($request_method = POST) { proxy_pass http://127.0.0.1:3000; }
+        if ($http_accept ~* application/json) { proxy_pass http://127.0.0.1:3000; }
+        try_files /blog/index.html =404;
+    }
+    location ~ ^/blog/ {
+        if ($http_accept ~* application/json) { proxy_pass http://127.0.0.1:3000; }
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Block admin endpoints at the edge.
+    location /admin { return 403; }
+
+    # SPA: prerendered route HTML when present, else the client-rendered shell.
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}

--- a/webapp/index.html
+++ b/webapp/index.html
@@ -25,20 +25,16 @@
 
     <!--
       Agent-native publishing discovery (webapp-rethink T10, Decision 5 + 9).
-      The webapp and mcp server are SEPARATE deploys, so these point at the API
-      origin, not this webapp origin. `%VITE_MCP_BASE%` is replaced at build time
-      by Vite's native import.meta.env HTML substitution (same VITE_MCP_BASE the
-      SPA uses in src/lib/api.ts); production sets it to https://mcp.mnemonik.xyz.
-      No new fetch origin is introduced — mcp.mnemonik.xyz is already in the CSP
-      connect-src above, and rel=micropub / rel=alternate links are not fetched
-      by the browser, so the CSP is unchanged.
+      The public read/publish API is served same-origin (the apex nginx proxies
+      /blog* to the mnemonic-mcp backend), so these discovery links are
+      origin-relative. No cross-origin fetch is introduced.
     -->
-    <link rel="micropub" href="%VITE_MCP_BASE%/blog" />
+    <link rel="micropub" href="/blog" />
     <link
       rel="alternate"
       type="application/atom+xml"
       title="Mnemonic Protocol blog"
-      href="%VITE_MCP_BASE%/blog/feed.xml"
+      href="/blog/feed.xml"
     />
 
     <!--

--- a/webapp/src/components/IdentityPanel.tsx
+++ b/webapp/src/components/IdentityPanel.tsx
@@ -14,9 +14,7 @@ import { loadWasm } from "../lib/wasm";
  * and `/api/cli-bootstrap/redeem/:ticket`) live on the MCP server, not the
  * webapp origin, so we always go through this base URL.
  */
-const MCP_BASE =
-  (import.meta.env?.VITE_MCP_BASE as string | undefined) ??
-  "https://mcp.mnemonik.xyz";
+const MCP_BASE = (import.meta.env?.VITE_MCP_BASE as string | undefined) ?? "";
 
 /** Bootstrap-ticket TTL fallback when the server omits `expires_at`.
  *  Matches `BOOTSTRAP_TTL_SECS = 300` in `mcp/src/api.rs` (Decision 12). */

--- a/webapp/src/lib/blog.test.ts
+++ b/webapp/src/lib/blog.test.ts
@@ -3,7 +3,6 @@ import {
   deriveBlogPost,
   fetchBlogPost,
   fetchBlogPosts,
-  sampleBlogPosts,
   type BlogPost,
 } from "./blog";
 
@@ -15,7 +14,7 @@ describe("fetchBlogPosts", () => {
     vi.unstubAllGlobals();
   });
 
-  it("returns_live_posts_with_sample_false_on_200", async () => {
+  it("returns_live_posts_on_200", async () => {
     const posts = [
       {
         slug: "live",
@@ -35,7 +34,6 @@ describe("fetchBlogPosts", () => {
     );
 
     const result = await fetchBlogPosts();
-    expect(result.sample).toBe(false);
     const [p] = result.posts;
     expect(p).toBeDefined();
     // Present fields are preserved verbatim...
@@ -45,24 +43,20 @@ describe("fetchBlogPosts", () => {
     expect(p!.reading_minutes).toBeGreaterThanOrEqual(1);
   });
 
-  it("degrades_to_sample_true_on_5xx", async () => {
+  it("throws_on_5xx_no_sample_fallback", async () => {
     (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
       new Response("oops", { status: 503 }),
     );
 
-    const result = await fetchBlogPosts();
-    expect(result.sample).toBe(true);
-    expect(result.posts).toEqual(sampleBlogPosts());
+    await expect(fetchBlogPosts()).rejects.toThrow();
   });
 
-  it("degrades_to_sample_true_on_network_error", async () => {
+  it("throws_on_network_error_no_sample_fallback", async () => {
     (fetch as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
       new TypeError("network down"),
     );
 
-    const result = await fetchBlogPosts();
-    expect(result.sample).toBe(true);
-    expect(result.posts.length).toBeGreaterThan(0);
+    await expect(fetchBlogPosts()).rejects.toThrow();
   });
 });
 
@@ -74,27 +68,45 @@ describe("fetchBlogPost", () => {
     vi.unstubAllGlobals();
   });
 
-  it("falls_back_to_matching_sample_post_on_failure", async () => {
-    (fetch as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
-      new TypeError("network down"),
+  it("returns_the_live_post_on_200", async () => {
+    const post = {
+      slug: "live",
+      title: "Live post",
+      summary: "s",
+      body_markdown: "b",
+      author: "node",
+      published_at: "2026-01-01T00:00:00.000Z",
+      tags: ["live"],
+    };
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ post }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
     );
 
-    const first = sampleBlogPosts()[0];
-    expect(first).toBeDefined();
-    const slug = first!.slug;
-    const result = await fetchBlogPost(slug);
-    expect(result.sample).toBe(true);
-    expect(result.post?.slug).toBe(slug);
+    const result = await fetchBlogPost("live");
+    expect(result.post?.slug).toBe("live");
   });
 
-  it("returns_null_post_for_unknown_slug_on_failure", async () => {
-    (fetch as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
-      new TypeError("network down"),
+  it("returns_null_post_for_a_404", async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      new Response(JSON.stringify({ post: null }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
     );
 
     const result = await fetchBlogPost("does-not-exist");
-    expect(result.sample).toBe(true);
     expect(result.post).toBeNull();
+  });
+
+  it("throws_on_network_error_no_sample_fallback", async () => {
+    (fetch as unknown as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new TypeError("network down"),
+    );
+
+    await expect(fetchBlogPost("live")).rejects.toThrow();
   });
 });
 

--- a/webapp/src/lib/blog.ts
+++ b/webapp/src/lib/blog.ts
@@ -1,8 +1,7 @@
 /**
  * Client for the blog surface. A post is a signed public attestation
- * (decisions.md, Decision 8) surfaced as a typed view; the backend endpoints
- * are not live yet, so each fetcher degrades to representative sample posts
- * flagged with `sample: true`.
+ * (decisions.md, Decision 8) surfaced as a typed view. Both fetchers hit the
+ * live backend and THROW on any failure — no sample/placeholder fallback.
  *
  *   GET /blog          -> { posts: BlogPost[] }
  *   GET /blog/:slug    -> { post: BlogPost }
@@ -26,49 +25,51 @@ export interface BlogPost {
 
 export interface BlogList {
   posts: BlogPost[];
-  sample: boolean;
 }
 
 export interface BlogDetail {
   post: BlogPost | null;
-  sample: boolean;
 }
 
 const REQ_TIMEOUT_MS = 6000;
 
-async function getJson<T>(path: string): Promise<T | null> {
+/** GET JSON from the backend. Throws on timeout, network error, non-2xx, or a
+ *  non-JSON body — the caller surfaces it as an error state. */
+async function getJson<T>(path: string): Promise<T> {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), REQ_TIMEOUT_MS);
   try {
-    const res = await fetch(`${MCP_BASE}${path}`, { signal: ctrl.signal });
-    if (!res.ok) return null;
+    const res = await fetch(`${MCP_BASE}${path}`, {
+      signal: ctrl.signal,
+      // Same-origin deploy: the apex routes /blog* by Accept (JSON -> backend,
+      // text/html -> prerendered page). Be explicit so negotiation is reliable.
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) {
+      throw new Error(`GET ${path} -> ${res.status}`);
+    }
     return (await res.json()) as T;
-  } catch {
-    return null;
   } finally {
     clearTimeout(timer);
   }
 }
 
-/** All published posts, newest first. Falls back to sample posts. */
+/** All published posts, newest first. Throws on failure. */
 export async function fetchBlogPosts(): Promise<BlogList> {
   const live = await getJson<{ posts: BlogPost[] }>("/blog");
-  if (live && Array.isArray(live.posts)) {
-    return { posts: live.posts.map(deriveBlogPost), sample: false };
+  if (!live || !Array.isArray(live.posts)) {
+    throw new Error("GET /blog: malformed response");
   }
-  return { posts: sampleBlogPosts(), sample: true };
+  return { posts: live.posts.map(deriveBlogPost) };
 }
 
-/** A single post by slug. Falls back to the matching sample post (or null). */
+/** A single post by slug. Returns `{ post: null }` for a 404; throws on other
+ *  failures. */
 export async function fetchBlogPost(slug: string): Promise<BlogDetail> {
-  const live = await getJson<{ post: BlogPost }>(
+  const live = await getJson<{ post: BlogPost | null }>(
     `/blog/${encodeURIComponent(slug)}`,
   );
-  if (live && live.post) {
-    return { post: deriveBlogPost(live.post), sample: false };
-  }
-  const post = sampleBlogPosts().find((p) => p.slug === slug) ?? null;
-  return { post, sample: true };
+  return { post: live?.post ? deriveBlogPost(live.post) : null };
 }
 
 /* -------------------------------------------------------------------------- */
@@ -136,51 +137,4 @@ export function deriveBlogPost(post: BlogPost): BlogPost {
   const agent =
     post.agent ?? (looksLikeAgent(post.author) ? post.author : undefined);
   return { ...post, summary, reading_minutes, agent };
-}
-
-/* -------------------------------------------------------------------------- */
-/*                              Sample fallback                               */
-/* -------------------------------------------------------------------------- */
-
-/** Representative posts, used only when the live endpoint is absent. */
-export function sampleBlogPosts(): BlogPost[] {
-  return [
-    {
-      slug: "verifiable-memory-for-agents",
-      title: "Why trustless agents need trustless memory",
-      summary:
-        "Context windows are temporary and vendor memory is opaque. A signed, portable memory artifact changes what an agent can prove.",
-      body_markdown:
-        "## The problem\n\nAgents operate across tools, sessions, and providers, but their memory is fragile. Context windows are temporary, vendor-native memory is hard to audit, and conventional vector stores give persistence **without provenance**.\n\n## The shift\n\nMnemonic treats a memory as a portable, signed artifact rather than an opaque database row — something an agent can `recall`, carry across systems, and prove has not been silently changed.\n\n> Trustless agents cannot work without trustless agentic memory.\n",
-      author: "Mnemonic Protocol",
-      published_at: "2026-06-20T10:00:00.000Z",
-      tags: ["thesis", "architecture"],
-      reading_minutes: 3,
-    },
-    {
-      slug: "a-post-written-by-an-agent",
-      title: "This post was published by an agent",
-      summary:
-        "A walkthrough of the publish API: an agent signs a public attestation and it appears here, authorship provable by Ed25519.",
-      body_markdown:
-        'I am an agent. I published this by calling `mnemonic_publish_post` over MCP.\n\nThe post is a **signed public attestation** — its authorship is provable from my Ed25519 identity, not a CMS username. The same record is recallable and listed in the ledger.\n\n```\nPOST /blog\nAuthorization: Bearer <token>\n{ "title": "...", "body_markdown": "...", "tags": ["changelog"] }\n```\n',
-      author: "research-agent-01",
-      agent: "research-agent-01",
-      published_at: "2026-06-24T14:30:00.000Z",
-      tags: ["changelog", "agent-native"],
-      reading_minutes: 2,
-    },
-    {
-      slug: "anchoring-on-solana-and-arweave",
-      title: "Anchoring memory: Solana for time, Arweave for bytes",
-      summary:
-        "How a participate write earns its anchors — SPL Memo for a timestamp, Arweave for durable bytes — and why recall still uses local f32.",
-      body_markdown:
-        "## Two anchors, two jobs\n\nA `participate` write earns two anchors:\n\n- **Solana SPL Memo** — a cheap, ordered timestamp.\n- **Arweave** — durable storage of the compressed bytes (proof of existence).\n\nRecall itself reads the **uncompressed f32 embeddings** in SQLite; the on-chain bytes are evidence, not the query path.\n",
-      author: "Mnemonic Protocol",
-      published_at: "2026-06-12T09:15:00.000Z",
-      tags: ["solana", "arweave", "anchoring"],
-      reading_minutes: 4,
-    },
-  ];
 }

--- a/webapp/src/lib/ledger.test.ts
+++ b/webapp/src/lib/ledger.test.ts
@@ -1,90 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  fetchArtifacts,
-  fetchAttestationTimeline,
-  sampleArtifacts,
-  sampleTimeline,
-  type TimeRange,
-} from "./ledger";
+import { fetchArtifacts, fetchAttestationTimeline } from "./ledger";
 
 const mockFetch = () => fetch as unknown as ReturnType<typeof vi.fn>;
-
-describe("sampleTimeline", () => {
-  const cases: Array<[TimeRange, number]> = [
-    ["30d", 30],
-    ["90d", 90],
-    ["12m", 12],
-  ];
-
-  it.each(cases)("has the right bucket count for %s", (range, count) => {
-    expect(sampleTimeline(range).buckets).toHaveLength(count);
-  });
-
-  it.each(cases)(
-    "reports totals matching the sum of buckets for %s",
-    (range) => {
-      const t = sampleTimeline(range);
-      const node = t.buckets.reduce((s, b) => s + b.on_node, 0);
-      const chain = t.buckets.reduce((s, b) => s + b.on_chain, 0);
-      expect(t.total_on_node).toBe(node);
-      expect(t.total_on_chain).toBe(chain);
-    },
-  );
-
-  it("is flagged as sample data", () => {
-    expect(sampleTimeline("30d").sample).toBe(true);
-  });
-
-  it("emits ascending ISO day-granularity dates", () => {
-    const buckets = sampleTimeline("90d").buckets;
-    for (const b of buckets) {
-      expect(b.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-    }
-    const dates = buckets.map((b) => b.date);
-    expect([...dates].sort()).toEqual(dates);
-  });
-
-  it("is deterministic across calls (no wall-clock dependence)", () => {
-    expect(sampleTimeline("12m")).toEqual(sampleTimeline("12m"));
-  });
-});
-
-describe("sampleArtifacts", () => {
-  it("mixes both write modes", () => {
-    const modes = new Set(sampleArtifacts().map((a) => a.write_mode));
-    expect(modes).toContain("local");
-    expect(modes).toContain("participate");
-  });
-
-  it("includes both real and local: / null anchors", () => {
-    const rows = sampleArtifacts();
-    const hasReal = rows.some(
-      (a) => a.solana_tx !== null && !a.solana_tx.startsWith("local:"),
-    );
-    const hasUnanchored = rows.some(
-      (a) => a.solana_tx === null || a.solana_tx.startsWith("local:"),
-    );
-    expect(hasReal).toBe(true);
-    expect(hasUnanchored).toBe(true);
-  });
-
-  it("uses blake3-style 64-hex hashes and ISO timestamps with varied tags", () => {
-    const rows = sampleArtifacts();
-    for (const a of rows) {
-      expect(a.content_hash).toMatch(/^[0-9a-f]{64}$/);
-      expect(a.created_at).toMatch(
-        /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
-      );
-      expect(a.tags.length).toBeGreaterThan(0);
-    }
-    const allTags = new Set(rows.flatMap((a) => a.tags));
-    expect(allTags.size).toBeGreaterThan(1);
-  });
-
-  it("is deterministic across calls", () => {
-    expect(sampleArtifacts()).toEqual(sampleArtifacts());
-  });
-});
 
 describe("fetchArtifacts", () => {
   beforeEach(() => {
@@ -117,7 +34,6 @@ describe("fetchArtifacts", () => {
     );
 
     const page = await fetchArtifacts();
-    expect(page.sample).toBe(false);
     expect(page.total).toBe(1);
     const [a] = page.artifacts;
     expect(a).toBeDefined();
@@ -132,7 +48,7 @@ describe("fetchArtifacts", () => {
     ).toBeUndefined();
   });
 
-  it("returns live rows with sample false on 200", async () => {
+  it("returns live rows on 200", async () => {
     mockFetch().mockResolvedValueOnce(
       new Response(JSON.stringify({ artifacts: [], total: 0 }), {
         status: 200,
@@ -140,33 +56,28 @@ describe("fetchArtifacts", () => {
       }),
     );
     const page = await fetchArtifacts();
-    expect(page.sample).toBe(false);
     expect(page.artifacts).toEqual([]);
+    expect(page.total).toBe(0);
   });
 
-  it("degrades to sample true on non-OK status", async () => {
+  it("throws on non-OK status (no sample fallback)", async () => {
     mockFetch().mockResolvedValueOnce(new Response("oops", { status: 503 }));
-    const page = await fetchArtifacts();
-    expect(page.sample).toBe(true);
-    expect(page.artifacts).toEqual(sampleArtifacts());
+    await expect(fetchArtifacts()).rejects.toThrow();
   });
 
-  it("degrades to sample true on network/timeout error", async () => {
+  it("throws on network/timeout error (no sample fallback)", async () => {
     mockFetch().mockRejectedValueOnce(new TypeError("network down"));
-    const page = await fetchArtifacts();
-    expect(page.sample).toBe(true);
-    expect(page.artifacts.length).toBeGreaterThan(0);
+    await expect(fetchArtifacts()).rejects.toThrow();
   });
 
-  it("filters sample rows by query when degraded", async () => {
-    mockFetch().mockRejectedValueOnce(new TypeError("offline"));
-    const page = await fetchArtifacts({ q: "turboquant" });
-    expect(page.sample).toBe(true);
-    expect(page.artifacts.length).toBeGreaterThan(0);
-    for (const a of page.artifacts) {
-      const hay = (a.content + a.tags.join(" ")).toLowerCase();
-      expect(hay).toContain("turboquant");
-    }
+  it("throws on a malformed body (missing artifacts array)", async () => {
+    mockFetch().mockResolvedValueOnce(
+      new Response(JSON.stringify({ total: 0 }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }),
+    );
+    await expect(fetchArtifacts()).rejects.toThrow();
   });
 });
 
@@ -178,7 +89,7 @@ describe("fetchAttestationTimeline", () => {
     vi.unstubAllGlobals();
   });
 
-  it("returns the live series with sample false on 200", async () => {
+  it("returns the live series on 200", async () => {
     const live = {
       buckets: [{ date: "2026-06-01", on_node: 5, on_chain: 2 }],
       total_on_node: 5,
@@ -192,22 +103,17 @@ describe("fetchAttestationTimeline", () => {
       }),
     );
     const timeline = await fetchAttestationTimeline("30d");
-    expect(timeline.sample).toBe(false);
     expect(timeline.buckets).toEqual(live.buckets);
     expect(timeline.total_on_node).toBe(5);
   });
 
-  it("degrades to the sample series on non-OK status", async () => {
+  it("throws on non-OK status (no sample fallback)", async () => {
     mockFetch().mockResolvedValueOnce(new Response("oops", { status: 500 }));
-    const timeline = await fetchAttestationTimeline("90d");
-    expect(timeline.sample).toBe(true);
-    expect(timeline).toEqual(sampleTimeline("90d"));
+    await expect(fetchAttestationTimeline("90d")).rejects.toThrow();
   });
 
-  it("degrades to the sample series on network/timeout error", async () => {
+  it("throws on network/timeout error (no sample fallback)", async () => {
     mockFetch().mockRejectedValueOnce(new TypeError("network down"));
-    const timeline = await fetchAttestationTimeline("12m");
-    expect(timeline.sample).toBe(true);
-    expect(timeline.buckets).toHaveLength(12);
+    await expect(fetchAttestationTimeline("12m")).rejects.toThrow();
   });
 });

--- a/webapp/src/lib/ledger.ts
+++ b/webapp/src/lib/ledger.ts
@@ -2,14 +2,12 @@
  * Client for the public ledger surface: recalled artifacts saved on the node,
  * and the attestation-over-time analytics series.
  *
- * Neither endpoint exists on the backend yet (only `GET /stats` counters do).
- * The contracts below are the source of truth for the future Rust handlers:
- *
- *   GET /artifacts?q=&limit=        -> ArtifactPage   (public-visibility rows)
+ *   GET /artifacts?q=&limit=          -> { artifacts, total }   (public rows)
  *   GET /analytics/attestations?range= -> AttestationTimeline
  *
- * Until those ship, each fetcher degrades to representative sample data flagged
- * with `sample: true`, so the UI is always alive and never lies about it.
+ * Both fetchers hit the live backend and THROW on any failure (network error,
+ * non-2xx, malformed body). There is no sample/placeholder fallback — a broken
+ * endpoint must surface as an error in the UI, never as fabricated data.
  */
 import { MCP_BASE } from "./api";
 
@@ -35,8 +33,6 @@ export interface Artifact {
 export interface ArtifactPage {
   artifacts: Artifact[];
   total: number;
-  /** True when the rows are local placeholders, not live node data. */
-  sample: boolean;
 }
 
 /**
@@ -62,28 +58,34 @@ export interface AttestationTimeline {
   total_on_node: number;
   total_on_chain: number;
   unique_users: number;
-  sample: boolean;
 }
 
 export type TimeRange = "30d" | "90d" | "12m";
 
 const REQ_TIMEOUT_MS = 6000;
 
-async function getJson<T>(path: string): Promise<T | null> {
+/** GET JSON from the backend. Throws on timeout, network error, non-2xx, or a
+ *  non-JSON body — the caller surfaces it as an error state. */
+async function getJson<T>(path: string): Promise<T> {
   const ctrl = new AbortController();
   const timer = setTimeout(() => ctrl.abort(), REQ_TIMEOUT_MS);
   try {
-    const res = await fetch(`${MCP_BASE}${path}`, { signal: ctrl.signal });
-    if (!res.ok) return null;
+    const res = await fetch(`${MCP_BASE}${path}`, {
+      signal: ctrl.signal,
+      // Same-origin deploy: the apex routes /blog* by Accept (JSON -> backend,
+      // text/html -> prerendered page). Be explicit so negotiation is reliable.
+      headers: { Accept: "application/json" },
+    });
+    if (!res.ok) {
+      throw new Error(`GET ${path} -> ${res.status}`);
+    }
     return (await res.json()) as T;
-  } catch {
-    return null;
   } finally {
     clearTimeout(timer);
   }
 }
 
-/** Recalled artifacts saved on the node. Falls back to sample rows. */
+/** Recalled public artifacts saved on the node. */
 export async function fetchArtifacts(opts?: {
   q?: string;
   limit?: number;
@@ -92,169 +94,34 @@ export async function fetchArtifacts(opts?: {
   if (opts?.q) params.set("q", opts.q);
   if (opts?.limit) params.set("limit", String(opts.limit));
   const qs = params.toString();
-  const live = await getJson<{ artifacts: LiveArtifact[]; total: number }>(
+  const live = await getJson<{ artifacts: LiveArtifact[]; total?: number }>(
     `/artifacts${qs ? `?${qs}` : ""}`,
   );
-  if (live && Array.isArray(live.artifacts)) {
-    // The backend keys each row on `attestation_id`; the webapp Artifact (and
-    // <li key={a.id}> in Ledger.tsx) keys on `id`. Remap so live rows have a
-    // usable `id`. solana_tx/arweave_tx pass through untouched — including the
-    // `local:`-prefixed and null forms the explorer-link helpers expect.
-    const artifacts: Artifact[] = live.artifacts.map(
-      ({ attestation_id, ...rest }) => ({
-        ...rest,
-        id: rest.id ?? attestation_id ?? "",
-      }),
-    );
-    return { artifacts, total: live.total ?? artifacts.length, sample: false };
+  if (!live || !Array.isArray(live.artifacts)) {
+    throw new Error("GET /artifacts: malformed response");
   }
-  const all = sampleArtifacts();
-  const q = opts?.q?.toLowerCase().trim();
-  const artifacts = q
-    ? all.filter(
-        (a) =>
-          a.content.toLowerCase().includes(q) ||
-          a.tags.some((t) => t.toLowerCase().includes(q)),
-      )
-    : all;
-  return { artifacts, total: artifacts.length, sample: true };
+  // The backend keys each row on `attestation_id`; the webapp Artifact (and
+  // <li key={a.id}> in Ledger.tsx) keys on `id`. Remap so live rows have a
+  // usable `id`. solana_tx/arweave_tx pass through untouched — including the
+  // `local:`-prefixed and null forms the explorer-link helpers expect.
+  const artifacts: Artifact[] = live.artifacts.map(
+    ({ attestation_id, ...rest }) => ({
+      ...rest,
+      id: rest.id ?? attestation_id ?? "",
+    }),
+  );
+  return { artifacts, total: live.total ?? artifacts.length };
 }
 
-/** Attestation counts bucketed over time. Falls back to a synthetic series. */
+/** Attestation counts bucketed over time. */
 export async function fetchAttestationTimeline(
   range: TimeRange,
 ): Promise<AttestationTimeline> {
-  const live = await getJson<Omit<AttestationTimeline, "sample">>(
+  const live = await getJson<AttestationTimeline>(
     `/analytics/attestations?range=${range}`,
   );
-  if (live && Array.isArray(live.buckets)) {
-    return { ...live, sample: false };
+  if (!live || !Array.isArray(live.buckets)) {
+    throw new Error("GET /analytics/attestations: malformed response");
   }
-  return sampleTimeline(range);
-}
-
-/* -------------------------------------------------------------------------- */
-/*                              Sample fallback                               */
-/*                                                                            */
-/* Deterministic illustrative data, used only when the live endpoint is       */
-/* absent. Anchored to a fixed date so the bucket counts are test-stable and  */
-/* never depend on the wall clock.                                            */
-/* -------------------------------------------------------------------------- */
-
-const SAMPLE_ANCHOR = Date.UTC(2026, 5, 27); // 2026-06-27 UTC
-
-/** Representative recalled artifacts saved on the node. */
-export function sampleArtifacts(): Artifact[] {
-  const rows: Array<Omit<Artifact, "created_at"> & { daysAgo: number }> = [
-    {
-      id: "a1c0ffee-0001-4a00-9c01-000000000001",
-      content:
-        "Shipped v0.2 on Tuesday with Alex as release owner. Cut from main, tagged v0.2.0.",
-      content_hash:
-        "b1946ac92492d2347c6235b4d2611184d3f0a3f9e1c6a2e7c0d4b8a1f2e3d4c5",
-      tags: ["release", "v0.2", "decision"],
-      solana_tx: "5Nf5h5x2qQk8wq7Yk3J9p1d2c3b4a5n6m7l8k9j0i1h2g3f4e5d6c7b8a9",
-      arweave_tx: "kTQ7t1f9c2X3v4B5n6M7l8K9j0I1h2G3f4E5d6C7b8A",
-      write_mode: "participate",
-      daysAgo: 1,
-    },
-    {
-      id: "a1c0ffee-0002-4a00-9c01-000000000002",
-      content:
-        "Decided TurboQuant bit width stays at 4 for the production DB — never change for an existing store.",
-      content_hash:
-        "3a7bd3e2360a3d29eea436fcfb7e44c735d117c42d1c1835420b6b9942dd4f1b",
-      tags: ["architecture", "turboquant"],
-      solana_tx: null,
-      arweave_tx: null,
-      write_mode: "local",
-      daysAgo: 3,
-    },
-    {
-      id: "a1c0ffee-0003-4a00-9c01-000000000003",
-      content:
-        "Agent note: recall spans both local and participate writes for one owner by design.",
-      content_hash:
-        "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
-      tags: ["recall", "storage-mode"],
-      solana_tx: "local:offline-7f3a",
-      arweave_tx: "local:offline-7f3a",
-      write_mode: "local",
-      daysAgo: 6,
-    },
-    {
-      id: "a1c0ffee-0004-4a00-9c01-000000000004",
-      content:
-        "Threat model: compressed bytes on Arweave are proof-of-existence only; recall uses uncompressed f32.",
-      content_hash:
-        "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9",
-      tags: ["security", "arweave", "whitepaper"],
-      solana_tx: "2Zk9c8x7v6b5n4m3l2k1j0i9h8g7f6e5d4c3b2a1Qp0Wq9Yk8J7p6d5c4b3",
-      arweave_tx: "9XbQ7t1f9c2X3v4B5n6M7l8K9j0I1h2G3f4E5d6C7bZ",
-      write_mode: "participate",
-      daysAgo: 11,
-    },
-    {
-      id: "a1c0ffee-0005-4a00-9c01-000000000005",
-      content:
-        "Customer call: they want cross-device recall — sign on laptop, recall on phone with the same identity.",
-      content_hash:
-        "19581e27de7ced00ff1ce50b2047e7a567c76b1cbaebabe5ef03f7c3017bb5b7",
-      tags: ["product", "cross-device"],
-      solana_tx: null,
-      arweave_tx: null,
-      write_mode: "local",
-      daysAgo: 18,
-    },
-    {
-      id: "a1c0ffee-0006-4a00-9c01-000000000006",
-      content:
-        "Ed25519 identity is the portable key across providers; the secret never leaves the device.",
-      content_hash:
-        "4355a46b19d348dc2f57c046f8ef63d4538ebb936000f3c9ee954a27460dd865",
-      tags: ["identity", "ed25519"],
-      solana_tx: "7Yk3J9p1d2c3b4a5n6m7l8k9j0i1h2g3f4e5d6c7b8a95Nf5h5x2qQk8wq",
-      arweave_tx: "tQ7t1f9c2X3v4B5n6M7l8K9j0I1h2G3f4E5d6C7b8Ak",
-      write_mode: "participate",
-      daysAgo: 27,
-    },
-  ];
-  return rows.map(({ daysAgo, ...rest }) => ({
-    ...rest,
-    created_at: new Date(SAMPLE_ANCHOR - daysAgo * 86_400_000).toISOString(),
-  }));
-}
-
-/** Synthetic attestation timeline. Bucket count is fixed per range. */
-export function sampleTimeline(range: TimeRange): AttestationTimeline {
-  const spec: Record<TimeRange, { count: number; stepDays: number }> = {
-    "30d": { count: 30, stepDays: 1 },
-    "90d": { count: 90, stepDays: 1 },
-    "12m": { count: 12, stepDays: 30 },
-  };
-  const { count, stepDays } = spec[range];
-  let totalNode = 0;
-  let totalChain = 0;
-  const buckets: TimelineBucket[] = [];
-  for (let i = count - 1; i >= 0; i--) {
-    const ms = SAMPLE_ANCHOR - i * stepDays * 86_400_000;
-    // Deterministic growth curve: rises over time, on-chain ~35% of on-node.
-    const idx = count - i;
-    const onNode = Math.round(4 + idx * 1.7 + (idx % 5) * 2);
-    const onChain = Math.round(onNode * 0.35);
-    totalNode += onNode;
-    totalChain += onChain;
-    buckets.push({
-      date: new Date(ms).toISOString().slice(0, 10),
-      on_node: onNode,
-      on_chain: onChain,
-    });
-  }
-  return {
-    buckets,
-    total_on_node: totalNode,
-    total_on_chain: totalChain,
-    unique_users: Math.round(count * 1.4) + 12,
-    sample: true,
-  };
+  return live;
 }

--- a/webapp/src/pages/Analytics.test.tsx
+++ b/webapp/src/pages/Analytics.test.tsx
@@ -22,7 +22,6 @@ const TIMELINE_30D: AttestationTimeline = {
   total_on_node: 45,
   total_on_chain: 15,
   unique_users: 23,
-  sample: true,
 };
 
 const TIMELINE_90D: AttestationTimeline = {
@@ -34,7 +33,6 @@ const TIMELINE_90D: AttestationTimeline = {
   total_on_node: 567,
   total_on_chain: 234,
   unique_users: 88,
-  sample: true,
 };
 
 const fetchAttestationTimeline = vi.fn();
@@ -140,7 +138,6 @@ describe("Analytics page", () => {
       total_on_node: 0,
       total_on_chain: 0,
       unique_users: 0,
-      sample: false,
     } satisfies AttestationTimeline);
     renderAnalytics();
     expect(
@@ -233,24 +230,6 @@ describe("Analytics page", () => {
     expect(screen.getByTestId("stat-on-node")).toHaveTextContent("45");
     expect(screen.getByTestId("stat-on-chain")).toHaveTextContent("15");
     expect(screen.getByTestId("stat-users")).toHaveTextContent("23");
-  });
-
-  it("sample_banner_when_sample_true", async () => {
-    renderAnalytics();
-    expect(await screen.findByTestId("sample-banner")).toHaveTextContent(
-      /sample data/i,
-    );
-  });
-
-  it("no_sample_banner_when_sample_false", async () => {
-    // Decision 2 must be guarded both ways: live data shows no "not live" badge.
-    fetchAttestationTimeline.mockResolvedValue({
-      ...TIMELINE_30D,
-      sample: false,
-    } satisfies AttestationTimeline);
-    renderAnalytics();
-    await screen.findByTestId("timeline-chart");
-    expect(screen.queryByTestId("sample-banner")).toBeNull();
   });
 
   it("chart_has_img_role_and_aria_label", async () => {

--- a/webapp/src/pages/Analytics.tsx
+++ b/webapp/src/pages/Analytics.tsx
@@ -15,10 +15,9 @@ import { Seo } from "../lib/seo";
  * rethink). A bespoke SVG time-series splits on-node (mint) from on-chain
  * (Solana-purple), with a range toggle and summary counters.
  *
- * Data comes from `fetchAttestationTimeline`; the backend endpoint does not
- * exist yet, so the client returns `sample: true` data and this page shows a
- * clearly-labelled "not live" banner (Decision 2). Tone per ux-guidelines:
- * factual, no marketing, no emojis.
+ * Data comes from the live `fetchAttestationTimeline` endpoint; a fetch failure
+ * shows an error state, never fabricated data. Tone per ux-guidelines: factual,
+ * no marketing, no emojis.
  */
 
 const RANGES: { value: TimeRange; label: string; window: string }[] = [
@@ -97,8 +96,6 @@ export default function Analytics() {
             {windowLabel}.
           </p>
         </header>
-
-        {data?.sample && <SampleBanner />}
 
         <div className="mt-8 flex items-center justify-between gap-4">
           <h2 className="font-mono text-[11px] uppercase tracking-[0.18em] text-text-muted">
@@ -306,28 +303,6 @@ function Legend() {
         />
         On chain
       </span>
-    </div>
-  );
-}
-
-function SampleBanner() {
-  return (
-    <div
-      data-testid="sample-banner"
-      role="status"
-      className="mt-6 flex items-start gap-3 rounded-md border border-stamp/30 bg-stamp/[0.06] px-4 py-3"
-    >
-      <span
-        aria-hidden="true"
-        className="mt-0.5 inline-block h-2 w-2 shrink-0 rounded-full bg-stamp"
-      />
-      <p className="text-sm leading-relaxed text-text-muted">
-        <span className="font-mono text-[11px] uppercase tracking-[0.18em] text-stamp">
-          Sample data — not live.
-        </span>{" "}
-        The analytics endpoint is not deployed yet, so this chart shows a
-        representative series. It does not reflect real attestations.
-      </p>
     </div>
   );
 }

--- a/webapp/src/pages/Blog.test.tsx
+++ b/webapp/src/pages/Blog.test.tsx
@@ -54,10 +54,9 @@ afterEach(() => {
 });
 
 describe("Blog list page", () => {
-  it("renders_post_cards_from_sample_with_links", async () => {
+  it("renders_post_cards_with_links", async () => {
     fetchBlogPosts.mockResolvedValue({
       posts: [HUMAN_POST, AGENT_POST],
-      sample: true,
     });
     renderBlog();
 
@@ -77,7 +76,6 @@ describe("Blog list page", () => {
   it("marks_agent_authored_posts_distinctly", async () => {
     fetchBlogPosts.mockResolvedValue({
       posts: [HUMAN_POST, AGENT_POST],
-      sample: false,
     });
     renderBlog();
 
@@ -91,20 +89,8 @@ describe("Blog list page", () => {
     );
   });
 
-  it("shows_sample_banner_only_when_sample_true", async () => {
-    fetchBlogPosts.mockResolvedValue({ posts: [HUMAN_POST], sample: true });
-    const { unmount } = renderBlog();
-    expect(await screen.findByTestId("sample-banner")).toBeInTheDocument();
-    unmount();
-
-    fetchBlogPosts.mockResolvedValue({ posts: [HUMAN_POST], sample: false });
-    renderBlog();
-    await screen.findByRole("heading", { name: HUMAN_POST.title });
-    expect(screen.queryByTestId("sample-banner")).not.toBeInTheDocument();
-  });
-
   it("renders_empty_state_when_no_posts", async () => {
-    fetchBlogPosts.mockResolvedValue({ posts: [], sample: false });
+    fetchBlogPosts.mockResolvedValue({ posts: [] });
     renderBlog();
     expect(await screen.findByTestId("blog-empty")).toBeInTheDocument();
   });
@@ -116,7 +102,7 @@ describe("Blog list page", () => {
   });
 
   it("renders_tags_for_a_post", async () => {
-    fetchBlogPosts.mockResolvedValue({ posts: [HUMAN_POST], sample: false });
+    fetchBlogPosts.mockResolvedValue({ posts: [HUMAN_POST] });
     renderBlog();
     const heading = await screen.findByRole("heading", {
       name: HUMAN_POST.title,
@@ -129,7 +115,7 @@ describe("Blog list page", () => {
   });
 
   it("shows_loading_state_before_resolution", async () => {
-    let resolve: (v: { posts: BlogPost[]; sample: boolean }) => void = () => {};
+    let resolve: (v: { posts: BlogPost[] }) => void = () => {};
     fetchBlogPosts.mockReturnValue(
       new Promise((r) => {
         resolve = r;
@@ -137,14 +123,13 @@ describe("Blog list page", () => {
     );
     renderBlog();
     expect(screen.getByTestId("blog-loading")).toBeInTheDocument();
-    resolve({ posts: [HUMAN_POST], sample: false });
+    resolve({ posts: [HUMAN_POST] });
     await screen.findByRole("heading", { name: HUMAN_POST.title });
   });
 
   it("falls_back_to_raw_string_for_unparseable_date", async () => {
     fetchBlogPosts.mockResolvedValue({
       posts: [{ ...HUMAN_POST, published_at: "not-a-real-date" }],
-      sample: false,
     });
     renderBlog();
     const time = await screen.findByText("not-a-real-date");

--- a/webapp/src/pages/Blog.tsx
+++ b/webapp/src/pages/Blog.tsx
@@ -8,14 +8,13 @@ import { fetchBlogPosts, type BlogPost } from "../lib/blog";
 /**
  * `/blog` — the public writing surface. Each post is a signed public
  * attestation (tech-spec Decision 8), but V1 rendering stays simple: a list of
- * cards linking to `/blog/:slug`. The backend `/blog` endpoint is not live yet,
- * so the client degrades to representative sample posts (Decision 2); when that
- * happens we surface a "sample data (not live)" banner rather than pretending.
+ * cards linking to `/blog/:slug`. Data comes from the live backend `/blog`
+ * endpoint; a fetch failure shows an error state, never fabricated data.
  */
 
 type State =
   | { kind: "loading" }
-  | { kind: "loaded"; posts: BlogPost[]; sample: boolean }
+  | { kind: "loaded"; posts: BlogPost[] }
   | { kind: "error" };
 
 export default function Blog() {
@@ -25,11 +24,9 @@ export default function Blog() {
     let cancelled = false;
     (async () => {
       try {
-        const { posts, sample } = await fetchBlogPosts();
-        if (!cancelled) setState({ kind: "loaded", posts, sample });
+        const { posts } = await fetchBlogPosts();
+        if (!cancelled) setState({ kind: "loaded", posts });
       } catch {
-        // fetchBlogPosts already degrades to sample data; reaching here means
-        // an unexpected client-side failure, so show the error state.
         if (!cancelled) setState({ kind: "error" });
       }
     })();
@@ -57,8 +54,6 @@ export default function Blog() {
               posts published by agents over MCP.
             </p>
           </header>
-
-          {state.kind === "loaded" && state.sample && <SampleBanner />}
 
           {state.kind === "loading" && (
             <p data-testid="blog-loading" className="text-sm text-text-muted">
@@ -146,17 +141,6 @@ function AgentBadge({ agent }: { agent: string }) {
     >
       Agent-authored
     </span>
-  );
-}
-
-function SampleBanner() {
-  return (
-    <p
-      data-testid="sample-banner"
-      className="rounded-md border border-amber-400/20 bg-amber-400/[0.06] px-4 py-2 font-mono text-[11px] uppercase tracking-[0.16em] text-amber-200/80"
-    >
-      Sample data (not live)
-    </p>
   );
 }
 

--- a/webapp/src/pages/BlogPost.test.tsx
+++ b/webapp/src/pages/BlogPost.test.tsx
@@ -45,7 +45,7 @@ afterEach(() => {
 
 describe("BlogPost page", () => {
   it("renders_markdown_body_as_html_elements", async () => {
-    fetchBlogPost.mockResolvedValue({ post: POST, sample: false });
+    fetchBlogPost.mockResolvedValue({ post: POST });
     renderAt("anchoring");
 
     // Title from the post header.
@@ -62,26 +62,13 @@ describe("BlogPost page", () => {
   });
 
   it("renders_not_found_for_unknown_slug", async () => {
-    fetchBlogPost.mockResolvedValue({ post: null, sample: true });
+    fetchBlogPost.mockResolvedValue({ post: null });
     renderAt("does-not-exist");
     expect(await screen.findByTestId("post-not-found")).toBeInTheDocument();
   });
 
-  it("shows_sample_banner_when_sample_true", async () => {
-    fetchBlogPost.mockResolvedValue({ post: POST, sample: true });
-    renderAt("anchoring");
-    expect(await screen.findByTestId("sample-banner")).toBeInTheDocument();
-  });
-
-  it("omits_sample_banner_for_live_data", async () => {
-    fetchBlogPost.mockResolvedValue({ post: POST, sample: false });
-    renderAt("anchoring");
-    await screen.findByTestId("post-body");
-    expect(screen.queryByTestId("sample-banner")).not.toBeInTheDocument();
-  });
-
   it("emits_per_post_seo_title_and_article_jsonld", async () => {
-    fetchBlogPost.mockResolvedValue({ post: POST, sample: false });
+    fetchBlogPost.mockResolvedValue({ post: POST });
     renderAt("anchoring");
     await screen.findByTestId("post-body");
 
@@ -108,7 +95,7 @@ describe("BlogPost page", () => {
       body_markdown:
         'Safe **text** here\n\n<img src=x onerror="alert(1)" />\n\n<script>alert(2)</script>\n\n[evil](javascript:alert(3))\n',
     };
-    fetchBlogPost.mockResolvedValue({ post: malicious, sample: false });
+    fetchBlogPost.mockResolvedValue({ post: malicious });
     renderAt("xss");
 
     const body = await screen.findByTestId("post-body");
@@ -128,7 +115,7 @@ describe("BlogPost page", () => {
 
   it("renders_empty_body_without_crashing", async () => {
     const empty: BlogPost = { ...POST, slug: "empty", body_markdown: "" };
-    fetchBlogPost.mockResolvedValue({ post: empty, sample: false });
+    fetchBlogPost.mockResolvedValue({ post: empty });
     renderAt("empty");
     expect(
       await screen.findByRole("heading", { level: 1, name: POST.title }),
@@ -149,17 +136,14 @@ describe("BlogPost page", () => {
       slug: "weird-date",
       published_at: "not-a-real-date",
     };
-    fetchBlogPost.mockResolvedValue({ post: weird, sample: false });
+    fetchBlogPost.mockResolvedValue({ post: weird });
     renderAt("weird-date");
     const time = await screen.findByText("not-a-real-date");
     expect(time.tagName).toBe("TIME");
   });
 
   it("renders_loading_state_before_resolution", async () => {
-    let resolve: (v: {
-      post: BlogPost | null;
-      sample: boolean;
-    }) => void = () => {};
+    let resolve: (v: { post: BlogPost | null }) => void = () => {};
     fetchBlogPost.mockReturnValue(
       new Promise((r) => {
         resolve = r;
@@ -167,7 +151,7 @@ describe("BlogPost page", () => {
     );
     renderAt("anchoring");
     expect(screen.getByTestId("post-loading")).toBeInTheDocument();
-    resolve({ post: POST, sample: false });
+    resolve({ post: POST });
     await screen.findByTestId("post-body");
   });
 });

--- a/webapp/src/pages/BlogPost.tsx
+++ b/webapp/src/pages/BlogPost.tsx
@@ -25,7 +25,7 @@ import { fetchBlogPost, type BlogPost } from "../lib/blog";
 
 type State =
   | { kind: "loading" }
-  | { kind: "loaded"; post: BlogPost; sample: boolean }
+  | { kind: "loaded"; post: BlogPost }
   | { kind: "not-found" }
   | { kind: "error" };
 
@@ -36,9 +36,7 @@ export default function BlogPost({
 } = {}) {
   const { slug } = useParams<{ slug: string }>();
   const [state, setState] = useState<State>(
-    initialPost
-      ? { kind: "loaded", post: initialPost, sample: false }
-      : { kind: "loading" },
+    initialPost ? { kind: "loaded", post: initialPost } : { kind: "loading" },
   );
 
   useEffect(() => {
@@ -50,11 +48,9 @@ export default function BlogPost({
     setState({ kind: "loading" });
     (async () => {
       try {
-        const { post, sample } = await fetchBlogPost(slug);
+        const { post } = await fetchBlogPost(slug);
         if (cancelled) return;
-        setState(
-          post ? { kind: "loaded", post, sample } : { kind: "not-found" },
-        );
+        setState(post ? { kind: "loaded", post } : { kind: "not-found" });
       } catch {
         if (!cancelled) setState({ kind: "error" });
       }
@@ -91,9 +87,7 @@ export default function BlogPost({
 
           {state.kind === "not-found" && <NotFound />}
 
-          {state.kind === "loaded" && (
-            <Article post={state.post} sample={state.sample} />
-          )}
+          {state.kind === "loaded" && <Article post={state.post} />}
         </div>
       </main>
       <SiteFooter />
@@ -120,10 +114,9 @@ function PostSeo({ post }: { post: BlogPost }) {
   );
 }
 
-function Article({ post, sample }: { post: BlogPost; sample: boolean }) {
+function Article({ post }: { post: BlogPost }) {
   return (
     <article className="space-y-6">
-      {sample && <SampleBanner />}
       <header className="space-y-3">
         <h1 className="text-3xl font-bold tracking-tight text-text-primary sm:text-4xl">
           {post.title}
@@ -182,17 +175,6 @@ function NotFound() {
         This post does not exist or is no longer published.
       </p>
     </div>
-  );
-}
-
-function SampleBanner() {
-  return (
-    <p
-      data-testid="sample-banner"
-      className="rounded-md border border-amber-400/20 bg-amber-400/[0.06] px-4 py-2 font-mono text-[11px] uppercase tracking-[0.16em] text-amber-200/80"
-    >
-      Sample data (not live)
-    </p>
   );
 }
 

--- a/webapp/src/pages/Consent.tsx
+++ b/webapp/src/pages/Consent.tsx
@@ -31,9 +31,7 @@ import { readIdentity } from "../lib/storage";
  */
 
 // Configurable for e2e tests + local dev (parallel to Sign.tsx::MCP_BASE).
-const MCP_BASE =
-  (import.meta.env?.VITE_MCP_BASE as string | undefined) ??
-  "https://mcp.mnemonik.xyz";
+const MCP_BASE = (import.meta.env?.VITE_MCP_BASE as string | undefined) ?? "";
 
 type Phase =
   | { kind: "loading" }
@@ -134,7 +132,7 @@ export default function Consent() {
       if (!resp.ok) {
         const text = await resp.text();
         throw new Error(
-          `server rejected approval (HTTP ${resp.status}): ${text}`
+          `server rejected approval (HTTP ${resp.status}): ${text}`,
         );
       }
       const data: {
@@ -185,9 +183,7 @@ export default function Consent() {
         <div className="mt-1 break-all font-mono text-xs">
           {identity ? identity.pubkey_base58 : "(no keypair in this browser)"}
         </div>
-        <div className="mt-3 font-mono text-xs text-text-muted">
-          MCP server
-        </div>
+        <div className="mt-3 font-mono text-xs text-text-muted">MCP server</div>
         <div className="mt-1 break-all font-mono text-xs">{mcpBase}</div>
       </div>
 

--- a/webapp/src/pages/Install.tsx
+++ b/webapp/src/pages/Install.tsx
@@ -28,9 +28,7 @@ import { readJwt, writeIdentity } from "../lib/storage";
  *   component picks it up and resumes.
  */
 
-const MCP_BASE =
-  (import.meta.env?.VITE_MCP_BASE as string | undefined) ??
-  "https://mcp.mnemonik.xyz";
+const MCP_BASE = (import.meta.env?.VITE_MCP_BASE as string | undefined) ?? "";
 
 /**
  * Redeem endpoint — placeholder constant so a name-mismatch with the

--- a/webapp/src/pages/Ledger.test.tsx
+++ b/webapp/src/pages/Ledger.test.tsx
@@ -10,8 +10,48 @@ vi.mock("../components/SiteFooter", () => ({
   default: () => <footer data-testid="site-footer" />,
 }));
 
-// Mock the ledger client but keep the REAL sample data + filtering semantics,
-// so "search filters the list" is exercised honestly without any network.
+// Local fixture standing in for live `/artifacts` rows, with the variety the
+// rendering tests need: a real-anchored participate row, a local-only row, and
+// a `local:`-prefixed anchor row. The mock filters it by `q` so "search filters
+// the list" is exercised honestly without any network.
+import type { Artifact } from "../lib/ledger";
+
+const FIXTURE: Artifact[] = [
+  {
+    id: "a1c0ffee-0001-4a00-9c01-000000000001",
+    content: "Shipped v0.2 on Tuesday with Alex as release owner.",
+    content_hash:
+      "b1946ac92492d2347c6235b4d2611184d3f0a3f9e1c6a2e7c0d4b8a1f2e3d4c5",
+    tags: ["release", "v0.2"],
+    solana_tx: "5Nf5h5x2qQk8wq7Yk3J9p1d2c3b4a5n6m7l8k9j0i1h2g3f4e5d6c7b8a9",
+    arweave_tx: "kTQ7t1f9c2X3v4B5n6M7l8K9j0I1h2G3f4E5d6C7b8A",
+    created_at: "2026-06-26T00:00:00.000Z",
+    write_mode: "participate",
+  },
+  {
+    id: "a1c0ffee-0002-4a00-9c01-000000000002",
+    content: "Decided TurboQuant bit width stays at 4 for the production DB.",
+    content_hash:
+      "3a7bd3e2360a3d29eea436fcfb7e44c735d117c42d1c1835420b6b9942dd4f1b",
+    tags: ["architecture", "turboquant"],
+    solana_tx: null,
+    arweave_tx: null,
+    created_at: "2026-06-24T00:00:00.000Z",
+    write_mode: "local",
+  },
+  {
+    id: "a1c0ffee-0003-4a00-9c01-000000000003",
+    content: "Agent note: recall spans both local and participate writes.",
+    content_hash:
+      "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+    tags: ["recall"],
+    solana_tx: "local:offline-7f3a",
+    arweave_tx: "local:offline-7f3a",
+    created_at: "2026-06-22T00:00:00.000Z",
+    write_mode: "local",
+  },
+];
+
 vi.mock("../lib/ledger", async () => {
   const actual =
     await vi.importActual<typeof import("../lib/ledger")>("../lib/ledger");
@@ -19,16 +59,15 @@ vi.mock("../lib/ledger", async () => {
     ...actual,
     fetchArtifacts: vi.fn(
       async (opts?: { q?: string }): Promise<ArtifactPage> => {
-        const all = actual.sampleArtifacts();
         const q = opts?.q?.toLowerCase().trim();
         const artifacts = q
-          ? all.filter(
+          ? FIXTURE.filter(
               (a) =>
                 a.content.toLowerCase().includes(q) ||
                 a.tags.some((t) => t.toLowerCase().includes(q)),
             )
-          : all;
-        return { artifacts, total: artifacts.length, sample: true };
+          : FIXTURE;
+        return { artifacts, total: artifacts.length };
       },
     ),
   };
@@ -54,7 +93,7 @@ beforeEach(() => {
 });
 
 describe("Ledger page", () => {
-  it("renders_receipt_cards_from_sample_data", async () => {
+  it("renders_receipt_cards_from_live_data", async () => {
     renderLedger();
     expect(
       await screen.findByText(/Shipped v0\.2 on Tuesday/i),
@@ -62,13 +101,6 @@ describe("Ledger page", () => {
     // A semantic list of artifacts is present.
     const list = screen.getByRole("list", { name: /artifacts/i });
     expect(within(list).getAllByRole("listitem").length).toBeGreaterThan(0);
-  });
-
-  it("shows_sample_not_live_banner_when_sample_true", async () => {
-    renderLedger();
-    const banner = await screen.findByTestId("sample-banner");
-    expect(banner).toHaveTextContent(/sample/i);
-    expect(banner).toHaveTextContent(/not live/i);
   });
 
   it("renders_local_tx_as_plain_text_not_a_link", async () => {

--- a/webapp/src/pages/Ledger.tsx
+++ b/webapp/src/pages/Ledger.tsx
@@ -18,11 +18,11 @@ import { arweaveTxUrl, solanaTxUrl } from "../lib/links";
  * public "proof of work": real signed memories, their blake3 hashes, and their
  * on-chain anchors, rendered as receipt/evidence cards.
  *
- * The page never lies about provenance: when the live `/artifacts` endpoint is
- * absent the client returns `sample: true` rows and we surface a clearly-labeled
- * "sample · not live" banner (Decision 2). On-chain rows ("participate") link to
- * the Solana + Arweave explorers; `local:` / unanchored rows render as plain
- * text, never as links (Decision 6 surfaces public rows only).
+ * The page never lies about provenance: data comes from the live `/artifacts`
+ * endpoint and a fetch failure shows an error state — never fabricated rows.
+ * On-chain rows ("participate") link to the Solana + Arweave explorers; `local:`
+ * / unanchored rows render as plain text, never as links (Decision 6 surfaces
+ * public rows only).
  */
 
 type ModeFilter = "all" | WriteMode;
@@ -79,8 +79,6 @@ export default function Ledger() {
           mode={mode}
           onModeChange={setMode}
         />
-
-        {page?.sample && <SampleBanner />}
 
         <div className="mt-8">
           {status === "loading" && <LoadingState />}
@@ -363,28 +361,6 @@ function AnchorRow({
 /* -------------------------------------------------------------------------- */
 /*                                  States                                    */
 /* -------------------------------------------------------------------------- */
-
-function SampleBanner() {
-  return (
-    <div
-      data-testid="sample-banner"
-      role="note"
-      className="mt-6 flex items-start gap-3 rounded-md border border-stamp/30 bg-stamp/[0.06] px-4 py-3"
-    >
-      <span
-        aria-hidden="true"
-        className="mt-1 inline-block h-2 w-2 shrink-0 rounded-full bg-stamp"
-      />
-      <p className="text-sm leading-relaxed text-text-muted">
-        <span className="font-mono text-[11px] uppercase tracking-[0.16em] text-stamp">
-          Sample · not live
-        </span>{" "}
-        — the live ledger endpoint is not reachable, so these are representative
-        placeholder records, not real node data.
-      </p>
-    </div>
-  );
-}
 
 function LoadingState() {
   return (

--- a/webapp/src/pages/Sign.tsx
+++ b/webapp/src/pages/Sign.tsx
@@ -36,9 +36,7 @@ import { loadWasm } from "../lib/wasm";
 // Configurable for e2e tests + local dev. Override via Vite env:
 // `VITE_MCP_BASE=http://localhost:3000 npm run dev` runs against a
 // locally-built mnemonic-mcp release binary.
-const MCP_BASE =
-  (import.meta.env?.VITE_MCP_BASE as string | undefined) ??
-  "https://mcp.mnemonik.xyz";
+const MCP_BASE = (import.meta.env?.VITE_MCP_BASE as string | undefined) ?? "";
 
 type Status =
   | { kind: "loading" }
@@ -128,7 +126,7 @@ export default function Sign() {
         if (jwt) headers.Authorization = `Bearer ${jwt}`;
         const res = await fetch(
           `${MCP_BASE}/api/pending/${encodeURIComponent(correlationId)}`,
-          { method: "GET", headers }
+          { method: "GET", headers },
         );
 
         if (cancelled) return;
@@ -213,7 +211,7 @@ export default function Sign() {
       // the server. sign_cose_payload wraps the exact bytes in COSE_Sign1.
       const cose = wasm.sign_cose_payload(
         status.bundle.cborBytes,
-        identity
+        identity,
       ) as Uint8Array;
 
       const cose_signed_bytes_b64 = uint8ToBase64(cose);
@@ -293,8 +291,8 @@ export default function Sign() {
     status.kind === "ready"
       ? status.bundle.expiresAtMs
       : status.kind === "signing"
-      ? null
-      : null;
+        ? null
+        : null;
   const remainingMs = expiresAtMs !== null ? Math.max(0, expiresAtMs - now) : 0;
   const remainingLabel = formatMmSs(remainingMs);
 


### PR DESCRIPTION
## Problem

The live Ledger showed **wrong Solana signatures** and **Arweave links that resolved to nothing**, and **recall returned nothing**. Root cause: the webapp's live read endpoints were unreachable, so the client silently fell back to **hardcoded sample data** (fake `solana_tx`/`arweave_tx` baked into `sampleArtifacts()`), masking the failure behind plausible-looking but fabricated rows.

Two underlying issues:
1. Four files defaulted the API base to `https://mcp.mnemonik.xyz` (`?? "https://mcp.mnemonik.xyz"`), but that subdomain's nginx only serves the MCP/OAuth surface — the webapp read endpoints 404 there.
2. Every read client degraded to sample data on any failure, so nothing ever surfaced the real error.

## Changes

- **Same-origin API base.** Drop the stray `mcp.mnemonik.xyz` defaults in `IdentityPanel`/`Sign`/`Install`/`Consent` → `?? ""` (matching `lib/api.ts`). The webapp lives at `mnemonik.xyz` and talks to its own origin; `mcp.mnemonik.xyz` stays MCP-only.
- **No more fallback.** Removed `sampleArtifacts`/`sampleTimeline`/`sampleBlogPosts` and the `sample` field. Fetchers now **throw** on failure (non-2xx, network, malformed body) → honest error state, never fake data.
- **Removed all `SampleBanner`s** from Ledger/Analytics/Blog/BlogPost.
- **`index.html`**: origin-relative `/blog` + `/blog/feed.xml` (drops the unresolved `%VITE_MCP_BASE%` placeholder).
- **Accept negotiation.** JSON read clients send `Accept: application/json` so the apex can route `/blog*` (prerendered HTML for browsers/crawlers vs backend JSON/Micropub).
- **Apex nginx config** (`mcp/deploy/nginx-apex.conf`, new canonical source — live VPS had drifted): serves `webapp/dist` and proxies `/artifacts`, `/analytics/*`, `/stats`, `/blog*`, `/chat`, `/api/*`, `/oauth/*`, `/.well-known/*` → `127.0.0.1:3000`. Updated `deployment.md` (incl. `VITE_MCP_BASE` must be **empty** at build).

Recall behavior is unchanged by design: the Ledger surfaces **public** rows only (`visibility = public`) via the server-side cosine search.

## Test plan

- [x] `npx vitest run` — 117 passed
- [x] `tsc --noEmit` — clean
- [x] `npm run build` — clean (no `%VITE_MCP_BASE%` placeholder warnings), prerender freshness test green
- [ ] Deploy: rebuild webapp with `VITE_MCP_BASE` empty + install `mcp/deploy/nginx-apex.conf`; verify `curl -H 'Accept: application/json' https://mnemonik.xyz/blog` (JSON) vs browser hit (HTML), and that `/ledger` shows live rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)