### PR TITLE
chore: vendor reth as submodule + isolated-sync stall research

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "reth"]
+	path = reth
+	url = git@github.com:paradigmxyz/reth.git

--- a/work/reth-isolated-sync-stall/README.md
+++ b/work/reth-isolated-sync-stall/README.md
@@ -4,10 +4,42 @@ Investigation into why a reth node with a single reachable peer (rest of the
 internet firewalled) intermittently stops syncing and never recovers.
 
 - **`spec.md`** — root-cause analysis + fix proposal + test plan.
+- **`fix.patch`** — the implemented fix + regression tests, as a diff against the
+  pinned upstream commit `3d76b93`. Apply with:
+
+  ```bash
+  git submodule update --init reth
+  git -C reth apply ../work/reth-isolated-sync-stall/fix.patch
+  ```
+
+  (The fix is also committed locally in the submodule on branch
+  `claude/fix-isolated-peer-eviction`, commit `d0a9c0dbb`.)
 - **`../../reth`** — reth is vendored as a git submodule, pinned to upstream
   commit `3d76b93` (the exact base the analysis was performed against). Run
   `git submodule update --init reth` from the repo root to check it out; then the
   `crates/net/...:line` references in `spec.md` resolve directly.
+
+## What the fix does (`crates/net/network/src/peers.rs`)
+
+1. **Reset on stable session** — in `on_connection_failure`, if the peer had held
+   an active session for ≥ `STABLE_SESSION_MIN_UPTIME` (30s) before the drop, its
+   `severe_backoff_counter` is reset to 0 instead of incremented. A node that keeps
+   syncing between blinks never accumulates toward eviction.
+2. **Never evict the last peer** — the backoff-driven removal now also requires
+   `total_peers > 1`. A firewalled node's sole block source is kept (backed off but
+   still dialable) rather than deleted, since discovery cannot re-add it.
+3. **Observability** — backoff-driven removals now log at `warn!` (were silent
+   `trace!`), so operators can see why they reached zero peers.
+
+Regression tests added: `test_stable_session_resets_severe_backoff_counter`,
+`test_last_peer_not_removed_on_max_backoff`; the existing
+`test_remove_on_max_backoff_count` was updated to use two peers (so the removal
+path still exercises under the new last-peer guard).
+
+> **Not compiled in this environment:** the sandbox proxy blocks crates.io (HTTP
+> 403), so reth's dependencies can't be fetched and `cargo check` can't run here.
+> The change was verified by hand against the crate's types/APIs. Run
+> `cargo nextest run -p reth-network` in a networked environment to validate.
 
 ## TL;DR
 

--- a/work/reth-isolated-sync-stall/README.md
+++ b/work/reth-isolated-sync-stall/README.md
@@ -1,0 +1,25 @@
+# reth isolated-environment sync stall — research
+
+Investigation into why a reth node with a single reachable peer (rest of the
+internet firewalled) intermittently stops syncing and never recovers.
+
+- **`spec.md`** — root-cause analysis + fix proposal + test plan.
+- **`../../reth`** — reth is vendored as a git submodule, pinned to upstream
+  commit `3d76b93` (the exact base the analysis was performed against). Run
+  `git submodule update --init reth` from the repo root to check it out; then the
+  `crates/net/...:line` references in `spec.md` resolve directly.
+
+## TL;DR
+
+A network "blink" drops the session to the sole peer with a transient
+`io::Error` that is classified as a *severe* backoff. The per-peer
+`severe_backoff_counter` only resets on a graceful close, so it climbs
+monotonically across blinks; after `max_backoff_count` (default 5) the `Basic`
+peer is permanently removed. With discovery firewalled, nothing re-adds it, so
+the node goes to zero peers and sync stalls. See `spec.md` for the annotated
+code path and the proposed fix.
+
+> Note: the spec was also committed inside the reth submodule locally at
+> `reth/docs/specs/isolated-peer-removal-sync-stall.md`, but that commit is not
+> pushed anywhere (no write access to `paradigmxyz/reth`), so this monorepo copy
+> is the canonical, version-controlled deliverable.

--- a/work/reth-isolated-sync-stall/fix.patch
+++ b/work/reth-isolated-sync-stall/fix.patch
@@ -1,0 +1,166 @@
+diff --git a/crates/net/network/src/peers.rs b/crates/net/network/src/peers.rs
+index ed0bec86d..16763d703 100644
+--- a/crates/net/network/src/peers.rs
++++ b/crates/net/network/src/peers.rs
+@@ -40,6 +40,14 @@ use tokio::{
+ use tokio_stream::wrappers::UnboundedReceiverStream;
+ use tracing::{trace, warn};
+ 
++/// Minimum time an active session must have stayed up before a subsequent connection failure is
++/// treated as transient. A drop after a session this stable resets the peer's severe backoff
++/// counter instead of advancing it toward eviction, so a node that keeps successfully syncing
++/// between brief network partitions ("blinks") never accumulates enough severe backoffs to evict
++/// its peer. Without this, an isolated node with a single reachable peer loses its only block
++/// source after `max_backoff_count` unrelated blinks and stalls, since discovery cannot re-add it.
++const STABLE_SESSION_MIN_UPTIME: Duration = Duration::from_secs(30);
++
+ /// Maintains the state of _all_ the peers known to the network.
+ ///
+ /// This is supposed to be owned by the network itself, but can be reached via the [`PeersHandle`].
+@@ -735,6 +743,8 @@ impl PeersManager {
+         } else {
+             let mut backoff_until = None;
+             let mut remove_peer = false;
++            // captured before the mutable borrow below so the last-peer removal guard can read it
++            let total_peers = self.peers.len();
+ 
+             if let Some(peer) = self.peers.get_mut(peer_id) {
+                 if let Some(kind) = err.should_backoff() {
+@@ -748,8 +758,17 @@ impl PeersManager {
+                         backoff_until = Some(std::time::Instant::now() + backoff);
+                         trace!(target: "net::peers", ?peer_id, ?backoff, "backing off trusted peer");
+                     } else {
+-                        // Increment peer.backoff_counter
+-                        if kind.is_severe() {
++                        // A peer that held a stable session before this failure is not a
++                        // persistently bad peer: a transient drop (e.g. a brief network partition)
++                        // must not accumulate toward permanent eviction. Reset the counter so an
++                        // isolated single-peer node doesn't evict its only block source after a run
++                        // of unrelated blinks. Otherwise increment on severe failures as before.
++                        if peer.connected_for_at_least(
++                            std::time::Instant::now(),
++                            STABLE_SESSION_MIN_UPTIME,
++                        ) {
++                            peer.severe_backoff_counter = 0;
++                        } else if kind.is_severe() {
+                             peer.severe_backoff_counter =
+                                 peer.severe_backoff_counter.saturating_add(1);
+                         }
+@@ -775,17 +794,23 @@ impl PeersManager {
+ 
+                 if peer.severe_backoff_counter > self.max_backoff_count &&
+                     !peer.is_trusted() &&
+-                    !peer.is_static()
++                    !peer.is_static() &&
++                    total_peers > 1
+                 {
+                     // mark peer for removal if it has been backoff too many times and is _not_
+-                    // trusted or static
++                    // trusted or static.
++                    //
++                    // We never remove the *last* known peer this way: on an isolated node whose
++                    // discovery is firewalled, a removed peer can never be re-added, so evicting
++                    // the sole block source permanently stalls sync. Keeping it (backed off, but
++                    // still dialable) lets `fill_outbound_slots` retry once the link recovers.
+                     remove_peer = true;
+                 }
+             }
+ 
+             // remove peer if it has been marked for removal
+             if remove_peer {
+-                trace!(target: "net", ?peer_id, "removed peer after exceeding backoff counter");
++                warn!(target: "net::peers", ?peer_id, max_backoff_count=self.max_backoff_count, "removed peer after exceeding severe backoff counter");
+                 let (peer_id, _) = self.peers.remove_entry(peer_id).expect("peer must exist");
+                 self.queued_actions.push_back(PeerAction::PeerRemoved(peer_id));
+             } else if let Some(backoff_until) = backoff_until {
+@@ -1932,6 +1957,18 @@ mod tests {
+         let config = PeersConfig::test();
+         let mut peers = PeersManager::new(config.clone());
+         peers.add_peer(peer, PeerAddr::from_tcp(socket_addr), None);
++
++        // a second, already-connected peer so the target isn't the last one in the set; the last
++        // remaining peer is never evicted via the backoff path (see the last-peer guard).
++        let filler = PeerId::random();
++        let mut filler_peer = Peer::with_kind(
++            PeerAddr::from_tcp(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 3)), 8009)),
++            PeerKind::Basic,
++        );
++        filler_peer.state = PeerConnectionState::Out;
++        peers.peers.insert(filler, filler_peer);
++        peers.connection_info.inc_out();
++
+         let peer_struct = peers.peers.get_mut(&peer).unwrap();
+ 
+         // Simulate a peer that was already backed off once
+@@ -1980,6 +2017,71 @@ mod tests {
+         assert!(!peers.peers.contains_key(&peer));
+     }
+ 
++    // A peer that held a stable session before a transient drop (a network "blink") must have its
++    // severe backoff counter reset rather than advanced toward eviction. Regression for isolated
++    // single-peer nodes that stalled after repeated blinks evicted their only block source.
++    #[tokio::test]
++    async fn test_stable_session_resets_severe_backoff_counter() {
++        let peer = PeerId::random();
++        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2)), 8008);
++        let config = PeersConfig::test();
++        let mut peers = PeersManager::new(config.clone());
++        peers.add_peer(peer, PeerAddr::from_tcp(socket_addr), None);
++
++        // a second peer so removal is otherwise possible; this isolates the reset from the
++        // last-peer guard.
++        let filler = PeerId::random();
++        peers.peers.insert(
++            filler,
++            Peer::with_kind(
++                PeerAddr::from_tcp(SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 3)), 8009)),
++                PeerKind::Basic,
++            ),
++        );
++
++        let peer_struct = peers.peers.get_mut(&peer).unwrap();
++        // already past the eviction threshold, but with a stable session behind it
++        peer_struct.severe_backoff_counter = config.max_backoff_count + 1;
++        peer_struct.connected_at = Some(std::time::Instant::now() - STABLE_SESSION_MIN_UPTIME * 2);
++
++        // an active session drop with a severe (Medium) transient io error
++        peers.on_active_session_dropped(
++            &socket_addr,
++            &peer,
++            &io::Error::new(io::ErrorKind::TimedOut, "blink").into(),
++        );
++
++        let peer_struct = peers.peers.get(&peer).expect("stable peer must be retained");
++        assert_eq!(peer_struct.severe_backoff_counter, 0);
++    }
++
++    // The last remaining peer must never be evicted via the backoff path: on an isolated node
++    // whose discovery is firewalled, a removed peer can never be re-added, so evicting the sole
++    // block source permanently stalls sync.
++    #[tokio::test]
++    async fn test_last_peer_not_removed_on_max_backoff() {
++        let peer = PeerId::random();
++        let socket_addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 1, 2)), 8008);
++        let config = PeersConfig::test();
++        let mut peers = PeersManager::new(config.clone());
++        peers.add_peer(peer, PeerAddr::from_tcp(socket_addr), None);
++
++        // sole peer, already at the eviction threshold, with no prior stable session
++        peers.peers.get_mut(&peer).unwrap().severe_backoff_counter = config.max_backoff_count;
++
++        peers.on_outgoing_pending_session_dropped(
++            &socket_addr,
++            &peer,
++            &PendingSessionHandshakeError::Eth(
++                io::Error::new(io::ErrorKind::ConnectionRefused, "peer unreachable").into(),
++            ),
++        );
++
++        // retained (backed off), not removed, even though the counter crossed the threshold
++        let peer_struct = peers.peers.get(&peer).expect("the last peer must never be evicted");
++        assert!(peer_struct.severe_backoff_counter > config.max_backoff_count);
++    }
++
+     #[tokio::test]
+     async fn test_ban_on_pending_drop() {
+         let peer = PeerId::random();

--- a/work/reth-isolated-sync-stall/spec.md
+++ b/work/reth-isolated-sync-stall/spec.md
@@ -1,0 +1,278 @@
+# Spec: Single-neighbor node stops syncing after network "blinks"
+
+- **Component:** `crates/net/network` (peer management)
+- **Symptom:** A reth node running in an isolated environment, where it is allowed to
+  reach exactly **one** neighbor and the rest of the internet is firewalled, stops
+  syncing at random. Once it stops it never recovers on its own.
+- **Status:** Root cause identified. Fix proposal below.
+
+---
+
+## 1. Reported behavior & hypothesis
+
+The operator runs reth where security tooling blocks all outbound/inbound traffic
+except to a single peer that serves blocks. Sync works, then intermittently halts.
+
+Operator hypothesis:
+
+> If the network "blinks" (a short connectivity loss), the peer that serves blocks
+> is deleted from the peer list, and that is why the node stops syncing.
+
+This hypothesis is **correct**. There is a code path that permanently evicts the
+single serving peer after a handful of transient connection errors, and in an
+isolated environment nothing ever re-adds it.
+
+---
+
+## 2. Root cause
+
+### 2.1 The eviction path
+
+The relevant code is `PeersManager::on_connection_failure`
+(`crates/net/network/src/peers.rs:700`). It is invoked whenever an active session
+is dropped (`on_active_session_dropped`, peers.rs:664) or an outgoing dial fails
+(`on_outgoing_connection_failure`, peers.rs:675).
+
+For a **non-fatal** error the peer is not touched immediately; instead a
+per-peer counter is bumped and, once it crosses a threshold, the peer is deleted:
+
+```rust
+// crates/net/network/src/peers.rs:739
+if let Some(kind) = err.should_backoff() {
+    if peer.is_trusted() || peer.is_static() {
+        // trusted/static: short, fixed backoff, counter never used
+        backoff_until = Some(now + self.backoff_durations.low);
+    } else {
+        // Increment peer.backoff_counter
+        if kind.is_severe() {                                    // Medium or High
+            peer.severe_backoff_counter =
+                peer.severe_backoff_counter.saturating_add(1);  // <-- climbs
+        }
+        backoff_until = Some(self.backoff_durations.backoff_until(kind, peer.severe_backoff_counter));
+    }
+}
+...
+// crates/net/network/src/peers.rs:776
+if peer.severe_backoff_counter > self.max_backoff_count &&
+    !peer.is_trusted() &&
+    !peer.is_static()
+{
+    remove_peer = true;         // <-- permanent eviction of a Basic peer
+}
+...
+if remove_peer {
+    let (peer_id, _) = self.peers.remove_entry(peer_id).expect("peer must exist");
+    self.queued_actions.push_back(PeerAction::PeerRemoved(peer_id));
+}
+```
+
+`max_backoff_count` defaults to **5** (`crates/net/network-types/src/peers/config.rs:207`),
+and the check is strictly-greater, so a **Basic** (non-trusted, non-static) peer is
+removed on the **6th** severe backoff.
+
+### 2.2 A network blink is classified as a *severe* backoff
+
+What counts as "severe" is decided by `BackoffKind::is_severe`, which is true for
+`Medium` and `High` (`crates/net/network-types/src/backoff.rs:24`).
+
+The classification of a raw socket error lives in
+`impl SessionError for io::Error` (`crates/net/network/src/error.rs:296`):
+
+```rust
+fn should_backoff(&self) -> Option<BackoffKind> {
+    match self.kind() {
+        ErrorKind::ConnectionReset | ErrorKind::BrokenPipe => Some(BackoffKind::Low),   // NOT severe
+        ErrorKind::ConnectionRefused => Some(BackoffKind::High),                        // severe
+        _ => Some(BackoffKind::Medium),                                                 // severe (catch-all)
+    }
+}
+```
+
+A "network blink" surfaces as exactly the errors that fall into the `_ => Medium`
+catch-all (and `ConnectionRefused => High`):
+
+- `ErrorKind::TimedOut` — read/write/connect timed out while the link was down
+- `ErrorKind::HostUnreachable`, `ErrorKind::NetworkUnreachable`
+- `ErrorKind::NetworkDown`
+- `ErrorKind::ConnectionAborted`
+- `ErrorKind::ConnectionRefused` — peer/port briefly unreachable → `High`
+
+All of these are **severe**, so every blink increments `severe_backoff_counter`.
+(Only a clean RST/`BrokenPipe` is treated as `Low` and does not count.)
+
+### 2.3 The counter almost never resets
+
+`severe_backoff_counter` is reset to `0` in exactly **one** place —
+`on_active_session_gracefully_closed` (`crates/net/network/src/peers.rs:627`),
+i.e. only when an already-established session is closed **gracefully**:
+
+```rust
+// crates/net/network/src/peers.rs:612
+pub(crate) fn on_active_session_gracefully_closed(&mut self, peer_id: PeerId) {
+    ...
+    peer.severe_backoff_counter = 0;   // the ONLY reset
+    ...
+}
+```
+
+Crucially it is **not** reset when a connection *succeeds*. `mark_connected`
+(`crates/net/network-types/src/peers/mod.rs:63`) and
+`on_active_outgoing_established` (`peers.rs:650`) leave the counter untouched. A
+session that is established and then dies from a blink goes through
+`on_active_session_dropped` → `on_connection_failure` (the `Dropped` path), which is
+**not** a graceful close, so it does not reset the counter either.
+
+Net effect with a single neighbor: successful sync in between blinks does **not**
+clear the counter. The counter is monotonic across blinks and reaches 6, at which
+point the only peer is deleted.
+
+### 2.4 Why the node never recovers (the isolation trigger)
+
+In a normal deployment the eviction is self-healing: discovery (discv4/discv5) or a
+DNS/bootnode re-discovers the peer within seconds and `add_peer`
+(`peers.rs:821`) re-inserts it, so removal is just a long backoff.
+
+In the operator's isolated environment discovery is dead — every candidate except
+the one neighbor is firewalled. After the peer is removed:
+
+- `self.peers` no longer contains it, so `fill_outbound_slots` has nothing to dial.
+- Discovery yields nothing to re-add it.
+- `PeerAction::PeerRemoved` tears down the session; the sync pipeline loses its only
+  block source and stalls.
+
+The node is now permanently peerless and sync is stuck until manual restart.
+
+### 2.5 Summary of the chain
+
+```
+network blink
+  → active session drops with io::Error (TimedOut / *Unreachable / ConnectionRefused / aborted)
+  → should_backoff() = Medium/High  → is_severe() = true
+  → severe_backoff_counter += 1        (never reset by successful sync)
+  → after 6 blinks: counter (6) > max_backoff_count (5)
+  → peer is Basic (not trusted/static) → removed from self.peers + PeerRemoved
+  → isolated env: discovery cannot re-add it
+  → no peers left → sync stalls indefinitely
+```
+
+The behavior is confirmed by the existing unit test
+`test_remove_on_max_backoff_count` (`crates/net/network/src/peers.rs:1929`), which
+seeds `severe_backoff_counter = max_backoff_count` and asserts the peer is dropped.
+
+---
+
+## 3. Immediate mitigation (no code change)
+
+The removal branch is explicitly skipped for **trusted** and **static** peers
+(`peers.rs:776-779`, and `apply_reputation_change`/backoff give them fixed short
+backoffs instead of the climbing counter). So the operator can work around the bug
+today by pinning the single neighbor:
+
+- Add it to **`--trusted-peers`** (`enode://…`) — a trusted peer is never removed by
+  the backoff counter and is exempted from reputation slashing; the resolver keeps
+  retrying it (`on_outgoing_connection_failure` → `trusted_peers_resolver`, peers.rs:690).
+- Optionally set **`--trusted-only`** so the node does not waste slots on unreachable
+  discovered peers.
+- Adding it as a **static** peer via `admin_addPeer` (JSON-RPC) has the same
+  protective effect (`PeerKind::Static`).
+
+This is the recommended operational fix regardless of the code change below.
+
+---
+
+## 4. Proposed code fix
+
+The root defect is that a *transient, environmental* failure is accounted the same
+way as a *persistently bad peer*, and the accounting is effectively irreversible for
+a long-lived single peer. Two complementary changes:
+
+### Fix A (primary): reset the severe backoff counter on a successful, stable session
+
+A peer that connects and serves us blocks for a meaningful period is not a "bad
+peer"; its earlier blinks should not accumulate toward eviction. Reset the counter
+once a session has been *usefully* established, not only on graceful close.
+
+- Reset `severe_backoff_counter = 0` when a session has stayed up for at least a
+  minimum uptime. `Peer` already tracks `connected_at` and exposes
+  `connected_for_at_least(now, min_uptime)`
+  (`crates/net/network-types/src/peers/mod.rs:73`) for exactly this kind of check.
+- Concretely: in `on_active_session_dropped` / the `Dropped` arm of
+  `on_connection_failure`, if the peer was connected for ≥ `min_uptime` (e.g. 30s)
+  before the drop, reset the counter instead of (or before) incrementing it. This
+  keeps genuine flappers penalized while preventing a stable single peer from ever
+  crossing the threshold via unrelated blinks spread over hours.
+
+This directly falsifies the failure chain: a node that keeps successfully syncing
+between blinks keeps its counter at/near 0 and is never evicted.
+
+### Fix B (defense in depth): never evict the last usable peer / protect the sole block source
+
+Even with Fix A, an environment that only ever has one reachable peer should not be
+able to reach zero peers through the backoff path.
+
+- In the removal branch (`peers.rs:776`), additionally guard against removing a peer
+  when doing so would leave the peer set empty **and** discovery is effectively
+  unable to replenish it — e.g. skip removal when `self.peers.len() == 1`
+  (downgrade to a long backoff instead of deletion). A backed-off-but-present peer
+  is still re-dialable by `fill_outbound_slots`; a removed one is not.
+- This bounds the worst case: a single-neighbor node degrades to "retry with
+  backoff" rather than "peerless forever".
+
+### Fix C (optional, ergonomics): make the eviction observable and configurable
+
+- Emit a `warn!`/metric when a peer is removed due to
+  `severe_backoff_counter > max_backoff_count` (today it is only `trace!` at
+  peers.rs:788), so operators can see *why* they went to zero peers.
+- The threshold is already configurable via
+  `PeersConfig::with_max_backoff_count` and the counting itself is sound for the
+  normal (discovery-enabled) case, so no default change is required if Fix A + B land.
+
+### Non-goals / rejected
+
+- **Reclassifying blink errors as non-severe** (moving the `io::Error` catch-all
+  from `Medium` to `Low`) is rejected: `Low` is also used to *rate-limit* reconnects
+  and the catch-all legitimately covers genuinely unreachable peers. The problem is
+  the *irreversible accumulation*, not the per-event severity.
+- Removing the eviction entirely is rejected: in discovery-enabled deployments it is
+  a useful mechanism to evict truly dead peers and free slots.
+
+---
+
+## 5. Test plan
+
+- **Unit (regression for Fix A):** in `peers.rs` tests, drive a peer through
+  `max_backoff_count + 1` severe backoffs, but insert a "connected for ≥ min_uptime
+  then dropped" event partway through; assert the counter resets and the peer is
+  **not** removed. Mirror the structure of `test_remove_on_max_backoff_count`
+  (peers.rs:1929).
+- **Unit (Fix B):** with a single peer at `severe_backoff_counter = max_backoff_count`,
+  trigger one more severe backoff and assert the peer is retained (backed off) rather
+  than removed and `PeerRemoved` is **not** queued.
+- **Integration:** extend `crates/net/network/tests/it/connect.rs` (which already
+  uses `with_max_backoff_count`, connect.rs:722) with an isolated-topology test: one
+  configured peer, repeatedly force session drops with a `Medium` io error, verify
+  the node re-dials and retains the peer, and that sync-relevant `PeerAction`s are
+  not permanently `PeerRemoved`.
+
+## 6. Affected files (for the fix)
+
+- `crates/net/network/src/peers.rs` — reset logic in `on_connection_failure` /
+  `on_active_session_dropped`; single-peer removal guard; upgrade log level.
+- `crates/net/network-types/src/peers/mod.rs` — helper for "connected long enough to
+  reset" (reuse `connected_for_at_least`).
+- `crates/net/network-types/src/peers/config.rs` — optional `min_uptime`-style knob if
+  the reset threshold should be configurable.
+
+## 7. Key references
+
+| What | Location |
+| --- | --- |
+| Eviction on backoff counter | `crates/net/network/src/peers.rs:776-790` |
+| Counter increment (severe only) | `crates/net/network/src/peers.rs:752-755` |
+| Only reset point (graceful close) | `crates/net/network/src/peers.rs:627` |
+| Blink error → severe backoff | `crates/net/network/src/error.rs:296-308` |
+| `is_severe` = Medium/High | `crates/net/network-types/src/backoff.rs:24` |
+| Trusted/static exemption | `crates/net/network/src/peers.rs:551-568`, `776-779` |
+| `max_backoff_count` default = 5 | `crates/net/network-types/src/peers/config.rs:207` |
+| `connected_for_at_least` helper | `crates/net/network-types/src/peers/mod.rs:73` |
+| Existing removal test | `crates/net/network/src/peers.rs:1929` |


### PR DESCRIPTION
Add paradigmxyz/reth as a git submodule at reth/ (pinned to upstream
3d76b93) and document the single-neighbor sync-stall root cause under
work/reth-isolated-sync-stall/. The node evicts its sole Basic peer once
severe_backoff_counter exceeds max_backoff_count after repeated network
blinks; with discovery firewalled the peer is never re-added and sync
halts.